### PR TITLE
Project section: accordion → card grid

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -61,9 +61,7 @@ describe('ProjectsSection', () => {
     const images = screen.getAllByRole('img')
     expect(images).toHaveLength(1)
 
-    const projectTwoSection = screen.getByText('Project Two').closest('div')
-    const imgInProjectTwo = projectTwoSection?.querySelector('img')
-    expect(imgInProjectTwo).not.toBeInTheDocument()
+    expect(screen.queryByAltText('Project Two screenshot')).not.toBeInTheDocument()
   })
 
   it('renders project cards matching the entries in projects data', () => {

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -1,96 +1,79 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import ProjectsSection from './ProjectsSection'
 
-// Mock project data
 const mockProjects = [
   {
     id: '1',
     title: 'Project One',
     description: 'Description for project one',
     tags: ['React', 'TypeScript'],
+    links: [
+      { label: 'GitHub', url: 'https://github.com/project1' },
+      { label: 'Demo', url: 'https://demo.project1.com' }
+    ],
+    image: 'https://example.com/image1.png'
   },
   {
     id: '2',
     title: 'Project Two',
     description: 'Description for project two',
     tags: ['Node.js', 'Express'],
-  },
+    links: [
+      { label: 'Docs', url: 'https://docs.project2.com' }
+    ]
+  }
 ]
 
 describe('ProjectsSection', () => {
-  it('renders all projects collapsed by default', () => {
+  it('renders all projects as cards on initial render (no collapsed state)', () => {
     render(<ProjectsSection projects={mockProjects} />)
 
-    // Check that project titles are present
     expect(screen.getByText('Project One')).toBeInTheDocument()
     expect(screen.getByText('Project Two')).toBeInTheDocument()
 
-    // Check that descriptions are not visible (collapsed)
-    expect(screen.queryByText('Description for project one')).not.toBeInTheDocument()
-    expect(screen.queryByText('Description for project two')).not.toBeInTheDocument()
-
-    // Check that image placeholder is not visible
-    expect(screen.queryByText('// PROJECT IMAGE')).not.toBeInTheDocument()
-  })
-
-  it('expands a project when clicked', () => {
-    render(<ProjectsSection projects={mockProjects} />)
-
-    // Click the first project header
-    const projectOneHeader = screen.getByText('Project One')
-    fireEvent.click(projectOneHeader)
-
-    // Now the description and image placeholder should be visible
     expect(screen.getByText('Description for project one')).toBeInTheDocument()
-    expect(screen.getByText('// PROJECT IMAGE')).toBeInTheDocument()
-
-    // The second project should still be collapsed
-    expect(screen.queryByText('Description for project two')).not.toBeInTheDocument()
-  })
-
-  it('collapses an already expanded project when clicked again', async () => {
-    render(<ProjectsSection projects={mockProjects} />)
-
-    const projectOneHeader = screen.getByText('Project One')
-    fireEvent.click(projectOneHeader)
-    expect(screen.getByText('Description for project one')).toBeInTheDocument()
-
-    fireEvent.click(projectOneHeader)
-    await waitFor(() => {
-      expect(screen.queryByText('Description for project one')).not.toBeInTheDocument()
-    })
-  })
-
-  it('expanding a second project collapses the first', async () => {
-    render(<ProjectsSection projects={mockProjects} />)
-
-    const projectOneHeader = screen.getByText('Project One')
-    fireEvent.click(projectOneHeader)
-    expect(screen.getByText('Description for project one')).toBeInTheDocument()
-
-    const projectTwoHeader = screen.getByText('Project Two')
-    fireEvent.click(projectTwoHeader)
-
-    await waitFor(() => {
-      expect(screen.queryByText('Description for project one')).not.toBeInTheDocument()
-    })
     expect(screen.getByText('Description for project two')).toBeInTheDocument()
   })
 
-  it('renders project rows matching the entries in projects data', () => {
+  it('displays title, description, tags, and links for each card', () => {
     render(<ProjectsSection projects={mockProjects} />)
-    
-    // Check that we have two project rows (we'll assume each project is a row)
-    const projectHeaders = screen.getAllByRole('heading', { level: 3 }) // Assuming h3 for project titles
-    expect(projectHeaders).toHaveLength(2)
-    expect(projectHeaders.map(h => h.textContent)).toContain('Project One')
-    expect(projectHeaders.map(h => h.textContent)).toContain('Project Two')
-    
-    // Check that tags are rendered
+
+    expect(screen.getByText('Project One')).toBeInTheDocument()
+    expect(screen.getByText('Description for project one')).toBeInTheDocument()
     expect(screen.getByText('React')).toBeInTheDocument()
     expect(screen.getByText('TypeScript')).toBeInTheDocument()
-    expect(screen.getByText('Node.js')).toBeInTheDocument()
-    expect(screen.getByText('Express')).toBeInTheDocument()
+    expect(screen.getByText('// GitHub ↗')).toBeInTheDocument()
+    expect(screen.getByText('// Demo ↗')).toBeInTheDocument()
+  })
+
+  it('renders image when provided', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const images = screen.getAllByRole('img')
+    expect(images).toHaveLength(1)
+    expect(images[0]).toHaveAttribute('src', 'https://example.com/image1.png')
+  })
+
+  it('renders color placeholder when no image provided', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const images = screen.getAllByRole('img')
+    expect(images).toHaveLength(1)
+
+    const projectTwoSection = screen.getByText('Project Two').closest('div')
+    const imgInProjectTwo = projectTwoSection?.querySelector('img')
+    expect(imgInProjectTwo).not.toBeInTheDocument()
+  })
+
+  it('renders project cards matching the entries in projects data', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const headings = screen.getAllByRole('heading', { level: 3 })
+    expect(headings).toHaveLength(2)
+    expect(headings.map(h => h.textContent)).toContain('Project One')
+    expect(headings.map(h => h.textContent)).toContain('Project Two')
+
+    expect(screen.getByText('// Docs ↗')).toBeInTheDocument()
   })
 })

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -63,11 +63,7 @@ describe('ProjectsSection', () => {
 
     expect(screen.queryByAltText('Project Two screenshot')).not.toBeInTheDocument()
 
-    const projectTwoTitle = screen.getByText('Project Two')
-    const cardElement = projectTwoTitle.closest('div[class*="relative"]')
-    expect(cardElement).toBeInTheDocument()
-    const placeholderDiv = cardElement?.querySelector('div[class="mb-4 h-32 rounded"]')
-    expect(placeholderDiv).toBeInTheDocument()
+    expect(screen.getByTestId('project-2-placeholder')).toBeInTheDocument()
   })
 
   it('renders project cards matching the entries in projects data', () => {

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -62,6 +62,12 @@ describe('ProjectsSection', () => {
     expect(images).toHaveLength(1)
 
     expect(screen.queryByAltText('Project Two screenshot')).not.toBeInTheDocument()
+
+    const projectTwoTitle = screen.getByText('Project Two')
+    const cardElement = projectTwoTitle.closest('div[class*="relative"]')
+    expect(cardElement).toBeInTheDocument()
+    const placeholderDiv = cardElement?.querySelector('div[class="mb-4 h-32 rounded"]')
+    expect(placeholderDiv).toBeInTheDocument()
   })
 
   it('renders project cards matching the entries in projects data', () => {

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -90,6 +90,7 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
           </div>
         ) : (
           <div
+            data-testid={`project-${project.id}-placeholder`}
             className="mb-4 h-32 rounded"
             style={{ backgroundColor: placeholderColor }}
           />

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -67,9 +67,9 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
       }}
     >
       <div
-        className="absolute inset-0 bg-atomic-tangerine opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+        className="absolute left-0 top-0 bottom-0 w-1 bg-atomic-tangerine opacity-0 group-hover:opacity-100 transition-all duration-300"
         style={{
-          clipPath: 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)',
+          clipPath: 'polygon(0 20px, 4px 20px, 4px calc(100% - 20px), 4px 100%, 0 100%, 0 20px)',
         }}
       />
 
@@ -127,7 +127,7 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-body text-xs text-graphite hover:text-atomic-tangerine transition-colors"
+              className="font-mono text-xs text-graphite hover:text-atomic-tangerine transition-colors"
             >
               // {link.label} ↗
             </a>

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,27 +1,23 @@
-import { useState } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { fadeUp } from '../animations/variants'
-
-interface Project {
-  id: string
-  title: string
-  description: string
-  tags: string[]
-}
+import type { Project } from '../data/projects'
 
 interface Props {
   projects: Project[]
 }
 
-const STRIPE_STYLE = {
-  background: 'repeating-linear-gradient(45deg, #3A3B3A, #3A3B3A 2px, #4A4B4A 2px, #4A4B4A 14px)',
-}
-
 const TAG_COLORS = [
-  { bg: '#E0007F', fg: '#EFF1F3' }, // fuchsia-flame - light text
-  { bg: '#5200E0', fg: '#EFF1F3' }, // ultrasonic-blue - light text
-  { bg: '#FF8547', fg: '#050609' }, // atomic-tangerine - dark text
-  { bg: '#FFCE47', fg: '#050609' }, // golden-pollen - dark text
+  { bg: '#E0007F', fg: '#EFF1F3' },
+  { bg: '#5200E0', fg: '#EFF1F3' },
+  { bg: '#FF8547', fg: '#050609' },
+  { bg: '#FFCE47', fg: '#050609' },
+]
+
+const PLACEHOLDER_COLORS = [
+  '#E0007F',
+  '#5200E0',
+  '#FF8547',
+  '#FFCE47',
 ]
 
 function getTagStyle(tagIndex: number) {
@@ -29,13 +25,11 @@ function getTagStyle(tagIndex: number) {
   return { backgroundColor: color.bg, color: color.fg }
 }
 
+function getPlaceholderColor(projectIndex: number) {
+  return PLACEHOLDER_COLORS[projectIndex % 4]
+}
+
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
-  const [expandedId, setExpandedId] = useState<string | null>(null)
-
-  const toggleExpand = (id: string) => {
-    setExpandedId(expandedId === id ? null : id)
-  }
-
   return (
     <motion.section
       id="projects"
@@ -51,78 +45,96 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
         <hr className="flex-1 border-graphite/20" />
       </div>
 
-      <div className="space-y-0">
-        {projects.map((project) => {
-          const isExpanded = expandedId === project.id
-          return (
-            <div key={project.id}>
-              <div
-                className={`overflow-hidden border border-graphite/20 ${isExpanded ? 'bg-white/5' : ''}`}
-                style={isExpanded ? { borderLeft: '3px solid #FF8547' } : {}}
-              >
-                <div
-                  onClick={() => toggleExpand(project.id)}
-                  className="flex items-center justify-between px-4 py-4 cursor-pointer hover:bg-white/5"
-                >
-                  <div className="flex items-center gap-6">
-                    <span className="text-xs text-graphite font-body">
-                      _{project.id.padStart(2, '0')}
-                    </span>
-                    <h3 className="font-body font-bold text-base text-black">
-                      {project.title}
-                    </h3>
-                  </div>
-                  <div className="flex items-center gap-4">
-                    <div className="flex gap-2">
-                      {project.tags.map((tag, tagIndex) => (
-                        <span
-                          key={tag}
-                          className="text-xs px-2 py-0.5 font-body rounded"
-                          style={getTagStyle(tagIndex)}
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                    <span className="text-atomic-tangerine text-xs font-body">
-                      {isExpanded ? '↑' : '↓'}
-                    </span>
-                  </div>
-                </div>
-
-                <AnimatePresence>
-                  {isExpanded && (
-                    <motion.div
-                      key={project.id}
-                      initial={{ height: 0, opacity: 0 }}
-                      animate={{ height: 'auto', opacity: 1 }}
-                      exit={{ height: 0, opacity: 0 }}
-                      transition={{ duration: 0.25, ease: 'easeInOut' }}
-                      className="overflow-hidden"
-                    >
-                      <div className="grid grid-cols-[40%_60%] gap-6 p-6">
-                        <div
-                          className="flex items-center justify-center h-40 rounded"
-                          style={STRIPE_STYLE}
-                        >
-                          <span className="text-graphite/60 text-xs font-body">
-                            // PROJECT IMAGE
-                          </span>
-                        </div>
-                        <p className="text-graphite text-sm font-body leading-relaxed self-center">
-                          {project.description}
-                        </p>
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-              <hr className="border-graphite/10" />
-            </div>
-          )
-        })}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {projects.map((project, projectIndex) => (
+          <ProjectCard key={project.id} project={project} projectIndex={projectIndex} />
+        ))}
       </div>
     </motion.section>
+  )
+}
+
+const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ project, projectIndex }) => {
+  const placeholderColor = getPlaceholderColor(projectIndex)
+
+  return (
+    <motion.div
+      whileHover={{ y: -4 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      className="relative group"
+      style={{
+        clipPath: 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)',
+      }}
+    >
+      <div
+        className="absolute inset-0 bg-atomic-tangerine opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+        style={{
+          clipPath: 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)',
+        }}
+      />
+
+      <div
+        className="relative bg-white border-0 p-5 h-full"
+        style={{
+          clipPath: 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)',
+          backgroundImage: 'linear-gradient(135deg, #F8F9FA 0%, #FFFFFF 100%)',
+        }}
+      >
+        {project.image ? (
+          <div className="mb-4 rounded overflow-hidden" style={{ backgroundColor: '#3A3B3A' }}>
+            <img
+              src={project.image}
+              alt={`${project.title} screenshot`}
+              className="w-full h-32 object-cover"
+            />
+          </div>
+        ) : (
+          <div
+            className="mb-4 h-32 rounded"
+            style={{ backgroundColor: placeholderColor }}
+          />
+        )}
+
+        <div className="flex items-center gap-3 mb-2">
+          <span className="font-body text-xs text-graphite">
+            _{project.id.padStart(2, '0')}
+          </span>
+          <h3 className="font-body font-bold text-base text-black">
+            {project.title}
+          </h3>
+        </div>
+
+        <p className="text-graphite text-sm font-body leading-relaxed mb-4">
+          {project.description}
+        </p>
+
+        <div className="flex flex-wrap gap-2 mb-4">
+          {project.tags.map((tag, tagIndex) => (
+            <span
+              key={tag}
+              className="text-xs px-2 py-0.5 font-body rounded"
+              style={getTagStyle(tagIndex)}
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          {project.links.map((link) => (
+            <a
+              key={link.label}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-body text-xs text-graphite hover:text-atomic-tangerine transition-colors"
+            >
+              // {link.label} ↗
+            </a>
+          ))}
+        </div>
+      </div>
+    </motion.div>
   )
 }
 

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,8 +1,15 @@
+export interface ProjectLink {
+  label: string
+  url: string
+}
+
 export interface Project {
   id: string
   title: string
   description: string
   tags: string[]
+  links: ProjectLink[]
+  image?: string
 }
 
 export const projects: Project[] = [
@@ -10,12 +17,19 @@ export const projects: Project[] = [
     id: '1',
     title: 'LEVIATHAN',
     description: '20M-parameter searchless transformer chess engine with custom attention. Reduced KV-cache memory by 8× via Multi-Head Latent Attention. Custom 4,247-token tokenizer for single-token move prediction. Trained on 3M+ positions with gradient checkpointing and FP16 — 19ms per-move latency on edge hardware.',
-    tags: ['PyTorch', 'FastAPI', 'Next.js']
+    tags: ['PyTorch', 'FastAPI', 'Next.js'],
+    links: [
+      { label: 'HuggingFace', url: 'https://huggingface.co/spaces/NemesisTCO/LeviathanChess' }
+    ]
   },
   {
     id: '2',
     title: 'MLA_IMPL',
     description: 'Research implementation of Multi-Head Latent Attention from DeepSeek-V2. Modular PyTorch library with clean abstractions for KV compression and low-rank projection components. Published as a production-ready PyPI package with type hints, documentation, and integration examples.',
-    tags: ['PyTorch', 'Python', 'PyPI']
+    tags: ['PyTorch', 'Python', 'PyPI'],
+    links: [
+      { label: 'GitHub', url: 'https://github.com/Nemesis-12/multihead-latent-attention' },
+      { label: 'PyPI', url: 'https://pypi.org/project/multihead-latent-attention' }
+    ]
   }
 ]


### PR DESCRIPTION
## Purpose

Replaces the existing accordion-style ProjectsSection with a card grid layout as specified in issue #12.

## Changes made

- Added `ProjectLink` interface and `links: ProjectLink[]` + optional `image?: string` to `Project` type
- Populated real links: LEVIATHAN → HuggingFace Spaces; MLA_IMPL → GitHub + PyPI
- Replaced accordion expand/collapse with always-visible card grid (2-col desktop, 1-col mobile)
- Added diagonal clip-path notch at top-left and bottom-right corners
- Added atomic-tangerine left-edge outline on hover that fades in bottom-to-top
- Added subtle card lift on hover
- Added color placeholder cycling through brand palette when no image provided
- Updated tests to verify card grid behavior instead of accordion

## Additional notes

- All 42 tests passing, TypeScript compiles without errors
- Removed accordion state (useState, click handlers, expand/collapse icons)
- Tags continue to use existing TAG_COLORS rotation pattern

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects now include external links (GitHub, Demo, Docs, etc.) and may display an image or a deterministic color placeholder.

* **Changes**
  * Projects section redesigned from an expandable list to a responsive static card grid with hover lift; all project details are visible by default.

* **Tests**
  * Test suite updated to assert card rendering, link presence/labels, image vs. placeholder behavior, tags, and project headings/count.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->