### PR TITLE
Fix layout issues in Projects and Skills sections

### DIFF
--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { fadeUp } from '../animations/variants'
 import type { Project } from '../data/projects'
@@ -19,6 +20,8 @@ const PLACEHOLDER_COLORS = [
   '#FF8547',
   '#FFCE47',
 ]
+
+const NOTCH = 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)'
 
 function getTagStyle(tagIndex: number) {
   const color = TAG_COLORS[tagIndex % 4]
@@ -55,43 +58,35 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
 }
 
 const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ project, projectIndex }) => {
+  const [isHovered, setIsHovered] = useState(false)
   const placeholderColor = getPlaceholderColor(projectIndex)
 
   return (
     <motion.div
-      whileHover={{ y: -4 }}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      animate={{ y: isHovered ? -4 : 0 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
-      className="relative group"
-      style={{
-        clipPath: 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)',
-      }}
+      className="relative"
+      style={{ clipPath: NOTCH }}
     >
+      {/* Card background */}
       <div
-        className="absolute left-0 top-0 bottom-0 w-1 bg-atomic-tangerine opacity-0 group-hover:opacity-100 transition-all duration-300"
-        style={{
-          clipPath: 'polygon(0 20px, 4px 20px, 4px calc(100% - 20px), 4px 100%, 0 100%, 0 20px)',
-        }}
-      />
-
-      <div
-        className="relative bg-white border-0 p-5 h-full"
-        style={{
-          clipPath: 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)',
-          backgroundImage: 'linear-gradient(135deg, #F8F9FA 0%, #FFFFFF 100%)',
-        }}
+        className="relative bg-white p-5"
+        style={{ backgroundImage: 'linear-gradient(135deg, #F8F9FA 0%, #FFFFFF 100%)' }}
       >
         {project.image ? (
-          <div className="mb-4 rounded overflow-hidden" style={{ backgroundColor: '#3A3B3A' }}>
+          <div className="mb-4 overflow-hidden" style={{ backgroundColor: '#3A3B3A' }}>
             <img
               src={project.image}
               alt={`${project.title} screenshot`}
-              className="w-full h-32 object-cover"
+              className="w-full h-40 object-cover"
             />
           </div>
         ) : (
           <div
             data-testid={`project-${project.id}-placeholder`}
-            className="mb-4 h-32 rounded"
+            className="mb-4 h-40"
             style={{ backgroundColor: placeholderColor }}
           />
         )}
@@ -135,6 +130,15 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
           ))}
         </div>
       </div>
+
+      {/* Left-edge hover outline — rendered after card so it sits on top */}
+      <motion.div
+        className="absolute left-0 top-0 bottom-0 w-[3px] bg-atomic-tangerine"
+        initial={{ scaleY: 0, opacity: 0 }}
+        animate={{ scaleY: isHovered ? 1 : 0, opacity: isHovered ? 1 : 0 }}
+        style={{ transformOrigin: 'bottom' }}
+        transition={{ duration: 0.25, ease: 'easeOut' }}
+      />
     </motion.div>
   )
 }

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -12,22 +12,43 @@ interface SkillTile {
   fg: string
 }
 
+// Desktop (4-col):
+//   R1: Python(2) TypeScript(1) Docker(1)
+//   R2: Python(2) TypeScript(1) C/C++(1)
+//   R3: JavaScript(1) FastAPI(1) PyTorch(2)
+//   R4: NumPy(2) Pandas(1) Ansible(1)
+//   R5: NumPy(2) HuggingFace(2)
+//   R6: Linux(1) Git(1) Scikit-learn(2)
+//   R7: SQL(1) Accent(3)
+//
+// Mobile (2-col):
+//   R1: Python(2)
+//   R2: TypeScript(1) Docker(1)
+//   R3: TypeScript(1) C/C++(1)
+//   R4: JavaScript(1) FastAPI(1)
+//   R5: PyTorch(2)
+//   R6: NumPy(1) Pandas(1)
+//   R7: NumPy(1) Ansible(1)
+//   R8: HuggingFace(1) Linux(1)
+//   R9: Git(1) Scikit-learn(1)
+//   R10: SQL(2)
+//   R11: Accent(2)
 const tiles: SkillTile[] = [
-  { category: 'LANGUAGE', name: 'Python',       colSpan: 'col-span-2', rowSpan: 'row-span-2', bg: '#FF8547', fg: '#050609' },
-  { category: 'LANGUAGE', name: 'TypeScript',  colSpan: 'col-span-1', rowSpan: 'row-span-2 md:row-span-1', bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'TOOL',     name: 'Docker',       colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#EFF1F3', fg: '#2A2B2A' },
-  { category: 'ML / DL', name: 'PyTorch',      colSpan: 'col-span-2 md:col-span-1', rowSpan: 'row-span-1', bg: '#FFCE47', fg: '#050609' },
-  { category: 'LANGUAGE', name: 'C / C++',      colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'LANGUAGE', name: 'JavaScript',  colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#EFF1F3', fg: '#2A2B2A' },
-  { category: 'FRAMEWORK',name: 'FastAPI',     colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'ML / DL', name: 'Hugging Face',colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#FFCE47', fg: '#050609' },
-  { category: 'TOOL',     name: 'Git',          colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#FF8547', fg: '#050609' },
-  { category: 'DATA',    name: 'NumPy',        colSpan: 'col-span-1', rowSpan: 'row-span-2 md:row-span-1', bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'DATA',    name: 'Pandas',       colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'TOOL',    name: 'Ansible',      colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#FF8547', fg: '#050609' },
-  { category: 'TOOL',    name: 'Linux',        colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#EFF1F3', fg: '#2A2B2A' },
-  { category: 'ML / DL', name: 'Scikit-learn', colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#FFCE47', fg: '#050609' },
-  { category: 'LANGUAGE', name: 'SQL',         colSpan: 'col-span-1', rowSpan: 'row-span-1', bg: '#5200E0', fg: '#EFF1F3' },
+  { category: 'LANGUAGE',  name: 'Python',       colSpan: 'col-span-2',                rowSpan: 'row-span-1 md:row-span-2', bg: '#FF8547', fg: '#050609' },
+  { category: 'LANGUAGE',  name: 'TypeScript',   colSpan: 'col-span-1',                rowSpan: 'row-span-2',               bg: '#5200E0', fg: '#EFF1F3' },
+  { category: 'TOOL',      name: 'Docker',       colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
+  { category: 'LANGUAGE',  name: 'C / C++',      colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
+  { category: 'LANGUAGE',  name: 'JavaScript',   colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
+  { category: 'FRAMEWORK', name: 'FastAPI',      colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
+  { category: 'ML / DL',   name: 'PyTorch',      colSpan: 'col-span-2',                rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'DATA',      name: 'NumPy',        colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-2',               bg: '#5200E0', fg: '#EFF1F3' },
+  { category: 'DATA',      name: 'Pandas',       colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
+  { category: 'TOOL',      name: 'Ansible',      colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Hugging Face', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'TOOL',      name: 'Linux',        colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
+  { category: 'TOOL',      name: 'Git',          colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Scikit-learn', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'LANGUAGE',  name: 'SQL',          colSpan: 'col-span-2 md:col-span-1',  rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
 ]
 
 function SkillTileCard({ tile }: { tile: SkillTile }) {
@@ -70,8 +91,9 @@ export function SkillsSection() {
           <SkillTileCard key={tile.name} tile={tile} />
         ))}
 
+        {/* Accent tile: fills R7 C2-C4 on desktop (col-span-3), full width on mobile */}
         <div
-          className="col-span-2 md:col-span-4 min-h-24 rounded-lg"
+          className="col-span-2 md:col-span-3 min-h-24 rounded-lg"
           style={{ backgroundColor: '#E0007F' }}
         />
       </div>


### PR DESCRIPTION
## Purpose

Addresses layout and visual polish issues in the Projects and Skills bento grid sections.

## Changes made

**ProjectsSection:**
- Replaced `whileHover` with explicit `useState` + `animate` to fix hover jank caused by `clipPath` clipping the Framer Motion overlay
- Extracted `NOTCH` clip-path constant to avoid duplication
- Moved left-edge accent bar to render after the card so it sits on top of the clip region
- Increased image/placeholder height from `h-32` to `h-40` for better visual balance

**SkillsSection:**
- Fixed bento grid tile ordering and `colSpan`/`rowSpan` values for correct layout on both desktop (4-col) and mobile (2-col)
- Python tile now spans 2 rows on desktop, 1 on mobile
- NumPy, Hugging Face, Scikit-learn now span 2 cols on desktop, 1 on mobile
- Accent tile corrected from `col-span-4` to `col-span-3` on desktop (fills remaining space in last row)
- Added grid layout comment documenting the intended row-by-row arrangement

## Additional notes

No new issues were opened for these fixes — changes were part of an existing layout pass. All 44 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style

* **Project Cards** – Enhanced hover interactions with newly added left-edge visual outline effect and refined overall card styling for improved visual feedback
* **Skills Section** – Reorganized skill tile grid layout with adjusted tile positioning and resized accent element for optimized display across desktop and mobile screen sizes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->