### PR TITLE
Fix layout, card colors, and rename color tokens

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -54,17 +54,17 @@ A single-page scrollable portfolio website built with Vite + React + TypeScript 
 ### Color Palette (Tailwind theme tokens)
 | Token | Hex | Usage |
 |---|---|---|
-| `mint-cream` | `#2A2B2A` | Page background, loading screen background (dark graphite) |
+| `graphite` | `#2A2B2A` | Page background, loading screen background |
 | `atomic-tangerine` | `#FF8547` | Accents, active nav underline, progress bar, bento tiles |
 | `ultrasonic-blue` | `#5200E0` | Bento tiles, project tag palette |
 | `fuchsia-flame` | `#E0007F` | Bento tiles, project tag palette |
 | `golden-pollen` | `#FFCE47` | Bento tiles, project tag palette |
-| `black` | `#EFF1F3` | Headings, primary text (platinum/light) |
-| `graphite` | `#B2B6D2` | Body text, secondary text (periwinkle) |
+| `platinum` | `#EFF1F3` | Headings, primary text, light backgrounds |
+| `periwinkle` | `#B2B6D2` | Body text, secondary text |
 
-The site uses a dark theme. "Black" resolves to a near-white platinum; "graphite" resolves to a muted periwinkle. All Tailwind utility classes (`text-black`, `bg-mint-cream`, etc.) reference these tokens — no direct hex values in components except for tile and stripe definitions.
+The site uses a dark theme. `platinum` is a near-white used for headings and light surfaces; `periwinkle` is a muted blue-grey used for body and secondary text; `graphite` is the dark page background. All Tailwind utility classes (`text-platinum`, `bg-graphite`, etc.) reference these tokens — no direct hex values in components except for tile and stripe definitions.
 
-Tiles using the old dark (`#050609`) background (Docker, JavaScript, Linux) are flipped to platinum (`#EFF1F3`) background with dark graphite text (`#2A2B2A`) to maintain contrast on the dark page.
+Tiles using the old dark (`#050609`) background (Docker, JavaScript, Linux) are flipped to `platinum` (`#EFF1F3`) background with `graphite` (`#2A2B2A`) text to maintain contrast on the dark page.
 
 ### Typography
 - **Press Start 2P** (Google Fonts) — all headings and display text
@@ -72,7 +72,7 @@ Tiles using the old dark (`#050609`) background (Docker, JavaScript, Linux) are 
 
 ### Loading Screen
 - Renders as a full-page overlay on top of the main content on every visit (no session caching).
-- Background: `mint-cream` (dark graphite `#2A2B2A`).
+- Background: `graphite` (`#2A2B2A`).
 - Centre-aligned: `SYSTEM_INIT...` label, name in pixel font, animated progress bar (orange fill), and a cycling status message below the bar.
 - Status message sequence: `ESTABLISHING_SIGNAL` → `COMPILING_MODULES` → `LOADING_ASSETS` → `SYSTEM_READY`.
 - On completion, the overlay fades out via Framer Motion to reveal the site.
@@ -82,7 +82,7 @@ Tiles using the old dark (`#050609`) background (Docker, JavaScript, Linux) are 
 - Logo: `FM_` in pixel font, links to top of page.
 - Links: HERO, PROJECTS, SKILLS, TIMELINE, CONTACT — smooth-scroll to section anchors.
 - Active link: orange underline, determined by IntersectionObserver watching each section.
-- Inactive links use `text-black` (platinum) — not `text-graphite` (periwinkle), which is too dim at small nav sizes.
+- Inactive links use `text-platinum` — not `text-periwinkle`, which is too dim at small nav sizes.
 - **Mobile**: hamburger icon replaces inline links. Opens `MobileMenu`.
 
 ### MobileMenu
@@ -94,8 +94,8 @@ Tiles using the old dark (`#050609`) background (Docker, JavaScript, Linux) are 
 - Height: `min-h-[60vh]` — tall enough to feel like a landing section without consuming a full viewport before content begins.
 - Dot-grid background pattern via CSS radial-gradient. Dot color `#3A3B3A` (subtle dark-on-dark dots).
 - `// PORTFOLIO_INIT` label in accent orange.
-- Name in large pixel font, platinum.
-- Subtitle: `CS_STUDENT · DEVELOPER` in monospace, graphite.
+- Name in large pixel font, `platinum`.
+- Subtitle: `CS_STUDENT · DEVELOPER` in monospace, `periwinkle`.
 - `VIEW_WORK →` link that smooth-scrolls to the Projects section.
 
 ### Section Spacing
@@ -107,7 +107,7 @@ All sections use `py-14` (reduced from `py-24`) to keep content tighter given th
 - Each row shows: index (`_01`), project name, tech stack tags, expand/collapse arrow.
 - **Tag colors**: cycle through the four brand colors — fuchsia-flame, ultrasonic-blue, atomic-tangerine, golden-pollen — by tag index modulo 4. Each project resets to index 0. Tags have colored backgrounds with legible foreground text (dark text on light colors, light text on dark colors).
 - Expanded row shows: project image placeholder (dark diagonal stripe pattern), description paragraph.
-- Hover and expanded states use `bg-white/5` (subtle light overlay on dark background).
+- Hover and expanded states use `bg-platinum/5` (subtle light overlay on dark background).
 - Accordion expansion animated via Framer Motion `AnimatePresence`.
 
 ### Project Data Shape
@@ -126,7 +126,7 @@ interface Project {
 - Each tile: category label (small caps, muted) + skill name (bold monospace).
 - Tile colors assigned per skill from the brand palette.
 - **Creative asymmetric layout**: Python anchors rows 1–2 as `col-span-2 row-span-2`; TypeScript anchors col 3 rows 1–2 as `col-span-1 row-span-2`. This breaks the uniform single-cell grid into a visually dynamic arrangement.
-- Tiles previously using dark (`#050609`) backgrounds (Docker, JavaScript, Linux) use platinum (`#EFF1F3`) background on the dark page.
+- Tiles previously using dark (`#050609`) backgrounds (Docker, JavaScript, Linux) use `platinum` (`#EFF1F3`) background on the dark page.
 - Hugging Face uses golden-pollen (`#FFCE47`) background (was previously the same as the page background and effectively invisible).
 - Row 5 ends at col 3 (15 tiles total; col 4 of last row is intentionally open).
 - **Decorative stripes**: below the main tile grid, a separate aligned row places four thin vertical colored stripes (fuchsia-flame, ultrasonic-blue, atomic-tangerine, golden-pollen) in the right half (`col-span-2`). Desktop only (`hidden md:grid`). Each stripe is a `flex-1 rounded-lg` div inside a `flex gap-1` container.
@@ -134,13 +134,13 @@ interface Project {
 
 ### TimelineSection
 - Hardcoded entries split into Education and Experience subsections.
-- Each entry: date range (left column, accent orange), institution (accent orange), role title (pixel font, platinum), description (monospace, graphite).
+- Each entry: date range (left column, accent orange), institution (accent orange), role title (pixel font, `platinum`), description (monospace, `periwinkle`).
 - Horizontal rule separates entries within a subsection.
 
 ### ContactSection
 - `// 04 CONTACT` section label.
-- `LET'S CONNECT.` in large pixel font, platinum.
-- Single CTA: `SEND_MESSAGE →` as an `<a href="mailto:...">` link, styled as a bordered button. Border and text use `text-black` (platinum) on the dark background; hover inverts to platinum fill with dark graphite text via `hover:bg-black hover:text-mint-cream`.
+- `LET'S CONNECT.` in large pixel font, `platinum`.
+- Single CTA: `SEND_MESSAGE →` as an `<a href="mailto:...">` link, styled as a bordered button. Border and text use `text-platinum` on the dark background; hover inverts to platinum fill with `graphite` text via `hover:bg-platinum hover:text-graphite`.
 - Footer links: `// GITHUB`, `// LINKEDIN`, `// EMAIL`, `// RESUME` — Resume opens in new tab.
 - Resume PDF served from `public/resume.pdf`.
 

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -21,7 +21,7 @@ export default function ContactSection() {
       >
         <p className="font-body text-sm text-atomic-tangerine mb-8">// 04 CONTACT</p>
 
-        <h2 className="font-display text-3xl md:text-5xl text-black leading-tight mb-12">
+        <h2 className="font-display text-3xl md:text-5xl text-platinum leading-tight mb-12">
           LET'S CONNECT.
         </h2>
 
@@ -30,7 +30,7 @@ export default function ContactSection() {
           variants={hoverEase}
           initial="idle"
           whileHover="hover"
-          className="inline-block font-body text-sm border-2 border-black text-black px-8 py-4 mb-12 hover:bg-black hover:text-mint-cream transition-colors"
+          className="inline-block font-body text-sm border-2 border-platinum text-platinum px-8 py-4 mb-12 hover:bg-platinum hover:text-mint-cream transition-colors"
         >
           SEND_MESSAGE →
         </motion.a>
@@ -45,14 +45,14 @@ export default function ContactSection() {
               variants={hoverEase}
               initial="idle"
               whileHover="hover"
-              className="font-body text-sm text-graphite hover:text-atomic-tangerine transition-colors"
+              className="font-body text-sm text-periwinkle hover:text-atomic-tangerine transition-colors"
             >
               {label}
             </motion.a>
           ))}
         </div>
 
-        <div className="flex justify-between items-center pt-8 border-t border-graphite/20 text-xs font-body text-graphite">
+        <div className="flex justify-between items-center pt-8 border-t border-periwinkle/20 text-xs font-body text-periwinkle">
           <span>FARHAN_MOHAMMED © 2026</span>
           <span>PORTFOLIO.EXE</span>
         </div>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -30,7 +30,7 @@ export default function ContactSection() {
           variants={hoverEase}
           initial="idle"
           whileHover="hover"
-          className="inline-block font-body text-sm border-2 border-platinum text-platinum px-8 py-4 mb-12 hover:bg-platinum hover:text-mint-cream transition-colors"
+          className="inline-block font-body text-sm border-2 border-platinum text-platinum px-8 py-4 mb-12 hover:bg-platinum hover:text-graphite transition-colors"
         >
           SEND_MESSAGE →
         </motion.a>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -22,11 +22,11 @@ const HeroSection: React.FC = () => {
           <div className="w-8 h-0.5 bg-atomic-tangerine" />
         </div>
 
-        <h1 className="font-display text-5xl text-black leading-tight">
+        <h1 className="font-display text-5xl text-platinum leading-tight">
           FARHAN MOHAMMED
         </h1>
 
-        <p className="font-body text-xl text-graphite">
+        <p className="font-body text-xl text-periwinkle">
           CS_STUDENT · DEVELOPER
         </p>
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -3,7 +3,7 @@ import { fadeUp } from '../animations/variants'
 
 const HeroSection: React.FC = () => {
   return (
-    <section id="hero" className="relative min-h-[60vh] flex flex-col justify-center bg-mint-cream">
+    <section id="hero" className="relative min-h-[60vh] flex flex-col justify-center bg-graphite">
       <div className="absolute inset-0 pointer-events-none">
         <div className="absolute inset-0 bg-[radial-gradient(#3A3B3A_1px,transparent_1px)] bg-[size:20px_20px]"></div>
       </div>

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -36,7 +36,7 @@ export default function LoadingScreen({ onComplete }: LoadingScreenProps) {
 
   return (
     <motion.div
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-mint-cream"
+      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-graphite"
       exit={{ opacity: 0 }}
       transition={{ duration: 0.5 }}
     >

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -43,7 +43,7 @@ export default function LoadingScreen({ onComplete }: LoadingScreenProps) {
       <p className="mb-4 font-display text-xs text-atomic-tangerine">
         SYSTEM_INIT...
       </p>
-      <h1 className="mb-8 font-display text-2xl text-black">
+      <h1 className="mb-8 font-display text-2xl text-platinum">
         FARHAN MOHAMMED
       </h1>
       <div
@@ -51,7 +51,7 @@ export default function LoadingScreen({ onComplete }: LoadingScreenProps) {
         aria-valuemin={0}
         aria-valuemax={100}
         aria-valuenow={progress}
-        className="mb-4 h-2 w-64 overflow-hidden rounded-none bg-graphite/20"
+        className="mb-4 h-2 w-64 overflow-hidden rounded-none bg-periwinkle/20"
       >
         <motion.div
           className="h-full bg-atomic-tangerine"
@@ -60,7 +60,7 @@ export default function LoadingScreen({ onComplete }: LoadingScreenProps) {
           transition={{ duration: 0.3, ease: 'easeOut' }}
         />
       </div>
-      <p className="font-body text-xs text-graphite">
+      <p className="font-body text-xs text-periwinkle">
         {STATUS_MESSAGES[messageIndex]}
       </p>
     </motion.div>

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -32,7 +32,7 @@ export default function MobileMenu({ isOpen, onClose, links }: MobileMenuProps) 
             variants={hoverEase}
             initial="idle"
             whileHover="hover"
-            className="absolute top-5 right-6 text-graphite"
+            className="absolute top-5 right-6 text-periwinkle"
           >
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
               <line x1="18" y1="6" x2="6" y2="18" />
@@ -49,7 +49,7 @@ export default function MobileMenu({ isOpen, onClose, links }: MobileMenuProps) 
                   variants={hoverEase}
                   initial="idle"
                   whileHover="hover"
-                  className="font-body text-2xl text-graphite no-underline"
+                  className="font-body text-2xl text-periwinkle no-underline"
                 >
                   {label}
                 </motion.a>

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -24,7 +24,7 @@ export default function MobileMenu({ isOpen, onClose, links }: MobileMenuProps) 
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.25 }}
-          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-mint-cream"
+          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-graphite"
         >
           <motion.button
             onClick={onClose}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,7 +33,7 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="sticky top-0 z-40 w-full flex items-center justify-between px-6 py-4 bg-mint-cream/90 backdrop-blur-sm">
+      <nav className="sticky top-0 z-40 w-full flex items-center justify-between px-6 py-4 bg-graphite/90 backdrop-blur-sm">
         <a href="#" className="font-display text-platinum text-lg no-underline">
           FM_
         </a>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -34,7 +34,7 @@ export default function Navbar() {
   return (
     <>
       <nav className="sticky top-0 z-40 w-full flex items-center justify-between px-6 py-4 bg-mint-cream/90 backdrop-blur-sm">
-        <a href="#" className="font-display text-black text-lg no-underline">
+        <a href="#" className="font-display text-platinum text-lg no-underline">
           FM_
         </a>
 
@@ -48,7 +48,7 @@ export default function Navbar() {
                   variants={hoverEase}
                   initial="idle"
                   whileHover="hover"
-                  className={`font-body text-sm no-underline pb-0.5${isActive ? ' text-atomic-tangerine border-b-2 border-atomic-tangerine' : ' text-black'}`}
+                  className={`font-body text-sm no-underline pb-0.5${isActive ? ' text-atomic-tangerine border-b-2 border-atomic-tangerine' : ' text-platinum'}`}
                 >
                   {label}
                 </motion.a>
@@ -58,7 +58,7 @@ export default function Navbar() {
         </ul>
 
         <motion.button
-          className="flex md:hidden text-graphite"
+          className="flex md:hidden text-periwinkle"
           onClick={() => setMenuOpen(true)}
           variants={hoverEase}
           initial="idle"

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -71,10 +71,7 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
       style={{ clipPath: NOTCH }}
     >
       {/* Card background */}
-      <div
-        className="relative bg-white p-5"
-        style={{ backgroundImage: 'linear-gradient(135deg, #F8F9FA 0%, #FFFFFF 100%)' }}
-      >
+      <div className="relative bg-platinum p-5">
         {project.image ? (
           <div className="mb-4 overflow-hidden" style={{ backgroundColor: '#3A3B3A' }}>
             <img
@@ -92,15 +89,15 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
         )}
 
         <div className="flex items-center gap-3 mb-2">
-          <span className="font-body text-xs text-periwinkle">
+          <span className="font-body text-xs text-graphite/50">
             _{project.id.padStart(2, '0')}
           </span>
-          <h3 className="font-body font-bold text-base text-platinum">
+          <h3 className="font-body font-bold text-base text-graphite">
             {project.title}
           </h3>
         </div>
 
-        <p className="text-periwinkle text-sm font-body leading-relaxed mb-4">
+        <p className="text-graphite/70 text-sm font-body leading-relaxed mb-4">
           {project.description}
         </p>
 
@@ -123,7 +120,7 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-mono text-xs text-periwinkle hover:text-atomic-tangerine transition-colors"
+              className="font-mono text-xs text-graphite/50 hover:text-atomic-tangerine transition-colors"
             >
               // {link.label} ↗
             </a>

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -44,8 +44,8 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
     >
       <div className="flex items-center gap-3 mb-8">
         <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 01</span>
-        <span className="font-body text-xs text-graphite tracking-widest whitespace-nowrap">PROJECTS</span>
-        <hr className="flex-1 border-graphite/20" />
+        <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">PROJECTS</span>
+        <hr className="flex-1 border-periwinkle/20" />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -92,15 +92,15 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
         )}
 
         <div className="flex items-center gap-3 mb-2">
-          <span className="font-body text-xs text-graphite">
+          <span className="font-body text-xs text-periwinkle">
             _{project.id.padStart(2, '0')}
           </span>
-          <h3 className="font-body font-bold text-base text-black">
+          <h3 className="font-body font-bold text-base text-platinum">
             {project.title}
           </h3>
         </div>
 
-        <p className="text-graphite text-sm font-body leading-relaxed mb-4">
+        <p className="text-periwinkle text-sm font-body leading-relaxed mb-4">
           {project.description}
         </p>
 
@@ -123,7 +123,7 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-mono text-xs text-graphite hover:text-atomic-tangerine transition-colors"
+              className="font-mono text-xs text-periwinkle hover:text-atomic-tangerine transition-colors"
             >
               // {link.label} ↗
             </a>

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -82,8 +82,8 @@ export function SkillsSection() {
     >
       <div className="flex items-center gap-3 mb-12">
         <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 02</span>
-        <span className="font-body text-xs text-graphite tracking-widest whitespace-nowrap">SKILLS</span>
-        <hr className="flex-1 border-graphite/20" />
+        <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">SKILLS</span>
+        <hr className="flex-1 border-periwinkle/20" />
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -47,16 +47,16 @@ function EntryList({ entries }: { entries: TimelineEntry[] }) {
               </p>
             </div>
             <div>
-              <h3 className="font-display text-xs text-black mb-3 leading-relaxed">
+              <h3 className="font-display text-xs text-platinum mb-3 leading-relaxed">
                 {entry.role}
               </h3>
-              <p className="font-body text-sm text-graphite leading-relaxed">
+              <p className="font-body text-sm text-periwinkle leading-relaxed">
                 {entry.description}
               </p>
             </div>
           </div>
           {index < entries.length - 1 && (
-            <hr className="border-graphite/20" />
+            <hr className="border-periwinkle/20" />
           )}
         </div>
       ))}
@@ -76,24 +76,24 @@ const TimelineSection: React.FC = () => {
     >
       <div className="flex items-center gap-3 mb-12">
         <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 03</span>
-        <span className="font-body text-xs text-graphite tracking-widest whitespace-nowrap">TIMELINE</span>
-        <hr className="flex-1 border-graphite/20" />
+        <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">TIMELINE</span>
+        <hr className="flex-1 border-periwinkle/20" />
       </div>
 
       <div className="space-y-12">
         <div>
-          <p className="font-body text-xs text-graphite/60 tracking-widest mb-2 uppercase">
+          <p className="font-body text-xs text-periwinkle/60 tracking-widest mb-2 uppercase">
             Education
           </p>
-          <hr className="border-graphite/10 mb-0" />
+          <hr className="border-periwinkle/10 mb-0" />
           <EntryList entries={education} />
         </div>
 
         <div>
-          <p className="font-body text-xs text-graphite/60 tracking-widest mb-2 uppercase">
+          <p className="font-body text-xs text-periwinkle/60 tracking-widest mb-2 uppercase">
             Experience
           </p>
-          <hr className="border-graphite/10 mb-0" />
+          <hr className="border-periwinkle/10 mb-0" />
           <EntryList entries={experience} />
         </div>
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -6,8 +6,8 @@
   --color-ultrasonic-blue: #5200E0;
   --color-fuchsia-flame: #E0007F;
   --color-golden-pollen: #FFCE47;
-  --color-black: #EFF1F3;
-  --color-graphite: #B2B6D2;
+  --color-platinum: #EFF1F3;
+  --color-periwinkle: #B2B6D2;
 
   --font-display: 'Press Start 2P', monospace;
   --font-body: 'Space Mono', monospace;
@@ -21,7 +21,7 @@ body {
   margin: 0;
   font-family: var(--font-body);
   background-color: var(--color-mint-cream);
-  color: var(--color-graphite);
+  color: var(--color-periwinkle);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 @theme {
-  --color-mint-cream: #2A2B2A;
+  --color-graphite: #2A2B2A;
   --color-atomic-tangerine: #FF8547;
   --color-ultrasonic-blue: #5200E0;
   --color-fuchsia-flame: #E0007F;
@@ -20,7 +20,7 @@ html {
 body {
   margin: 0;
   font-family: var(--font-body);
-  background-color: var(--color-mint-cream);
+  background-color: var(--color-graphite);
   color: var(--color-periwinkle);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Purpose

Fixes visual issues in the Projects and Skills sections and aligns all color token names with the PRD. Closes the work started in the previously closed PR.

## Changes made

**Color token renames (CSS + all components + PRD):**
- `mint-cream` → `graphite` (`#2A2B2A`) — page background
- `black` → `platinum` (`#EFF1F3`) — light text/surface
- `graphite` → `periwinkle` (`#B2B6D2`) — secondary text

**ProjectsSection:**
- Card background changed to `bg-platinum` with `text-graphite` for legible dark-on-light text
- Replaced `whileHover` with `useState` + `animate` to fix hover jank with `clipPath`
- Left-edge accent bar moved to render on top of clip region
- Image/placeholder height increased from `h-32` to `h-40`
- Placeholder colors changed to muted dark variants (no longer using full-brightness accent colors at large block size)

**SkillsSection:**
- Fixed bento grid `colSpan`/`rowSpan` values for correct desktop (4-col) and mobile (2-col) layout
- Accent tile corrected from `col-span-4` to `col-span-3`

**PRD:**
- Updated color palette table and all prose references to use the new token names

## Additional notes

All 44 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application's color theme for a refreshed visual experience. All interface sections, including navigation, hero section, project cards, skills grid, timeline, and contact areas, now use a revised color palette for a cohesive design throughout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->