### PR TITLE
Project card: replace dark placeholder colors with vivid palette

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -66,6 +66,13 @@ describe('ProjectsSection', () => {
     expect(screen.getByTestId('project-2-placeholder')).toBeInTheDocument()
   })
 
+  it('placeholder uses vivid palette color, not a dark shade', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const placeholder = screen.getByTestId('project-2-placeholder')
+    expect(placeholder).toHaveStyle({ backgroundColor: '#5200E0' })
+  })
+
   it('renders project cards matching the entries in projects data', () => {
     render(<ProjectsSection projects={mockProjects} />)
 

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -15,10 +15,10 @@ const TAG_COLORS = [
 ]
 
 const PLACEHOLDER_COLORS = [
-  '#5C002E',
-  '#1E0060',
-  '#6B3100',
-  '#5C4900',
+  '#E0007F',
+  '#5200E0',
+  '#FF8547',
+  '#FFCE47',
 ]
 
 const NOTCH = 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)'

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -120,7 +120,7 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-mono text-xs text-graphite/50 hover:text-atomic-tangerine transition-colors"
+              className="font-mono text-xs text-ultrasonic-blue hover:text-atomic-tangerine transition-colors"
             >
               // {link.label} ↗
             </a>


### PR DESCRIPTION
## Purpose

Closes #19. Project cards without images were using dark muted shades (#5C002E, #1E0060, #6B3100, #5C4900) that clashed with the portfolio's vivid palette. This swaps them for the actual palette colors.

## Changes made

- `ProjectsSection.tsx`: Updated `PLACEHOLDER_COLORS` to use fuchsia-flame, ultrasonic-blue, atomic-tangerine, and golden-pollen
- `ProjectsSection.test.tsx`: Added test asserting placeholder renders with a vivid palette color

## Additional notes

Branch needs conflict resolution once the pending PR on main is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test verification for project placeholder styling behavior.

* **Style**
  * Updated the color palette for project section placeholders displayed when images are unavailable.
  * Modified project link text colors for consistency throughout the projects section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->