### PR TITLE
Bento: set Python as large anchor tile (col-span-2, row-span-3)

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -55,6 +55,24 @@ describe('SkillsSection', () => {
     expect(new Set(heights).size).toBeGreaterThanOrEqual(2)
   })
 
+  it('Python tile spans at least 3 rows on desktop (md:row-span-3 or higher)', () => {
+    render(<SkillsSection />)
+    const pythonTile = screen.getByText('Python').closest('div')
+    expect(pythonTile).not.toBeNull()
+    expect(pythonTile!.className).toMatch(/md:row-span-[3-9]/)
+  })
+
+  it('grid defines at least 8 explicit rows to accommodate Python row-span-3 layout', () => {
+    render(<SkillsSection />)
+    const grid = screen.getByTestId('skills-grid')
+    const rowsClass = Array.from(grid.classList).find(c => c.includes('grid-rows-['))
+    expect(rowsClass).toBeDefined()
+    const match = rowsClass!.match(/grid-rows-\[(.+)\]/)
+    expect(match).not.toBeNull()
+    const heights = match![1].split('_')
+    expect(heights.length).toBeGreaterThanOrEqual(8)
+  })
+
   it('accent tile renders without category or skill name (colored fill only)', () => {
     render(<SkillsSection />)
 

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -15,26 +15,28 @@ interface SkillTile {
 // Desktop (4-col):
 //   R1: Python(2) TypeScript(1) Docker(1)
 //   R2: Python(2) TypeScript(1) C/C++(1)
-//   R3: JavaScript(1) FastAPI(1) PyTorch(2)
-//   R4: NumPy(2) Pandas(1) Ansible(1)
-//   R5: NumPy(2) HuggingFace(2)
-//   R6: Linux(1) Git(1) Scikit-learn(2)
-//   R7: SQL(1) Accent(3)
+//   R3: Python(2) JavaScript(1) FastAPI(1)
+//   R4: PyTorch(2) NumPy(2)
+//   R5: Pandas(1) Ansible(1) NumPy(2)
+//   R6: HuggingFace(2) Linux(1) Git(1)
+//   R7: Scikit-learn(3) SQL(1)
+//   R8: Accent(4)
 //
 // Mobile (2-col):
 //   R1: Python(2)
-//   R2: TypeScript(1) Docker(1)
-//   R3: TypeScript(1) C/C++(1)
-//   R4: JavaScript(1) FastAPI(1)
-//   R5: PyTorch(2)
-//   R6: NumPy(1) Pandas(1)
-//   R7: NumPy(1) Ansible(1)
-//   R8: HuggingFace(1) Linux(1)
-//   R9: Git(1) Scikit-learn(1)
-//   R10: SQL(2)
-//   R11: Accent(2)
+//   R2: Python(2)
+//   R3: TypeScript(1) Docker(1)
+//   R4: TypeScript(1) C/C++(1)
+//   R5: JavaScript(1) FastAPI(1)
+//   R6: PyTorch(2)
+//   R7: NumPy(1) Pandas(1)
+//   R8: NumPy(1) Ansible(1)
+//   R9: HuggingFace(1) Linux(1)
+//   R10: Git(1) Scikit-learn(1)
+//   R11: SQL(2)
+//   R12: Accent(2)
 const tiles: SkillTile[] = [
-  { category: 'LANGUAGE',  name: 'Python',       colSpan: 'col-span-2',                rowSpan: 'row-span-1 md:row-span-2', bg: '#FF8547', fg: '#050609' },
+  { category: 'LANGUAGE',  name: 'Python',       colSpan: 'col-span-2',                rowSpan: 'row-span-2 md:row-span-3', bg: '#FF8547', fg: '#050609' },
   { category: 'LANGUAGE',  name: 'TypeScript',   colSpan: 'col-span-1',                rowSpan: 'row-span-2',               bg: '#5200E0', fg: '#EFF1F3' },
   { category: 'TOOL',      name: 'Docker',       colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
   { category: 'LANGUAGE',  name: 'C / C++',      colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
@@ -47,7 +49,7 @@ const tiles: SkillTile[] = [
   { category: 'ML / DL',   name: 'Hugging Face', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
   { category: 'TOOL',      name: 'Linux',        colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
   { category: 'TOOL',      name: 'Git',          colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Scikit-learn', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Scikit-learn', colSpan: 'col-span-1 md:col-span-3',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
   { category: 'LANGUAGE',  name: 'SQL',          colSpan: 'col-span-2 md:col-span-1',  rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
 ]
 
@@ -86,14 +88,14 @@ export function SkillsSection() {
         <hr className="flex-1 border-periwinkle/20" />
       </div>
 
-      <div data-testid="skills-grid" className="grid grid-cols-2 md:grid-cols-4 gap-3 md:grid-rows-[120px_160px_120px_120px_120px_120px_120px]">
+      <div data-testid="skills-grid" className="grid grid-cols-2 md:grid-cols-4 gap-3 md:grid-rows-[120px_160px_120px_120px_120px_120px_120px_80px]">
         {tiles.map((tile) => (
           <SkillTileCard key={tile.name} tile={tile} />
         ))}
 
-        {/* Accent tile: fills R7 C2-C4 on desktop (col-span-3), full width on mobile */}
+        {/* Accent tile: fills R8 C1-C4 on desktop (col-span-4), full width on mobile */}
         <div
-          className="col-span-2 md:col-span-3 min-h-24 md:min-h-0 rounded-lg"
+          className="col-span-2 md:col-span-4 min-h-24 md:min-h-0 rounded-lg"
           style={{ backgroundColor: '#E0007F' }}
         />
       </div>


### PR DESCRIPTION
## Purpose

Gives the Python tile a dominant footprint so it anchors the bento grid corner visually. Closes #21.

## Changes made

- `Python` rowSpan: `row-span-1 md:row-span-2` → `row-span-2 md:row-span-3` (3 rows on desktop, 2 on mobile)
- `Scikit-learn` colSpan: `md:col-span-2` → `md:col-span-3` to fill R7 without a gap
- Accent tile: `md:col-span-3` → `md:col-span-4` (full desktop width, now occupies its own R8)
- `grid-rows` extended from 7 to 8 explicit rows — `80px` accent row appended
- Layout comment updated to reflect new 8-row desktop / 12-row mobile auto-placement
- Two new TDD tests added: Python `md:row-span-3+`, grid `≥ 8` explicit rows

## Additional notes

Scikit-learn widening to col-span-3 was the minimal change needed to avoid a gap at R7 C4. Issue #22 (magazine-style span redesign) can further redistribute spans across all tiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined the skills section grid layout with adjustments to individual tile heights, widths, and overall grid structure to enhance visual presentation and better organize skill categories.

* **Tests**
  * Enhanced test coverage for the skills section layout, including validation of tile sizing and grid configuration to ensure consistent responsive design behavior across devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->