### PR TITLE
Improve TimelineSection typography readability

### DIFF
--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -38,18 +38,18 @@ function EntryList({ entries }: { entries: TimelineEntry[] }) {
         <div key={index}>
           <div className="grid grid-cols-[30%_70%] gap-8 py-8">
             <div>
-              <p className="font-body text-xs text-atomic-tangerine tracking-wider uppercase">
+              <p className="font-body text-sm text-atomic-tangerine tracking-wider uppercase">
                 {entry.dateRange}
               </p>
-              <p className="font-body text-xs text-atomic-tangerine tracking-wider mt-1">
+              <p className="font-body text-sm text-atomic-tangerine tracking-wider mt-1">
                 {entry.institution}
               </p>
             </div>
             <div>
-              <h3 className="font-display text-xs text-platinum mb-3 leading-relaxed">
+              <h3 className="font-display text-sm text-platinum mb-3 leading-relaxed">
                 {entry.role}
               </h3>
-              <p className="font-body text-sm text-periwinkle leading-relaxed">
+              <p className="font-body text-base text-periwinkle leading-relaxed">
                 {entry.description}
               </p>
             </div>
@@ -68,14 +68,14 @@ const TimelineSection: React.FC = () => {
     <ScrollFadeSection id="timeline" className="min-h-screen flex flex-col justify-center py-14 px-6 max-w-5xl mx-auto">
       <div>
         <div className="flex items-center gap-3 mb-12">
-          <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 03</span>
-          <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">TIMELINE</span>
+          <span className="font-body text-sm text-atomic-tangerine tracking-widest whitespace-nowrap">// 03</span>
+          <span className="font-body text-sm text-periwinkle tracking-widest whitespace-nowrap">TIMELINE</span>
           <hr className="flex-1 border-periwinkle/20" />
         </div>
 
         <div className="space-y-12">
           <div>
-            <p className="font-body text-xs text-periwinkle/60 tracking-widest mb-2 uppercase">
+            <p className="font-body text-sm text-periwinkle tracking-widest mb-2 uppercase">
               Education
             </p>
             <hr className="border-periwinkle/10 mb-0" />
@@ -83,7 +83,7 @@ const TimelineSection: React.FC = () => {
           </div>
 
           <div>
-            <p className="font-body text-xs text-periwinkle/60 tracking-widest mb-2 uppercase">
+            <p className="font-body text-sm text-periwinkle tracking-widest mb-2 uppercase">
               Experience
             </p>
             <hr className="border-periwinkle/10 mb-0" />


### PR DESCRIPTION
## Purpose

Fixes two readability issues in the Timeline section (Education / Experience).

## Changes made

- Removed `/60` opacity modifier from `Education` and `Experience` section labels — `text-periwinkle/60` → `text-periwinkle`, restoring full color contrast
- Bumped all font sizes up by 2px:
  - `text-xs` (12px) → `text-sm` (14px) for section header, labels, date range, institution, and role
  - `text-sm` (14px) → `text-base` (16px) for description body text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced timeline section styling with updated text sizing and color adjustments for improved visual hierarchy and readability across timeline entries and section headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/28?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->