### PR TITLE
Improve bento grid padding, row heights, and scroll fade

### DIFF
--- a/src/components/ScrollFadeSection.tsx
+++ b/src/components/ScrollFadeSection.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 export function ScrollFadeSection({ id, children, className = '' }: Props) {
   const ref = useRef<HTMLElement>(null)
-  const isInView = useInView(ref, { margin: '-20% 0px -20% 0px', amount: 0.3 })
+  const isInView = useInView(ref, { margin: '-10% 0px -10% 0px', amount: 0.1 })
 
   return (
     <motion.section

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -61,7 +61,7 @@ function SkillTileCard({ tile }: { tile: SkillTile }) {
       variants={hoverEase}
       initial="idle"
       whileHover="hover"
-      className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-6 rounded-lg flex flex-col justify-between cursor-default`}
+      className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-5 rounded-lg flex flex-col justify-between cursor-default`}
       style={{ backgroundColor: tile.bg, color: tile.fg }}
     >
       <span className="text-xs uppercase tracking-widest font-body">

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -61,7 +61,7 @@ function SkillTileCard({ tile }: { tile: SkillTile }) {
       variants={hoverEase}
       initial="idle"
       whileHover="hover"
-      className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-5 rounded-lg flex flex-col justify-between cursor-default`}
+      className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-6 rounded-lg flex flex-col justify-between cursor-default`}
       style={{ backgroundColor: tile.bg, color: tile.fg }}
     >
       <span className="text-xs uppercase tracking-widest font-body">
@@ -84,7 +84,7 @@ export function SkillsSection() {
           <hr className="flex-1 border-periwinkle/20" />
         </div>
 
-        <div data-testid="skills-grid" className="grid grid-cols-2 md:grid-cols-4 gap-3 md:grid-rows-[80px_100px_80px_80px_80px_80px_80px_80px_60px]">
+        <div data-testid="skills-grid" className="grid grid-cols-2 md:grid-cols-4 gap-3 md:grid-rows-[90px_100px_90px_90px_90px_90px_90px_90px_60px]">
           {tiles.map((tile) => (
             <SkillTileCard key={tile.name} tile={tile} />
           ))}


### PR DESCRIPTION
## Purpose

Addresses readability and layout issues in the Skills bento grid.

## Changes made

- **`SkillsSection`**: bumped tile padding `p-5 → p-6` so name text has 24px of breathing room from the bottom edge instead of 20px; reduced grid row heights from `110/120px` back to `90/100px` so the full section fits within a 1080p viewport
- **`ScrollFadeSection`**: loosened `amount` from `0.3 → 0.1` and margins from `-20% → -10%` so the section stays visible while the user scrolls through it rather than fading out prematurely as its top exits the frame

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tighter scroll fade timing for smoother, more refined fade-in/out as sections enter view.
  * Increased desktop skill-grid row heights for improved spacing and readability of skill tiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->