### PR TITLE
Layout system: graphite-light token + max-w-7xl px-8 on all sections

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -13,8 +13,8 @@ const footerLinks = [
 
 export default function ContactSection() {
   return (
-    <ScrollFadeSection id="contact" className="min-h-screen flex flex-col justify-center px-6 py-14 md:px-16 lg:px-32">
-      <div className="max-w-5xl mx-auto w-full">
+    <ScrollFadeSection id="contact" className="min-h-screen flex flex-col justify-center px-8 py-14">
+      <div className="max-w-7xl mx-auto w-full">
         <p className="font-body text-sm text-atomic-tangerine mb-8">// 04 CONTACT</p>
 
         <h2 className="font-display text-3xl md:text-5xl text-platinum leading-tight mb-12">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -7,7 +7,7 @@ const HeroSection: React.FC = () => {
         <div className="absolute inset-0 bg-[radial-gradient(#3A3B3A_1px,transparent_1px)] bg-[size:20px_20px]"></div>
       </div>
 
-      <div className="relative z-10 px-6 max-w-5xl mx-auto space-y-6">
+      <div className="relative z-10 px-8 max-w-7xl mx-auto space-y-6">
         <div className="space-y-2">
           <p className="font-body text-xs text-atomic-tangerine tracking-widest">
             // PORTFOLIO_INIT

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,7 +33,7 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="sticky top-0 z-40 w-full flex items-center justify-between px-6 py-4 bg-graphite/90 backdrop-blur-sm">
+      <nav className="sticky top-0 z-40 w-full flex items-center justify-between px-8 py-4 bg-graphite/90 backdrop-blur-sm">
         <a href="#" className="font-display text-platinum text-lg no-underline">
           FM_
         </a>

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -34,7 +34,7 @@ function getPlaceholderColor(projectIndex: number) {
 
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
   return (
-    <ScrollFadeSection id="projects" className="min-h-screen flex flex-col justify-center py-14 px-6 max-w-5xl mx-auto">
+    <ScrollFadeSection id="projects" className="min-h-screen flex flex-col justify-center py-14 px-8 max-w-7xl mx-auto">
       <div>
         <div className="flex items-center gap-3 mb-8">
           <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 01</span>

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -76,7 +76,7 @@ function SkillTileCard({ tile }: { tile: SkillTile }) {
 
 export function SkillsSection() {
   return (
-    <ScrollFadeSection id="skills" className="min-h-screen flex flex-col justify-center py-14 px-6 max-w-5xl mx-auto">
+    <ScrollFadeSection id="skills" className="min-h-screen flex flex-col justify-center py-14 px-8 max-w-7xl mx-auto">
       <div>
         <div className="flex items-center gap-3 mb-12">
           <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 02</span>

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -65,7 +65,7 @@ function EntryList({ entries }: { entries: TimelineEntry[] }) {
 
 const TimelineSection: React.FC = () => {
   return (
-    <ScrollFadeSection id="timeline" className="min-h-screen flex flex-col justify-center py-14 px-6 max-w-5xl mx-auto">
+    <ScrollFadeSection id="timeline" className="min-h-screen flex flex-col justify-center py-14 px-8 max-w-7xl mx-auto">
       <div>
         <div className="flex items-center gap-3 mb-12">
           <span className="font-body text-sm text-atomic-tangerine tracking-widest whitespace-nowrap">// 03</span>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
 
 @theme {
   --color-graphite: #2A2B2A;
+  --color-graphite-light: #323332;
   --color-atomic-tangerine: #FF8547;
   --color-ultrasonic-blue: #5200E0;
   --color-fuchsia-flame: #E0007F;


### PR DESCRIPTION
## Purpose

Closes #30 - Establish the single container width that all sections and the navbar will share.

## Changes made

- Add `graphite-light: #323332` token to `@theme` block in `index.css`
- Update Navbar: `px-6` → `px-8`
- Update HeroSection, ProjectsSection, SkillsSection, TimelineSection, ContactSection: `max-w-5xl px-6` → `max-w-7xl px-8`

## Additional notes

- ContactSection also had `md:px-16 lg:px-32` which was simplified to single `px-8` for consistency
- Blocked by #39 (section headers ghost number + Press Start 2P heading)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased horizontal padding and expanded maximum container widths across multiple sections including the hero banner, navigation bar, projects display, skills section, timeline view, and contact area
  * Added new color variable to the application theme palette

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->