### PR TITLE
Background alternation: graphite/graphite-light per section

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -13,8 +13,8 @@ const footerLinks = [
 
 export default function ContactSection() {
   return (
-    <ScrollFadeSection id="contact" className="min-h-screen flex flex-col justify-center px-6 py-14 md:px-16 lg:px-32">
-      <div className="max-w-5xl mx-auto w-full">
+    <ScrollFadeSection id="contact" className="min-h-screen flex flex-col justify-center px-8 py-14 bg-graphite">
+      <div className="max-w-7xl mx-auto w-full">
         <p className="font-body text-sm text-atomic-tangerine mb-8">// 04 CONTACT</p>
 
         <h2 className="font-display text-3xl md:text-5xl text-platinum leading-tight mb-12">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -7,7 +7,7 @@ const HeroSection: React.FC = () => {
         <div className="absolute inset-0 bg-[radial-gradient(#3A3B3A_1px,transparent_1px)] bg-[size:20px_20px]"></div>
       </div>
 
-      <div className="relative z-10 px-6 max-w-5xl mx-auto space-y-6">
+      <div className="relative z-10 px-8 max-w-7xl mx-auto space-y-6">
         <div className="space-y-2">
           <p className="font-body text-xs text-atomic-tangerine tracking-widest">
             // PORTFOLIO_INIT

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,44 +33,46 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="sticky top-0 z-40 w-full flex items-center justify-between px-8 py-4 bg-graphite/90 backdrop-blur-sm">
-        <a href="#" className="font-display text-platinum text-lg no-underline">
-          FM_
-        </a>
+      <nav className="sticky top-0 z-40 w-full py-4 bg-graphite/90 backdrop-blur-sm">
+        <div className="max-w-7xl mx-auto w-full flex items-center justify-between px-8">
+          <a href="#" className="font-display text-platinum text-lg no-underline">
+            FM_
+          </a>
 
-        <ul className="hidden md:flex gap-8 list-none m-0 p-0">
-          {NAV_LINKS.map(({ label, href }) => {
-            const isActive = activeSection === href.slice(1)
-            return (
-              <li key={label}>
-                <motion.a
-                  href={href}
-                  variants={hoverEase}
-                  initial="idle"
-                  whileHover="hover"
-                  className={`font-body text-sm no-underline pb-0.5${isActive ? ' text-atomic-tangerine border-b-2 border-atomic-tangerine' : ' text-platinum'}`}
-                >
-                  {label}
-                </motion.a>
-              </li>
-            )
-          })}
-        </ul>
+          <ul className="hidden md:flex gap-8 list-none m-0 p-0">
+            {NAV_LINKS.map(({ label, href }) => {
+              const isActive = activeSection === href.slice(1)
+              return (
+                <li key={label}>
+                  <motion.a
+                    href={href}
+                    variants={hoverEase}
+                    initial="idle"
+                    whileHover="hover"
+                    className={`font-body text-sm no-underline pb-0.5${isActive ? ' text-atomic-tangerine border-b-2 border-atomic-tangerine' : ' text-platinum'}`}
+                  >
+                    {label}
+                  </motion.a>
+                </li>
+              )
+            })}
+          </ul>
 
-        <motion.button
-          className="flex md:hidden text-periwinkle"
-          onClick={() => setMenuOpen(true)}
-          variants={hoverEase}
-          initial="idle"
-          whileHover="hover"
-          aria-label="Open menu"
-        >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="3" y1="12" x2="21" y2="12" />
-            <line x1="3" y1="18" x2="21" y2="18" />
-          </svg>
-        </motion.button>
+          <motion.button
+            className="flex md:hidden text-periwinkle"
+            onClick={() => setMenuOpen(true)}
+            variants={hoverEase}
+            initial="idle"
+            whileHover="hover"
+            aria-label="Open menu"
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <line x1="3" y1="6" x2="21" y2="6" />
+              <line x1="3" y1="12" x2="21" y2="12" />
+              <line x1="3" y1="18" x2="21" y2="18" />
+            </svg>
+          </motion.button>
+        </div>
       </nav>
 
       <MobileMenu

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -33,7 +33,7 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="sticky top-0 z-40 w-full flex items-center justify-between px-6 py-4 bg-graphite/90 backdrop-blur-sm">
+      <nav className="sticky top-0 z-40 w-full flex items-center justify-between px-8 py-4 bg-graphite/90 backdrop-blur-sm">
         <a href="#" className="font-display text-platinum text-lg no-underline">
           FM_
         </a>

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -34,7 +34,7 @@ function getPlaceholderColor(projectIndex: number) {
 
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
   return (
-    <ScrollFadeSection id="projects" className="min-h-screen flex flex-col justify-center py-14 px-6 max-w-5xl mx-auto">
+    <ScrollFadeSection id="projects" className="min-h-screen flex flex-col justify-center py-14 px-8 max-w-7xl mx-auto bg-graphite-light">
       <div>
         <div className="flex items-center gap-3 mb-8">
           <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 01</span>

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -76,7 +76,7 @@ function SkillTileCard({ tile }: { tile: SkillTile }) {
 
 export function SkillsSection() {
   return (
-    <ScrollFadeSection id="skills" className="min-h-screen flex flex-col justify-center py-14 px-6 max-w-5xl mx-auto">
+    <ScrollFadeSection id="skills" className="min-h-screen flex flex-col justify-center py-14 px-8 max-w-7xl mx-auto bg-graphite">
       <div>
         <div className="flex items-center gap-3 mb-12">
           <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 02</span>

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -65,7 +65,7 @@ function EntryList({ entries }: { entries: TimelineEntry[] }) {
 
 const TimelineSection: React.FC = () => {
   return (
-    <ScrollFadeSection id="timeline" className="min-h-screen flex flex-col justify-center py-14 px-6 max-w-5xl mx-auto">
+    <ScrollFadeSection id="timeline" className="min-h-screen flex flex-col justify-center py-14 px-8 max-w-7xl mx-auto bg-graphite-light">
       <div>
         <div className="flex items-center gap-3 mb-12">
           <span className="font-body text-sm text-atomic-tangerine tracking-widest whitespace-nowrap">// 03</span>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
 
 @theme {
   --color-graphite: #2A2B2A;
+  --color-graphite-light: #323332;
   --color-atomic-tangerine: #FF8547;
   --color-ultrasonic-blue: #5200E0;
   --color-fuchsia-flame: #E0007F;


### PR DESCRIPTION
## Purpose

Closes #37 - Apply alternating background colours across sections to create scroll rhythm using the graphite-light token from #30.

## Changes made

- Add `graphite-light: #323332` token to `@theme` in `index.css`
- Hero: `bg-graphite` + `max-w-7xl px-8`
- Projects: `bg-graphite-light` + `max-w-7xl px-8`
- Skills: `bg-graphite` + `max-w-7xl px-8`
- Timeline: `bg-graphite-light` + `max-w-7xl px-8`
- Contact: `bg-graphite` + `max-w-7xl px-8`
- Navbar: `px-8`

## Additional notes

- Blocked by #39 (section headers ghost number + Press Start 2P heading)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Harmonized horizontal spacing and increased content widths across multiple page sections for improved alignment and a more spacious layout.
  * Introduced a lighter graphite color variant to the theme palette, used for a subtle background tone in select sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->