### PR TITLE
Skills: remove accent tile

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -95,8 +95,6 @@ describe('SkillsSection', () => {
     const gridContainer = document.querySelector('.grid')
     const children = Array.from(gridContainer?.children || [])
 
-    expect(children.length).toBe(15)
-
     const lastChild = children[children.length - 1]
     expect(lastChild.textContent).toContain('SQL')
     expect(lastChild.textContent).not.toMatch(/^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/)

--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -32,7 +32,7 @@ describe('SkillsSection', () => {
     }
   })
 
-  it('renders 15 skill tiles (no decorative stripe row with 4 vertical divs)', () => {
+  it('renders 15 skill tiles with no accent tile', () => {
     render(<SkillsSection />)
 
     const categoryLabels = screen.getAllByText(/^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/)
@@ -40,7 +40,7 @@ describe('SkillsSection', () => {
 
     const gridContainer = document.querySelector('.grid')
     const children = gridContainer?.children || []
-    expect(children.length).toBe(16)
+    expect(children.length).toBe(15)
   })
 
   it('desktop grid has an explicit grid-rows class with at least 3 distinct row heights', () => {
@@ -89,17 +89,17 @@ describe('SkillsSection', () => {
     expect(heights.length).toBeGreaterThanOrEqual(8)
   })
 
-  it('accent tile renders without category or skill name (colored fill only)', () => {
+  it('no accent tile renders at bottom of grid', () => {
     render(<SkillsSection />)
 
     const gridContainer = document.querySelector('.grid')
     const children = Array.from(gridContainer?.children || [])
-    const accentTile = children[children.length - 1]
 
-    expect(accentTile).not.toHaveTextContent(/LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA/)
-    expect(accentTile).not.toHaveTextContent(/Python|TypeScript|JavaScript|C \/ C\+\+|SQL/)
-
-    const styles = window.getComputedStyle(accentTile)
-    expect(styles.backgroundColor).not.toBe('rgba(0, 0, 0, 0)')
+    const allHaveCategoryOrSkill = children.every(child => {
+      const text = child.textContent || ''
+      return /^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/.test(text) ||
+             /Python|TypeScript|JavaScript|C \/ C\+\+|SQL|Docker|Git|Ansible|Linux|NumPy|Pandas|FastAPI|PyTorch|Hugging Face|Scikit-learn/.test(text)
+    })
+    expect(allHaveCategoryOrSkill).toBe(true)
   })
 })

--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -95,6 +95,12 @@ describe('SkillsSection', () => {
     const gridContainer = document.querySelector('.grid')
     const children = Array.from(gridContainer?.children || [])
 
+    expect(children.length).toBe(15)
+
+    const lastChild = children[children.length - 1]
+    expect(lastChild.textContent).toContain('SQL')
+    expect(lastChild.textContent).not.toMatch(/^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/)
+
     const allHaveCategoryOrSkill = children.every(child => {
       const text = child.textContent || ''
       return /^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/.test(text) ||

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -88,12 +88,6 @@ export function SkillsSection() {
           {tiles.map((tile) => (
             <SkillTileCard key={tile.name} tile={tile} />
           ))}
-
-          {/* Accent tile: fills R9 C1-C4 on desktop (col-span-4), full width on mobile */}
-          <div
-            className="col-span-2 md:col-span-4 min-h-24 md:min-h-0 rounded-lg"
-            style={{ backgroundColor: '#E0007F' }}
-          />
         </div>
       </div>
     </ScrollFadeSection>

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -13,7 +13,7 @@ interface SkillTile {
   fg: string
 }
 
-// Desktop (4-col, 9 rows — no two adjacent rows share the same span pattern):
+// Desktop (4-col, 8 rows — no two adjacent rows share the same span pattern):
 //   R1: Python(2) TypeScript(2)          [2,2]
 //   R2: Python(2) Docker(1) C/C++(1)     [2,1,1]
 //   R3: Python(2) JavaScript(2)          [2,2]
@@ -22,7 +22,6 @@ interface SkillTile {
 //   R6: NumPy(2) HuggingFace(2)          [2,2]
 //   R7: Scikit-learn(3) Linux(1)         [3,1]
 //   R8: Git(1) SQL(3)                    [1,3]
-//   R9: Accent(4)                        [4]
 //
 // Mobile (2-col):
 //   R1: Python(2)
@@ -36,7 +35,6 @@ interface SkillTile {
 //   R9: HuggingFace(1) Scikit-learn(1)
 //   R10: Linux(1) Git(1)
 //   R11: SQL(2)
-//   R12: Accent(2)
 const tiles: SkillTile[] = [
   { category: 'LANGUAGE',  name: 'Python',       colSpan: 'col-span-2',                rowSpan: 'row-span-2 md:row-span-3', bg: '#FF8547', fg: '#050609' },
   { category: 'LANGUAGE',  name: 'TypeScript',   colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-2 md:row-span-1', bg: '#5200E0', fg: '#EFF1F3' },
@@ -84,7 +82,7 @@ export function SkillsSection() {
           <hr className="flex-1 border-periwinkle/20" />
         </div>
 
-        <div data-testid="skills-grid" className="grid grid-cols-2 md:grid-cols-4 gap-3 md:grid-rows-[90px_100px_90px_90px_90px_90px_90px_90px_60px]">
+        <div data-testid="skills-grid" className="grid grid-cols-2 md:grid-cols-4 gap-3 md:grid-rows-[90px_100px_90px_90px_90px_90px_90px_90px]">
           {tiles.map((tile) => (
             <SkillTileCard key={tile.name} tile={tile} />
           ))}


### PR DESCRIPTION
## Purpose

Closes #35 - Remove the plain fuchsia accent block at the bottom of the skills grid.

## Changes made

- Remove accent tile div from SkillsSection.tsx
- Update test: 15 skill tiles with no accent tile
- Update test: assert no accent tile at bottom of grid

## Additional notes

- Blocked by #39 (section headers ghost number + Press Start 2P heading)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined the skills grid: removed the manual accent tile so the grid now renders 15 tiles for a more consistent layout and predictable ordering (last tile displays SQL).

* **Tests**
  * Updated tests to expect 15 tiles, assert the last tile contains SQL, and verify every tile shows only known category labels or skill names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->