### PR TITLE
ScrollFadeSection: fix opacity floor + add translateY reveal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfolio-scaffold",
       "version": "0.0.0",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "dotenv": "^17.4.2",
         "framer-motion": "^12.38.0",
         "react": "^19.2.6",
@@ -2434,6 +2435,48 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "dotenv": "^17.4.2",
         "framer-motion": "^12.38.0",
         "react": "^19.2.6",
@@ -2456,6 +2457,44 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "dotenv": "^17.4.2",
     "framer-motion": "^12.38.0",
     "react": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "sandcastle": "npx tsx .sandcastle/main.ts"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "dotenv": "^17.4.2",
     "framer-motion": "^12.38.0",
     "react": "^19.2.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
+import { Analytics } from '@vercel/analytics/react'
 import './index.css'
 import LoadingScreen from './components/LoadingScreen'
 import Navbar from './components/Navbar'
@@ -26,6 +27,7 @@ function App() {
         <TimelineSection />
         <ContactSection />
       </main>
+      <Analytics />
     </>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import { Analytics } from '@vercel/analytics/react'
+import { SpeedInsights } from '@vercel/speed-insights/react'
 import './index.css'
 import LoadingScreen from './components/LoadingScreen'
 import Navbar from './components/Navbar'
@@ -28,6 +29,7 @@ function App() {
         <ContactSection />
       </main>
       <Analytics />
+      <SpeedInsights />
     </>
   )
 }

--- a/src/components/ScrollFadeSection.test.tsx
+++ b/src/components/ScrollFadeSection.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ScrollFadeSection } from './ScrollFadeSection'
+
+describe('ScrollFadeSection', () => {
+  it('renders children inside the section', () => {
+    render(<ScrollFadeSection id="hero">Hello World</ScrollFadeSection>)
+    expect(screen.getByText('Hello World')).toBeInTheDocument()
+  })
+
+  it('starts with opacity 0 before scrolling into view', () => {
+    render(<ScrollFadeSection id="test-section">content</ScrollFadeSection>)
+    const section = document.getElementById('test-section')!
+    expect(section).toHaveStyle({ opacity: '0' })
+  })
+
+  it('starts at translateY 24px before scrolling into view', () => {
+    render(<ScrollFadeSection id="test-section">content</ScrollFadeSection>)
+    const section = document.getElementById('test-section')!
+    expect(section.style.transform).toContain('translateY(24px)')
+  })
+})

--- a/src/components/ScrollFadeSection.test.tsx
+++ b/src/components/ScrollFadeSection.test.tsx
@@ -2,7 +2,12 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { ScrollFadeSection } from './ScrollFadeSection'
 
+/**
+ * Tests for ScrollFadeSection component.
+ * Verifies children rendering and initial animation states.
+ */
 describe('ScrollFadeSection', () => {
+  /** Verifies that child content is rendered inside the section. */
   it('renders children inside the section', () => {
     render(<ScrollFadeSection id="hero">Hello World</ScrollFadeSection>)
     expect(screen.getByText('Hello World')).toBeInTheDocument()

--- a/src/components/ScrollFadeSection.tsx
+++ b/src/components/ScrollFadeSection.tsx
@@ -1,12 +1,21 @@
 import { motion, useInView } from 'framer-motion'
 import { useRef, type ReactNode } from 'react'
 
+/** Props for the ScrollFadeSection component. */
 interface Props {
+  /** Unique identifier for the section element. */
   id: string
+  /** Child content to render inside the section. */
   children: ReactNode
+  /** Optional CSS classes to apply to the section. */
   className?: string
 }
 
+/**
+ * A section that fades in and slides up when scrolled into view.
+ * Uses Framer Motion's useInView to trigger opacity and translateY
+ * animations with a 0.6s easeOut transition.
+ */
 export function ScrollFadeSection({ id, children, className = '' }: Props) {
   const ref = useRef<HTMLElement>(null)
   const isInView = useInView(ref, { margin: '-10% 0px -10% 0px', amount: 0.1 })

--- a/src/components/ScrollFadeSection.tsx
+++ b/src/components/ScrollFadeSection.tsx
@@ -16,9 +16,9 @@ export function ScrollFadeSection({ id, children, className = '' }: Props) {
       ref={ref}
       id={id}
       className={className}
-      initial={{ opacity: 0 }}
-      animate={{ opacity: isInView ? 1 : 0.3 }}
-      transition={{ duration: 0.4, ease: 'easeOut' }}
+      initial={{ opacity: 0, y: 24 }}
+      animate={{ opacity: isInView ? 1 : 0, y: isInView ? 0 : 24 }}
+      transition={{ duration: 0.6, ease: 'easeOut' }}
     >
       {children}
     </motion.section>


### PR DESCRIPTION
## Purpose

Fixes two animation bugs in `ScrollFadeSection`. Closes #31.

## Changes made

- Fixed `animate` opacity target from `0.3` → `0` so sections that are out of view don't linger at 30% opacity
- Added `y: 24` to `initial` and `y: isInView ? 0 : 24` to `animate` so each section rises 24px into view on scroll
- Fixed transition duration from `0.4s` → `0.6s` with `easeOut` per spec
- Created `ScrollFadeSection.test.tsx` with three tests: renders children, initial opacity is 0, initial translateY is 24px

## Additional notes

All 58 tests pass; no typecheck errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved scroll-fade animation for smoother opacity and vertical movement during reveal.

* **Tests**
  * Added tests confirming rendering and initial animation states for the scroll-fade section.

* **New Features**
  * Integrated site analytics and performance insights components into the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->