### PR TITLE
Hero: blinking cursor after name

### DIFF
--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -19,4 +19,11 @@ describe('HeroSection', () => {
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', '#projects')
   })
+
+  it('shows a blinking cursor after the name', () => {
+    render(<HeroSection />)
+    const cursor = document.querySelector('[data-testid="cursor"]')
+    expect(cursor).toBeInTheDocument()
+    expect(cursor).toHaveClass('bg-atomic-tangerine')
+  })
 })

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import HeroSection from './HeroSection'
+import HeroSection, { cursorVariants } from './HeroSection'
 
 describe('HeroSection', () => {
   it('shows the developer name', () => {
@@ -22,8 +22,27 @@ describe('HeroSection', () => {
 
   it('shows a blinking cursor after the name', () => {
     render(<HeroSection />)
-    const cursor = document.querySelector('[data-testid="cursor"]')
+    const heading = screen.getByRole('heading', { name: 'FARHAN MOHAMMED' })
+    const cursor = screen.getByTestId('cursor')
+
     expect(cursor).toBeInTheDocument()
     expect(cursor).toHaveClass('bg-atomic-tangerine')
+    expect(cursor).toHaveClass('w-[3px]')
+    expect(cursor.previousSibling?.textContent).toBe('FARHAN MOHAMMED')
+    expect(heading.lastElementChild).toBe(cursor)
+  })
+
+  it('uses a step-like one-second blink animation for the cursor', () => {
+    const blink = cursorVariants.blink
+
+    expect(blink).toMatchObject({
+      opacity: [1, 1, 0, 0, 1],
+      transition: {
+        duration: 1,
+        ease: 'linear',
+        repeat: Infinity,
+        times: [0, 0.49, 0.5, 0.99, 1],
+      },
+    })
   })
 })

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,4 +1,15 @@
+import { motion } from 'framer-motion'
 import { ScrollFadeSection } from './ScrollFadeSection'
+
+const cursorVariants = {
+  blink: {
+    opacity: [0, 1, 0],
+    transition: {
+      duration: 1,
+      repeat: Infinity,
+    },
+  },
+}
 
 const HeroSection: React.FC = () => {
   return (
@@ -17,6 +28,12 @@ const HeroSection: React.FC = () => {
 
         <h1 className="font-display text-5xl text-platinum leading-tight">
           FARHAN MOHAMMED
+          <motion.span
+            data-testid="cursor"
+            className="inline-block w-[3px] h-[1.2em] bg-atomic-tangerine align-middle ml-1"
+            variants={cursorVariants}
+            animate="blink"
+          />
         </h1>
 
         <p className="font-body text-xl text-periwinkle">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,12 +1,14 @@
-import { motion } from 'framer-motion'
+import { motion, type Variants } from 'framer-motion'
 import { ScrollFadeSection } from './ScrollFadeSection'
 
-const cursorVariants = {
+export const cursorVariants: Variants = {
   blink: {
-    opacity: [0, 1, 0],
+    opacity: [1, 1, 0, 0, 1],
     transition: {
       duration: 1,
+      ease: 'linear',
       repeat: Infinity,
+      times: [0, 0.49, 0.5, 0.99, 1],
     },
   },
 }
@@ -30,6 +32,7 @@ const HeroSection: React.FC = () => {
           FARHAN MOHAMMED
           <motion.span
             data-testid="cursor"
+            aria-hidden="true"
             className="inline-block w-[3px] h-[1.2em] bg-atomic-tangerine align-middle ml-1"
             variants={cursorVariants}
             animate="blink"


### PR DESCRIPTION
**Purpose** — Add a persistent blinking cursor after the hero name to match the issue #32 design requirement.

**What it does** — Renders a narrow atomic-tangerine motion span immediately after FARHAN MOHAMMED and animates it with a step-like one-second opacity blink.

**Changes made**
- Updated src/components/HeroSection.tsx to expose the cursor animation contract, use discrete hold/jump opacity keyframes, and mark the decorative cursor aria-hidden.
- Updated src/components/HeroSection.test.tsx to verify cursor placement after the name, width/color styling, and blink timing details.

**Additional notes** — The blink remains persistent for the page lifetime and does not implement typewriter movement.

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an animated blinking cursor to the hero section heading, creating a subtle visual effect that enhances the page's visual appeal.

* **Tests**
  * Added test coverage to verify the cursor element renders with proper styling and that the animation behavior meets specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->