### PR TITLE
mochiBot12: Navbar - > prefix on hover + update test (#42)

### DIFF
--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -140,4 +140,43 @@ describe('Navbar', () => {
       expect(innerContainer!.className).toContain('px-8')
     })
   })
+
+  describe('issue #42 - > prefix on hover', () => {
+    it('nav link shows > prefix on hover', async () => {
+      const user = userEvent.setup()
+      render(<Navbar />)
+
+      const homeLink = screen.getByRole('link', { name: /home/i })
+      const prefixSpan = homeLink.querySelector('span')
+      expect(prefixSpan).not.toBeNull()
+      expect(prefixSpan!.textContent).toBe('> ')
+      expect(prefixSpan!.style.opacity).toBe('0')
+
+      await user.hover(homeLink)
+      expect(prefixSpan!.style.opacity).toBe('1')
+
+      await user.unhover(homeLink)
+      expect(prefixSpan!.style.opacity).toBe('0')
+    })
+
+    it('> prefix appears on hover for all nav links', async () => {
+      const user = userEvent.setup()
+      render(<Navbar />)
+
+      const labels = ['HOME', 'PROJECTS', 'SKILLS', 'TIMELINE', 'CONTACT']
+      for (const label of labels) {
+        const link = screen.getByRole('link', { name: new RegExp(label, 'i') })
+        const prefixSpan = link.querySelector('span')
+        expect(prefixSpan).not.toBeNull()
+        expect(prefixSpan!.textContent).toBe('> ')
+        expect(prefixSpan!.style.opacity).toBe('0')
+
+        await user.hover(link)
+        expect(prefixSpan!.style.opacity).toBe('1')
+
+        await user.unhover(link)
+        expect(prefixSpan!.style.opacity).toBe('0')
+      }
+    })
+  })
 })

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,6 +14,7 @@ const NAV_LINKS = [
 export default function Navbar() {
   const [activeSection, setActiveSection] = useState<string>('')
   const [menuOpen, setMenuOpen] = useState(false)
+  const [hoveredLink, setHoveredLink] = useState<string | null>(null)
 
   useEffect(() => {
     const sections = document.querySelectorAll('section[id]')
@@ -42,6 +43,7 @@ export default function Navbar() {
         <ul className="hidden md:flex gap-8 list-none m-0 p-0">
           {NAV_LINKS.map(({ label, href }) => {
             const isActive = activeSection === href.slice(1)
+            const isHovered = hoveredLink === label
             return (
               <li key={label}>
                 <motion.a
@@ -49,8 +51,16 @@ export default function Navbar() {
                   variants={hoverEase}
                   initial="idle"
                   whileHover="hover"
-                  className={`font-body text-sm no-underline pb-0.5${isActive ? ' text-atomic-tangerine border-b-2 border-atomic-tangerine' : ' text-platinum'}`}
+                  onMouseEnter={() => setHoveredLink(label)}
+                  onMouseLeave={() => setHoveredLink(null)}
+                  className={`group font-body text-sm no-underline pb-0.5${isActive ? ' text-atomic-tangerine border-b-2 border-atomic-tangerine' : ' text-platinum'}`}
                 >
+                  <span
+                    style={{ opacity: isHovered ? 1 : 0 }}
+                    className="transition-opacity duration-200"
+                  >
+                    &gt;{' '}
+                  </span>
                   {label}
                 </motion.a>
               </li>


### PR DESCRIPTION
- Add terminal-style > prefix that appears on hover for all nav links
- Use React state (hoveredLink) to control span opacity on hover/unhover
- Add CSS transition for smooth opacity change
- Update Navbar.test.tsx to assert > prefix visible on hover and absent at rest

Blocked by: #38 (resolved)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation links now display a smooth hover indicator that fades in and out as you interact with the menu. This animation enhancement provides clearer visual feedback for all navigation options, making interactive elements more apparent and improving the overall navigation experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->