### PR TITLE
Projects: remove placeholder colored div

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -56,24 +56,6 @@ describe('ProjectsSection', () => {
     expect(images[0]).toHaveAttribute('src', 'https://example.com/image1.png')
   })
 
-  it('renders color placeholder when no image provided', () => {
-    render(<ProjectsSection projects={mockProjects} />)
-
-    const images = screen.getAllByRole('img')
-    expect(images).toHaveLength(1)
-
-    expect(screen.queryByAltText('Project Two screenshot')).not.toBeInTheDocument()
-
-    expect(screen.getByTestId('project-2-placeholder')).toBeInTheDocument()
-  })
-
-  it('placeholder uses vivid palette color, not a dark shade', () => {
-    render(<ProjectsSection projects={mockProjects} />)
-
-    const placeholder = screen.getByTestId('project-2-placeholder')
-    expect(placeholder).toHaveStyle({ backgroundColor: '#5200E0' })
-  })
-
   it('renders project cards matching the entries in projects data', () => {
     render(<ProjectsSection projects={mockProjects} />)
 

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -56,6 +56,19 @@ describe('ProjectsSection', () => {
     expect(images[0]).toHaveAttribute('src', 'https://example.com/image1.png')
   })
 
+  it('omits image and placeholder elements when no image is provided', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    expect(screen.queryByAltText('Project Two screenshot')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('project-2-placeholder')).not.toBeInTheDocument()
+
+    expect(screen.getByRole('heading', { name: 'Project Two' })).toBeInTheDocument()
+    expect(screen.getByText('Description for project two')).toBeInTheDocument()
+    expect(screen.getByText('Node.js')).toBeInTheDocument()
+    expect(screen.getByText('Express')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '// Docs ↗' })).toHaveAttribute('href', 'https://docs.project2.com')
+  })
+
   it('renders project cards matching the entries in projects data', () => {
     render(<ProjectsSection projects={mockProjects} />)
 

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -14,22 +14,11 @@ const TAG_COLORS = [
   { bg: '#FFCE47', fg: '#050609' },
 ]
 
-const PLACEHOLDER_COLORS = [
-  '#E0007F',
-  '#5200E0',
-  '#FF8547',
-  '#FFCE47',
-]
-
 const NOTCH = 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)'
 
 function getTagStyle(tagIndex: number) {
   const color = TAG_COLORS[tagIndex % 4]
   return { backgroundColor: color.bg, color: color.fg }
-}
-
-function getPlaceholderColor(projectIndex: number) {
-  return PLACEHOLDER_COLORS[projectIndex % 4]
 }
 
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
@@ -43,8 +32,8 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {projects.map((project, projectIndex) => (
-            <ProjectCard key={project.id} project={project} projectIndex={projectIndex} />
+          {projects.map((project) => (
+            <ProjectCard key={project.id} project={project} />
           ))}
         </div>
       </div>
@@ -52,9 +41,8 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
   )
 }
 
-const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ project, projectIndex }) => {
+const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
   const [isHovered, setIsHovered] = useState(false)
-  const placeholderColor = getPlaceholderColor(projectIndex)
 
   return (
     <motion.div
@@ -68,7 +56,7 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
     >
       {/* Card background */}
       <div className="relative bg-platinum p-5">
-        {project.image ? (
+        {project.image && (
           <div className="mb-4 overflow-hidden" style={{ backgroundColor: '#3A3B3A' }}>
             <img
               src={project.image}
@@ -76,12 +64,6 @@ const ProjectCard: React.FC<{ project: Project; projectIndex: number }> = ({ pro
               className="w-full h-40 object-cover"
             />
           </div>
-        ) : (
-          <div
-            data-testid={`project-${project.id}-placeholder`}
-            className="mb-4 h-40"
-            style={{ backgroundColor: placeholderColor }}
-          />
         )}
 
         <div className="flex items-center gap-3 mb-2">

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -17,7 +17,7 @@ const TAG_COLORS = [
 const NOTCH = 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)'
 
 function getTagStyle(tagIndex: number) {
-  const color = TAG_COLORS[tagIndex % 4]
+  const color = TAG_COLORS[tagIndex % TAG_COLORS.length]
   return { backgroundColor: color.bg, color: color.fg }
 }
 
@@ -54,7 +54,6 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
       className="relative"
       style={{ clipPath: NOTCH }}
     >
-      {/* Card background */}
       <div className="relative bg-platinum p-5">
         {project.image && (
           <div className="mb-4 overflow-hidden" style={{ backgroundColor: '#3A3B3A' }}>


### PR DESCRIPTION
**Purpose** — Remove the empty colored placeholder block from project cards without images so cards rely on their content for visual weight.

**What it does** — Renders project media only when an image URL exists and keeps the rest of each project card content unchanged.

**Changes made**
- Updated src/components/ProjectsSection.tsx to remove placeholder color logic and omit the media block when no image is provided.
- Updated src/components/ProjectsSection.test.tsx to assert the no-image path has no placeholder while still rendering title, description, tags, and links.
- Refined tag color cycling to derive from the palette length.

**Additional notes** — Verified with typecheck and the full Vitest suite. The prompt referenced .prompts/CODING_STANDARDS.md, but that file is not present in this checkout.

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Projects without images no longer display colored placeholders in the screenshot area.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->