### PR TITLE
Skills: dashboard layout — min-h-screen + fr row units

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -89,6 +89,26 @@ describe('SkillsSection', () => {
     expect(heights.length).toBeGreaterThanOrEqual(8)
   })
 
+  it('grid container has min-h-screen or min-h-svh class', () => {
+    render(<SkillsSection />)
+    const grid = screen.getByTestId('skills-grid')
+    const hasMinHeight = grid.classList.contains('min-h-screen') || 
+                         grid.classList.contains('min-h-svh')
+    expect(hasMinHeight).toBe(true)
+  })
+
+  it('grid rows use fr units instead of fixed px values', () => {
+    render(<SkillsSection />)
+    const grid = screen.getByTestId('skills-grid')
+    const rowsClass = Array.from(grid.classList).find(c => c.includes('grid-rows-['))
+    expect(rowsClass).toBeDefined()
+    const match = rowsClass!.match(/grid-rows-\[(.+)\]/)
+    expect(match).not.toBeNull()
+    const rowsValue = match![1]
+    expect(rowsValue).not.toMatch(/\d+px/)
+    expect(rowsValue).toMatch(/fr/)
+  })
+
   it('no accent tile renders at bottom of grid', () => {
     render(<SkillsSection />)
 

--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -2,6 +2,17 @@ import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { SkillsSection } from './SkillsSection'
 
+function getExplicitGridRows() {
+  const grid = screen.getByTestId('skills-grid')
+  const rowsClass = Array.from(grid.classList).find(className => className.includes('grid-rows-['))
+  expect(rowsClass).toBeDefined()
+
+  const match = rowsClass!.match(/grid-rows-\[(.+)\]/)
+  expect(match).not.toBeNull()
+
+  return match![1].split('_')
+}
+
 describe('SkillsSection', () => {
   it('renders a section element with id="skills"', () => {
     render(<SkillsSection />)
@@ -43,15 +54,9 @@ describe('SkillsSection', () => {
     expect(children.length).toBe(15)
   })
 
-  it('desktop grid has an explicit grid-rows class with at least 3 distinct row heights', () => {
+  it('desktop grid has an explicit grid-rows class with varied row heights', () => {
     render(<SkillsSection />)
-    const grid = screen.getByTestId('skills-grid')
-    const rowsClass = Array.from(grid.classList).find(c => c.includes('grid-rows-['))
-    expect(rowsClass).toBeDefined()
-
-    const match = rowsClass!.match(/grid-rows-\[(.+)\]/)
-    expect(match).not.toBeNull()
-    const heights = match![1].split('_')
+    const heights = getExplicitGridRows()
     expect(new Set(heights).size).toBeGreaterThanOrEqual(2)
   })
 
@@ -80,12 +85,7 @@ describe('SkillsSection', () => {
 
   it('grid defines at least 8 explicit rows to accommodate Python row-span-3 layout', () => {
     render(<SkillsSection />)
-    const grid = screen.getByTestId('skills-grid')
-    const rowsClass = Array.from(grid.classList).find(c => c.includes('grid-rows-['))
-    expect(rowsClass).toBeDefined()
-    const match = rowsClass!.match(/grid-rows-\[(.+)\]/)
-    expect(match).not.toBeNull()
-    const heights = match![1].split('_')
+    const heights = getExplicitGridRows()
     expect(heights.length).toBeGreaterThanOrEqual(8)
   })
 
@@ -99,14 +99,18 @@ describe('SkillsSection', () => {
 
   it('grid rows use fr units instead of fixed px values', () => {
     render(<SkillsSection />)
+    const rows = getExplicitGridRows()
+
+    expect(rows.every(row => /^(\d+|\d*\.\d+)fr$/.test(row))).toBe(true)
+  })
+
+  it('grid stays within the max-w-7xl section container', () => {
+    render(<SkillsSection />)
     const grid = screen.getByTestId('skills-grid')
-    const rowsClass = Array.from(grid.classList).find(c => c.includes('grid-rows-['))
-    expect(rowsClass).toBeDefined()
-    const match = rowsClass!.match(/grid-rows-\[(.+)\]/)
-    expect(match).not.toBeNull()
-    const rowsValue = match![1]
-    expect(rowsValue).not.toMatch(/\d+px/)
-    expect(rowsValue).toMatch(/fr/)
+
+    expect(grid.parentElement).not.toBeNull()
+    expect(grid.parentElement!.classList).toContain('max-w-7xl')
+    expect(grid.parentElement!.classList).toContain('w-full')
   })
 
   it('no accent tile renders at bottom of grid', () => {

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -82,7 +82,7 @@ export function SkillsSection() {
           <hr className="flex-1 border-periwinkle/20" />
         </div>
 
-        <div data-testid="skills-grid" className="grid grid-cols-2 md:grid-cols-4 gap-3 md:grid-rows-[90px_100px_90px_90px_90px_90px_90px_90px]">
+        <div data-testid="skills-grid" className="grid grid-cols-2 md:grid-cols-4 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr]">
           {tiles.map((tile) => (
             <SkillTileCard key={tile.name} tile={tile} />
           ))}


### PR DESCRIPTION
**Purpose** — Make the skills grid fill the viewport as a dashboard-style frame while preserving its max-width section containment.

**What it does** — Adds viewport-height sizing to the skills grid, switches desktop row sizing from fixed pixels to proportional fr units, and strengthens test coverage for the layout contract.

**Changes made**
- Updated `src/components/SkillsSection.tsx` to add `min-h-screen` and proportional `fr` grid rows.
- Updated `src/components/SkillsSection.test.tsx` to verify viewport min-height, all explicit row units, and `max-w-7xl` containment.

**Additional notes** — The referenced `.prompts/CODING_STANDARDS.md` file was not present in the repo, so review followed the existing local component and test style.

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated skills section grid layout on medium-sized screens and larger with improved proportional row heights and full-screen vertical alignment for enhanced visual presentation.

* **Tests**
  * Expanded test coverage for skills grid layout properties to validate responsive row height definitions and container constraint requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->