### PR TITLE
Contact/Footer: split CTA section from footer element

### DIFF
--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -35,7 +35,9 @@ describe('ContactSection', () => {
     expect(resumeLink).toHaveAttribute('href', '/resume.pdf')
     expect(resumeLink).toHaveAttribute('target', '_blank')
   })
+})
 
+describe('Footer', () => {
   it('renders copyright with FARHAN_MOHAMMED © 2026', () => {
     render(<ContactSection />)
     expect(screen.getByText(/FARHAN_MOHAMMED © 2026/)).toBeInTheDocument()
@@ -44,5 +46,18 @@ describe('ContactSection', () => {
   it('renders PORTFOLIO.EXE label', () => {
     render(<ContactSection />)
     expect(screen.getByText('PORTFOLIO.EXE')).toBeInTheDocument()
+  })
+
+  it('renders a footer element', () => {
+    render(<ContactSection />)
+    const footer = document.querySelector('footer')
+    expect(footer).toBeInTheDocument()
+  })
+
+  it('footer contains no anchor elements', () => {
+    render(<ContactSection />)
+    const footer = document.querySelector('footer')
+    const links = footer?.querySelectorAll('a')
+    expect(links?.length).toBe(0)
   })
 })

--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -1,63 +1,58 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import ContactSection from './ContactSection'
 
 describe('ContactSection', () => {
-  it('renders the // 04 CONTACT section label', () => {
+  it('renders a contact section with only the CTA heading and contact links', () => {
     render(<ContactSection />)
-    expect(screen.getByText('// 04 CONTACT')).toBeInTheDocument()
+    const section = document.querySelector('#contact') as HTMLElement
+
+    expect(section).toBeInTheDocument()
+    expect(within(section).getByRole('heading', { name: /LET'S CONNECT\./i })).toBeInTheDocument()
+
+    const links = within(section).getAllByRole('link')
+    expect(links.map((link) => link.textContent)).toEqual([
+      'SEND_MESSAGE →',
+      '// GITHUB',
+      '// LINKEDIN',
+      '// EMAIL',
+      '// RESUME',
+    ])
+
+    expect(section).not.toHaveTextContent('// 04 CONTACT')
+    expect(section).not.toHaveTextContent('FARHAN_MOHAMMED © 2026')
+    expect(section).not.toHaveTextContent('PORTFOLIO.EXE')
   })
 
-  it('renders LET\'S CONNECT. as an h2 heading', () => {
+  it('renders contact links with the expected destinations', () => {
     render(<ContactSection />)
-    const heading = screen.getByRole('heading', { name: /LET'S CONNECT\./i })
-    expect(heading).toBeInTheDocument()
-  })
+    const sendMessageLink = screen.getByRole('link', { name: 'SEND_MESSAGE →' })
+    const emailLink = screen.getByRole('link', { name: '// EMAIL' })
+    const resumeLink = screen.getByRole('link', { name: '// RESUME' })
 
-  it('renders SEND_MESSAGE → as a mailto link', () => {
-    render(<ContactSection />)
-    const link = screen.getByRole('link', { name: /SEND_MESSAGE →/ })
-    expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', expect.stringMatching(/^mailto:/))
-  })
-
-  it('renders footer links: GITHUB, LINKEDIN, EMAIL, RESUME', () => {
-    render(<ContactSection />)
-    expect(screen.getByText('// GITHUB')).toBeInTheDocument()
-    expect(screen.getByText('// LINKEDIN')).toBeInTheDocument()
-    expect(screen.getByText('// EMAIL')).toBeInTheDocument()
-    expect(screen.getByText('// RESUME')).toBeInTheDocument()
-  })
-
-  it('renders resume link with target="_blank" pointing to resume.pdf', () => {
-    render(<ContactSection />)
-    const resumeLink = screen.getByText('// RESUME').closest('a')
+    expect(sendMessageLink).toHaveAttribute('href', expect.stringMatching(/^mailto:/))
+    expect(emailLink).toHaveAttribute('href', expect.stringMatching(/^mailto:/))
     expect(resumeLink).toHaveAttribute('href', '/resume.pdf')
     expect(resumeLink).toHaveAttribute('target', '_blank')
   })
 })
 
 describe('Footer', () => {
-  it('renders copyright with FARHAN_MOHAMMED © 2026', () => {
+  it('renders a separate footer with only static labels', () => {
     render(<ContactSection />)
-    expect(screen.getByText(/FARHAN_MOHAMMED © 2026/)).toBeInTheDocument()
-  })
-
-  it('renders PORTFOLIO.EXE label', () => {
-    render(<ContactSection />)
-    expect(screen.getByText('PORTFOLIO.EXE')).toBeInTheDocument()
-  })
-
-  it('renders a footer element', () => {
-    render(<ContactSection />)
+    const section = document.querySelector('#contact')
     const footer = document.querySelector('footer')
+
     expect(footer).toBeInTheDocument()
-  })
-
-  it('footer contains no anchor elements', () => {
-    render(<ContactSection />)
-    const footer = document.querySelector('footer')
-    const links = footer?.querySelectorAll('a')
-    expect(links?.length).toBe(0)
+    expect(section?.nextElementSibling).toBe(footer)
+    expect(footer).toHaveTextContent('FARHAN_MOHAMMED © 2026')
+    expect(footer).toHaveTextContent('PORTFOLIO.EXE')
+    expect(Array.from(footer?.children ?? []).map((child) => child.textContent)).toEqual([
+      'FARHAN_MOHAMMED © 2026',
+      'PORTFOLIO.EXE',
+    ])
+    expect(footer).not.toHaveTextContent("LET'S CONNECT.")
+    expect(footer).not.toHaveTextContent('SEND_MESSAGE →')
+    expect(footer?.querySelectorAll('a, button, input, select, textarea, [tabindex]').length).toBe(0)
   })
 })

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -16,8 +16,6 @@ export default function ContactSection() {
     <>
       <ScrollFadeSection id="contact" className="min-h-screen flex flex-col justify-center px-8 py-14 bg-graphite">
         <div className="max-w-7xl mx-auto w-full">
-          <p className="font-body text-sm text-atomic-tangerine mb-8">// 04 CONTACT</p>
-
           <h2 className="font-display text-3xl md:text-5xl text-platinum leading-tight mb-12">
             LET'S CONNECT.
           </h2>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -13,46 +13,48 @@ const footerLinks = [
 
 export default function ContactSection() {
   return (
-    <ScrollFadeSection id="contact" className="min-h-screen flex flex-col justify-center px-8 py-14 bg-graphite">
-      <div className="max-w-7xl mx-auto w-full">
-        <p className="font-body text-sm text-atomic-tangerine mb-8">// 04 CONTACT</p>
+    <>
+      <ScrollFadeSection id="contact" className="min-h-screen flex flex-col justify-center px-8 py-14 bg-graphite">
+        <div className="max-w-7xl mx-auto w-full">
+          <p className="font-body text-sm text-atomic-tangerine mb-8">// 04 CONTACT</p>
 
-        <h2 className="font-display text-3xl md:text-5xl text-platinum leading-tight mb-12">
-          LET'S CONNECT.
-        </h2>
+          <h2 className="font-display text-3xl md:text-5xl text-platinum leading-tight mb-12">
+            LET'S CONNECT.
+          </h2>
 
-        <motion.a
-          href={`mailto:${EMAIL}`}
-          variants={hoverEase}
-          initial="idle"
-          whileHover="hover"
-          className="inline-block font-body text-sm border-2 border-platinum text-platinum px-8 py-4 mb-12 hover:bg-platinum hover:text-graphite transition-colors"
-        >
-          SEND_MESSAGE →
-        </motion.a>
+          <motion.a
+            href={`mailto:${EMAIL}`}
+            variants={hoverEase}
+            initial="idle"
+            whileHover="hover"
+            className="inline-block font-body text-sm border-2 border-platinum text-platinum px-8 py-4 mb-12 hover:bg-platinum hover:text-graphite transition-colors"
+          >
+            SEND_MESSAGE →
+          </motion.a>
 
-        <div className="flex flex-wrap gap-6 mb-16">
-          {footerLinks.map(({ label, href, target }) => (
-            <motion.a
-              key={label}
-              href={href}
-              target={target}
-              rel={target === '_blank' ? 'noopener noreferrer' : undefined}
-              variants={hoverEase}
-              initial="idle"
-              whileHover="hover"
-              className="font-body text-sm text-periwinkle hover:text-atomic-tangerine transition-colors"
-            >
-              {label}
-            </motion.a>
-          ))}
+          <div className="flex flex-wrap gap-6">
+            {footerLinks.map(({ label, href, target }) => (
+              <motion.a
+                key={label}
+                href={href}
+                target={target}
+                rel={target === '_blank' ? 'noopener noreferrer' : undefined}
+                variants={hoverEase}
+                initial="idle"
+                whileHover="hover"
+                className="font-body text-sm text-periwinkle hover:text-atomic-tangerine transition-colors"
+              >
+                {label}
+              </motion.a>
+            ))}
+          </div>
         </div>
+      </ScrollFadeSection>
 
-        <div className="flex justify-between items-center pt-8 border-t border-periwinkle/20 text-xs font-body text-periwinkle">
-          <span>FARHAN_MOHAMMED © 2026</span>
-          <span>PORTFOLIO.EXE</span>
-        </div>
-      </div>
-    </ScrollFadeSection>
+      <footer className="flex justify-between items-center px-8 py-8 border-t border-periwinkle/20 text-xs font-body text-periwinkle bg-graphite">
+        <span>FARHAN_MOHAMMED © 2026</span>
+        <span>PORTFOLIO.EXE</span>
+      </footer>
+    </>
   )
 }


### PR DESCRIPTION
**Purpose** — Split the contact CTA content from the footer so each element has a clear semantic role.

**What it does** — Keeps the contact section focused on the connection CTA and links, then renders a separate static footer below it.

**Changes made**
- Updated src/components/ContactSection.tsx so #contact contains only the CTA heading, mailto CTA, and social/contact links.
- Added a separate static footer with only FARHAN_MOHAMMED © 2026 and PORTFOLIO.EXE.
- Strengthened src/components/ContactSection.test.tsx coverage for section/footer boundaries and non-interactive footer content.

**Additional notes** — .prompts/CODING_STANDARDS.md was not present in this checkout; validation used the existing project style plus npm run typecheck, npm run test, and git diff --check.

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized contact section layout for improved visual hierarchy
  * Repositioned footer with enhanced spacing and styling
  * Improved visual separation between contact section and footer elements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->