### PR TITLE
Skills: stagger entrance animation

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -130,4 +130,26 @@ describe('SkillsSection', () => {
     })
     expect(allHaveCategoryOrSkill).toBe(true)
   })
+
+  it('tiles have entrance animation with staggered reveal on viewport entry', () => {
+    render(<SkillsSection />)
+
+    const grid = screen.getByTestId('skills-grid')
+    const children = Array.from(grid.children)
+
+    expect(children.length).toBe(15)
+
+    for (const child of children) {
+      expect(child.tagName.toLowerCase()).toBe('div')
+    }
+
+    const firstTile = children[0]
+    expect(firstTile.className.length).toBeGreaterThan(0)
+  })
+
+  it('grid container has staggerChildren variant for sequential tile animation', () => {
+    render(<SkillsSection />)
+    const grid = screen.getByTestId('skills-grid')
+    expect(grid).toBeInTheDocument()
+  })
 })

--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -1,6 +1,73 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import type { ReactElement, ReactNode } from 'react'
 import { SkillsSection } from './SkillsSection'
+
+const motionMock = vi.hoisted(() => ({
+  isInView: false,
+  divProps: [] as Array<Record<string, unknown>>,
+  useInView: vi.fn(),
+}))
+
+vi.mock('framer-motion', async () => {
+  const React = await vi.importActual<typeof import('react')>('react')
+
+  function getText(children: unknown): string {
+    if (children == null || typeof children === 'boolean') {
+      return ''
+    }
+
+    if (typeof children === 'string' || typeof children === 'number') {
+      return String(children)
+    }
+
+    if (Array.isArray(children)) {
+      return children.map(getText).join('')
+    }
+
+    if (React.isValidElement(children)) {
+      const element = children as ReactElement<{ children?: unknown }>
+      return getText(element.props.children)
+    }
+
+    return ''
+  }
+
+  function createMotionComponent(tagName: 'div' | 'section') {
+    return React.forwardRef<HTMLElement, Record<string, unknown>>(function MockMotionComponent(props, ref) {
+      const {
+        animate,
+        children,
+        initial,
+        transition,
+        variants,
+        whileHover,
+        ...domProps
+      } = props
+
+      if (tagName === 'div') {
+        motionMock.divProps.push({
+          animate,
+          initial,
+          text: getText(children),
+          transition,
+          variants,
+          whileHover,
+        })
+      }
+
+      return React.createElement(tagName, { ...domProps, ref }, children as ReactNode)
+    })
+  }
+
+  return {
+    motion: {
+      div: createMotionComponent('div'),
+      section: createMotionComponent('section'),
+    },
+    useInView: motionMock.useInView.mockImplementation(() => motionMock.isInView),
+  }
+})
 
 function getExplicitGridRows() {
   const grid = screen.getByTestId('skills-grid')
@@ -14,6 +81,12 @@ function getExplicitGridRows() {
 }
 
 describe('SkillsSection', () => {
+  beforeEach(() => {
+    motionMock.isInView = false
+    motionMock.divProps = []
+    motionMock.useInView.mockClear()
+  })
+
   it('renders a section element with id="skills"', () => {
     render(<SkillsSection />)
     const section = document.getElementById('skills')
@@ -131,25 +204,56 @@ describe('SkillsSection', () => {
     expect(allHaveCategoryOrSkill).toBe(true)
   })
 
-  it('tiles have entrance animation with staggered reveal on viewport entry', () => {
+  it('tiles animate from hidden opacity and scale to visible opacity and scale', () => {
     render(<SkillsSection />)
 
-    const grid = screen.getByTestId('skills-grid')
-    const children = Array.from(grid.children)
+    const tileAnimations = motionMock.divProps.filter(props => props.text !== undefined && props.text !== '')
 
-    expect(children.length).toBe(15)
+    expect(tileAnimations).toHaveLength(15)
 
-    for (const child of children) {
-      expect(child.tagName.toLowerCase()).toBe('div')
+    for (const tileAnimation of tileAnimations) {
+      expect(tileAnimation.variants).toMatchObject({
+        hidden: { opacity: 0, scale: 0.95 },
+        visible: {
+          opacity: 1,
+          scale: 1,
+          transition: { duration: 0.4, ease: 'easeOut' },
+        },
+      })
+      expect(tileAnimation.initial).toBeUndefined()
+      expect(tileAnimation.whileHover).toBe('hover')
     }
-
-    const firstTile = children[0]
-    expect(firstTile.className.length).toBeGreaterThan(0)
   })
 
-  it('grid container has staggerChildren variant for sequential tile animation', () => {
+  it('grid staggers tile animation and switches to visible on viewport entry once', () => {
+    motionMock.isInView = true
+
     render(<SkillsSection />)
-    const grid = screen.getByTestId('skills-grid')
-    expect(grid).toBeInTheDocument()
+
+    const gridAnimation = motionMock.divProps.find(props => props.text === '')
+
+    expect(gridAnimation).toMatchObject({
+      animate: 'visible',
+      initial: 'hidden',
+      variants: {
+        hidden: {},
+        visible: { transition: { staggerChildren: 0.05 } },
+      },
+    })
+    expect(motionMock.useInView).toHaveBeenCalledWith(
+      expect.objectContaining({ current: expect.any(HTMLElement) }),
+      { once: true, margin: '-10% 0px -10% 0px' },
+    )
+  })
+
+  it('keeps tile animation hidden until the skills grid enters the viewport', () => {
+    render(<SkillsSection />)
+
+    const gridAnimation = motionMock.divProps.find(props => props.text === '')
+
+    expect(gridAnimation).toMatchObject({
+      animate: 'hidden',
+      initial: 'hidden',
+    })
   })
 })

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -1,6 +1,23 @@
-import { motion } from 'framer-motion'
+import { motion, useInView } from 'framer-motion'
+import { useRef } from 'react'
 import { hoverEase } from '../animations/variants'
 import { ScrollFadeSection } from './ScrollFadeSection'
+
+const tileStagger = {
+  hidden: { opacity: 0, scale: 0.95 },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    transition: { duration: 0.4, ease: 'easeOut' as const },
+  },
+}
+
+const gridStagger = {
+  hidden: {},
+  visible: {
+    transition: { staggerChildren: 0.05 },
+  },
+}
 
 type Category = 'LANGUAGE' | 'FRAMEWORK' | 'TOOL' | 'ML / DL' | 'DATA'
 
@@ -56,7 +73,7 @@ const tiles: SkillTile[] = [
 function SkillTileCard({ tile }: { tile: SkillTile }) {
   return (
     <motion.div
-      variants={hoverEase}
+      variants={{ ...hoverEase, ...tileStagger }}
       initial="idle"
       whileHover="hover"
       className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-5 rounded-lg flex flex-col justify-between cursor-default`}
@@ -73,6 +90,9 @@ function SkillTileCard({ tile }: { tile: SkillTile }) {
 }
 
 export function SkillsSection() {
+  const gridRef = useRef<HTMLDivElement>(null)
+  const isInView = useInView(gridRef, { once: true, margin: '-10% 0px -10% 0px' })
+
   return (
     <ScrollFadeSection id="skills" className="min-h-screen flex flex-col justify-center py-14 px-8 bg-graphite">
       <div className="max-w-7xl mx-auto w-full">
@@ -82,11 +102,18 @@ export function SkillsSection() {
           <hr className="flex-1 border-periwinkle/20" />
         </div>
 
-        <div data-testid="skills-grid" className="grid grid-cols-2 md:grid-cols-4 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr]">
+        <motion.div
+          ref={gridRef}
+          data-testid="skills-grid"
+          variants={gridStagger}
+          initial="hidden"
+          animate={isInView ? 'visible' : 'hidden'}
+          className="grid grid-cols-2 md:grid-cols-4 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr]"
+        >
           {tiles.map((tile) => (
             <SkillTileCard key={tile.name} tile={tile} />
           ))}
-        </div>
+        </motion.div>
       </div>
     </ScrollFadeSection>
   )

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -19,6 +19,11 @@ const gridStagger = {
   },
 }
 
+const tileVariants = {
+  ...tileStagger,
+  hover: hoverEase.hover,
+}
+
 type Category = 'LANGUAGE' | 'FRAMEWORK' | 'TOOL' | 'ML / DL' | 'DATA'
 
 interface SkillTile {
@@ -73,8 +78,7 @@ const tiles: SkillTile[] = [
 function SkillTileCard({ tile }: { tile: SkillTile }) {
   return (
     <motion.div
-      variants={{ ...hoverEase, ...tileStagger }}
-      initial="idle"
+      variants={tileVariants}
       whileHover="hover"
       className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-5 rounded-lg flex flex-col justify-between cursor-default`}
       style={{ backgroundColor: tile.bg, color: tile.fg }}


### PR DESCRIPTION
**Purpose** — Add a viewport-triggered staggered entrance animation to the skills tiles.

**What it does** — Uses Framer Motion `useInView` and parent/child variants so tiles reveal sequentially once when the skills grid first enters the viewport.

**Changes made**
- Updated `SkillsSection` with grid-level `staggerChildren` and tile `opacity`/`scale` entrance variants.
- Kept hover scaling on the tile variant while letting the parent drive hidden/visible entrance state.
- Strengthened `SkillsSection` tests to assert viewport entry, one-time in-view options, stagger timing, and tile variant values.

**Additional notes** — The tile animation remains parent-driven so tiles stay visible after the once-only viewport trigger completes.

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added scroll-triggered staggered animations to skill tiles that smoothly animate into view when scrolling
  * Enhanced skill card hover interactions for improved visual feedback

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->