### PR TITLE
Hero: dual CTAs fade up after typewriter completes

### DIFF
--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -3,6 +3,11 @@ import { render, screen, act } from '@testing-library/react'
 import HeroSection from './HeroSection'
 import { cursorVariants } from './HeroSection.constants'
 
+const SUBTITLE_TEXT = 'CS_STUDENT · DEVELOPER'
+const VALUE_PROP_TEXT = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
+const TYPEWRITER_DURATION = 400 + SUBTITLE_TEXT.length * 60 + 400 + VALUE_PROP_TEXT.length * 35
+const CTA_DELAY = 200
+
 describe('HeroSection', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -49,25 +54,23 @@ describe('HeroSection', () => {
 
   it('subtitle completes at 60ms/char and removes its cursor immediately', () => {
     render(<HeroSection />)
-    const subtitleText = 'CS_STUDENT · DEVELOPER'
 
     act(() => {
       vi.advanceTimersByTime(400)
-      vi.advanceTimersByTime(subtitleText.length * 60)
+      vi.advanceTimersByTime(SUBTITLE_TEXT.length * 60)
     })
 
     const subtitle = screen.getByTestId('subtitle')
-    expect(subtitle.textContent).toBe(subtitleText)
+    expect(subtitle.textContent).toBe(SUBTITLE_TEXT)
     expect(screen.queryByTestId('subtitle-cursor')).not.toBeInTheDocument()
   })
 
   it('value prop waits until subtitle completes plus the 400ms gap before typing', () => {
     render(<HeroSection />)
-    const subtitleText = 'CS_STUDENT · DEVELOPER'
     const valueProp = screen.getByTestId('value-prop')
 
     act(() => {
-      vi.advanceTimersByTime(400 + subtitleText.length * 60)
+      vi.advanceTimersByTime(400 + SUBTITLE_TEXT.length * 60)
     })
 
     expect(valueProp.textContent).toBe('')
@@ -90,24 +93,21 @@ describe('HeroSection', () => {
 
   it('value prop completes at 35ms/char and removes its cursor immediately', () => {
     render(<HeroSection />)
-    const subtitleText = 'CS_STUDENT · DEVELOPER'
-    const valuePropText = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
 
     act(() => {
-      vi.advanceTimersByTime(400 + subtitleText.length * 60 + 400 + valuePropText.length * 35)
+      vi.advanceTimersByTime(TYPEWRITER_DURATION)
     })
 
     const valueProp = screen.getByTestId('value-prop')
-    expect(valueProp.textContent).toBe(valuePropText)
+    expect(valueProp.textContent).toBe(VALUE_PROP_TEXT)
     expect(screen.queryByTestId('value-prop-cursor')).not.toBeInTheDocument()
   })
 
   it('cleans up pending typewriter timers when unmounted', () => {
     const { unmount } = render(<HeroSection />)
-    const subtitleText = 'CS_STUDENT · DEVELOPER'
 
     act(() => {
-      vi.advanceTimersByTime(400 + subtitleText.length * 60)
+      vi.advanceTimersByTime(400 + SUBTITLE_TEXT.length * 60)
     })
 
     expect(vi.getTimerCount()).toBeGreaterThan(0)
@@ -119,11 +119,9 @@ describe('HeroSection', () => {
 
   it('shows the VIEW_WORK call-to-action linking to projects section', () => {
     render(<HeroSection />)
-    const subtitleText = 'CS_STUDENT · DEVELOPER'
-    const valuePropText = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
 
     act(() => {
-      vi.advanceTimersByTime(400 + subtitleText.length * 60 + 400 + valuePropText.length * 35 + 200)
+      vi.advanceTimersByTime(TYPEWRITER_DURATION + CTA_DELAY)
     })
 
     const link = screen.getByRole('link', { name: /VIEW_WORK →/i })
@@ -159,24 +157,45 @@ describe('HeroSection', () => {
 
   it('CTAs are absent before typewriter sequence completes', () => {
     render(<HeroSection />)
-    const subtitleText = 'CS_STUDENT · DEVELOPER'
-    const valuePropText = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
 
     act(() => {
-      vi.advanceTimersByTime(400 + subtitleText.length * 60 + 400 + valuePropText.length * 35)
+      vi.advanceTimersByTime(TYPEWRITER_DURATION)
     })
 
     expect(screen.queryByRole('link', { name: /VIEW_WORK →/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /VIEW_RESUME →/i })).not.toBeInTheDocument()
   })
 
-  it('CTAs appear after value prop completes plus 200ms delay', () => {
+  it('CTAs remain absent until the full 200ms post-typewriter delay elapses', () => {
     render(<HeroSection />)
-    const subtitleText = 'CS_STUDENT · DEVELOPER'
-    const valuePropText = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
 
     act(() => {
-      vi.advanceTimersByTime(400 + subtitleText.length * 60 + 400 + valuePropText.length * 35 + 200)
+      vi.advanceTimersByTime(TYPEWRITER_DURATION + CTA_DELAY - 1)
+    })
+
+    expect(screen.queryByRole('link', { name: /VIEW_WORK →/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /VIEW_RESUME →/i })).not.toBeInTheDocument()
+  })
+
+  it('cleans up the pending CTA reveal timer when unmounted', () => {
+    const { unmount } = render(<HeroSection />)
+
+    act(() => {
+      vi.advanceTimersByTime(TYPEWRITER_DURATION)
+    })
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+    unmount()
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('CTAs appear after value prop completes plus 200ms delay', () => {
+    render(<HeroSection />)
+
+    act(() => {
+      vi.advanceTimersByTime(TYPEWRITER_DURATION + CTA_DELAY)
     })
 
     const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
@@ -192,11 +211,9 @@ describe('HeroSection', () => {
 
   it('VIEW_WORK uses filled tangerine style, VIEW_RESUME uses outlined style', () => {
     render(<HeroSection />)
-    const subtitleText = 'CS_STUDENT · DEVELOPER'
-    const valuePropText = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
 
     act(() => {
-      vi.advanceTimersByTime(400 + subtitleText.length * 60 + 400 + valuePropText.length * 35 + 200)
+      vi.advanceTimersByTime(TYPEWRITER_DURATION + CTA_DELAY)
     })
 
     const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -119,6 +119,13 @@ describe('HeroSection', () => {
 
   it('shows the VIEW_WORK call-to-action linking to projects section', () => {
     render(<HeroSection />)
+    const subtitleText = 'CS_STUDENT · DEVELOPER'
+    const valuePropText = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
+
+    act(() => {
+      vi.advanceTimersByTime(400 + subtitleText.length * 60 + 400 + valuePropText.length * 35 + 200)
+    })
+
     const link = screen.getByRole('link', { name: /VIEW_WORK →/i })
     expect(link).toBeInTheDocument()
     expect(link).toHaveAttribute('href', '#projects')
@@ -148,5 +155,56 @@ describe('HeroSection', () => {
         times: [0, 0.49, 0.5, 0.99, 1],
       },
     })
+  })
+
+  it('CTAs are absent before typewriter sequence completes', () => {
+    render(<HeroSection />)
+    const subtitleText = 'CS_STUDENT · DEVELOPER'
+    const valuePropText = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
+
+    act(() => {
+      vi.advanceTimersByTime(400 + subtitleText.length * 60 + 400 + valuePropText.length * 35)
+    })
+
+    expect(screen.queryByRole('link', { name: /VIEW_WORK →/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /VIEW_RESUME →/i })).not.toBeInTheDocument()
+  })
+
+  it('CTAs appear after value prop completes plus 200ms delay', () => {
+    render(<HeroSection />)
+    const subtitleText = 'CS_STUDENT · DEVELOPER'
+    const valuePropText = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
+
+    act(() => {
+      vi.advanceTimersByTime(400 + subtitleText.length * 60 + 400 + valuePropText.length * 35 + 200)
+    })
+
+    const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
+    const viewResume = screen.getByRole('link', { name: /VIEW_RESUME →/i })
+
+    expect(viewWork).toBeInTheDocument()
+    expect(viewWork).toHaveAttribute('href', '#projects')
+    expect(viewResume).toBeInTheDocument()
+    expect(viewResume).toHaveAttribute('href', '/resume.pdf')
+    expect(viewResume).toHaveAttribute('target', '_blank')
+    expect(viewResume).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('VIEW_WORK uses filled tangerine style, VIEW_RESUME uses outlined style', () => {
+    render(<HeroSection />)
+    const subtitleText = 'CS_STUDENT · DEVELOPER'
+    const valuePropText = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
+
+    act(() => {
+      vi.advanceTimersByTime(400 + subtitleText.length * 60 + 400 + valuePropText.length * 35 + 200)
+    })
+
+    const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
+    const viewResume = screen.getByRole('link', { name: /VIEW_RESUME →/i })
+
+    expect(viewWork).toHaveClass('bg-atomic-tangerine')
+    expect(viewWork).toHaveClass('text-graphite')
+    expect(viewResume).toHaveClass('border-atomic-tangerine')
+    expect(viewResume).toHaveClass('text-atomic-tangerine')
   })
 })

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -10,11 +10,20 @@ const SUBTITLE_SPEED = 60
 const VALUE_PROP_DELAY = 400
 const VALUE_PROP_SPEED = 35
 
+const CTA_DELAY = 200
+const CTA_FADE_DURATION = 0.4
+
+const ctaVariants = {
+  hidden: { opacity: 0, y: 8 },
+  visible: { opacity: 1, y: 0 },
+}
+
 const HeroSection: React.FC = () => {
   const [subtitle, setSubtitle] = useState('')
   const [valueProp, setValueProp] = useState('')
   const [showSubtitleCursor, setShowSubtitleCursor] = useState(false)
   const [showValuePropCursor, setShowValuePropCursor] = useState(false)
+  const [showCTAs, setShowCTAs] = useState(false)
 
   const subtitleRef = useRef(0)
   const valuePropRef = useRef(0)
@@ -35,6 +44,7 @@ const HeroSection: React.FC = () => {
 
         if (valuePropRef.current === VALUE_PROP.length) {
           setShowValuePropCursor(false)
+          schedule(() => setShowCTAs(true), CTA_DELAY)
           return
         }
 
@@ -119,12 +129,30 @@ const HeroSection: React.FC = () => {
           )}
         </p>
 
-        <a
-          href="#projects"
-          className="inline-block px-6 py-2 border border-atomic-tangerine text-sm font-body text-atomic-tangerine hover:bg-atomic-tangerine/10 transition-colors duration-200"
-        >
-          VIEW_WORK →
-        </a>
+        {showCTAs && (
+          <motion.div
+            initial="hidden"
+            animate="visible"
+            variants={ctaVariants}
+            transition={{ duration: CTA_FADE_DURATION }}
+            className="flex gap-4"
+          >
+            <a
+              href="#projects"
+              className="inline-block px-6 py-2 bg-atomic-tangerine text-graphite text-sm font-body hover:bg-atomic-tangerine/90 transition-colors duration-200"
+            >
+              VIEW_WORK →
+            </a>
+            <a
+              href="/resume.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block px-6 py-2 border border-atomic-tangerine text-atomic-tangerine text-sm font-body hover:bg-atomic-tangerine/10 transition-colors duration-200"
+            >
+              VIEW_RESUME →
+            </a>
+          </motion.div>
+        )}
       </div>
     </ScrollFadeSection>
   )


### PR DESCRIPTION
**Purpose** — Add the requested dual hero CTAs that appear only after the typewriter sequence completes.

**What it does** — Reveals `VIEW_WORK →` and `VIEW_RESUME →` together in a single fade-up motion container after the value prop finishes plus a 200ms delay.

**Changes made**
- Updated `src/components/HeroSection.tsx` with delayed CTA reveal state, fade-up variants, primary work CTA styling, and resume link behavior.
- Updated `src/components/HeroSection.test.tsx` to cover CTA absence, reveal timing, link targets, styles, and timer cleanup.

**Additional notes** — Review pass added boundary coverage for the 200ms CTA delay and centralized test timing values to reduce maintenance drift.

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Call-to-action buttons now appear with a smooth fade animation that triggers after the introductory text completes its typing sequence. The "View Work" link directs to your project showcase, while "View Resume" provides access to your full resume, creating a more polished introduction flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->