### PR TITLE
Timeline: scroll-triggered typewriter per entry

### DIFF
--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -83,6 +83,21 @@ describe('TimelineSection', () => {
       screen.getAllByTestId('commit-author').forEach(el => {
         expect(el.textContent).toBe('Author: Farhan Mohammed')
       })
+
+      const dates = screen.getAllByTestId('commit-date')
+      expect(dates[0].textContent).toBe('Date:   JAN 2026 – PRESENT')
+      expect(dates[1].textContent).toBe('Date:   JAN 2022 – DEC 2025')
+      expect(dates[2].textContent).toBe('Date:   AUG 2024 – PRESENT')
+
+      const institutions = screen.getAllByTestId('commit-institution')
+      expect(institutions[0].textContent).toBe('WICHITA STATE UNIVERSITY')
+      expect(institutions[1].textContent).toBe('WICHITA STATE UNIVERSITY')
+      expect(institutions[2].textContent).toBe('NETAPP INC.')
+
+      const roles = screen.getAllByTestId('commit-role')
+      expect(roles[0].textContent).toBe('ACCELERATED_M.S._COMPUTER_SCIENCE')
+      expect(roles[1].textContent).toBe('B.S._COMPUTER_SCIENCE')
+      expect(roles[2].textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
     })
 
     it('typing does not restart when viewport is re-entered', () => {

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -1,8 +1,18 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { useInView } from 'framer-motion'
 import TimelineSection from './TimelineSection'
 
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
+  return { ...actual, useInView: vi.fn().mockReturnValue(false) }
+})
+
 describe('TimelineSection', () => {
+  beforeEach(() => {
+    vi.mocked(useInView).mockReturnValue(false)
+  })
+
   it('each entry has min-h-screen', () => {
     render(<TimelineSection />)
     const commitEntries = screen.getAllByTestId('commit-entry')
@@ -35,5 +45,67 @@ describe('TimelineSection', () => {
     institutionElements.forEach(el => expect(el).toHaveTextContent(''))
     roleElements.forEach(el => expect(el).toHaveTextContent(''))
     descriptionElements.forEach(el => expect(el).toHaveTextContent(''))
+  })
+
+  describe('issue #47 - scroll-triggered typewriter', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('text begins populating when entry enters the viewport', () => {
+      vi.mocked(useInView).mockReturnValue(true)
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      // Advance past first field's typing: "commit a3f9d2b" = 15 chars × 30ms = 450ms
+      act(() => { vi.advanceTimersByTime(1000) })
+
+      screen.getAllByTestId('commit-hash').forEach(el => {
+        expect(el.textContent).not.toBe('')
+      })
+    })
+
+    it('all text fields complete with expected content', () => {
+      vi.mocked(useInView).mockReturnValue(true)
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      // Longest entry: NetApp description ~351 chars → 1000ms delay + 351×30ms ≈ 11.5s
+      act(() => { vi.advanceTimersByTime(15000) })
+
+      const hashes = screen.getAllByTestId('commit-hash')
+      expect(hashes[0].textContent).toBe('commit a3f9d2b')
+      expect(hashes[1].textContent).toBe('commit b7c3e1a')
+      expect(hashes[2].textContent).toBe('commit d4e8f2c')
+
+      screen.getAllByTestId('commit-author').forEach(el => {
+        expect(el.textContent).toBe('Author: Farhan Mohammed')
+      })
+    })
+
+    it('typing does not restart when viewport is re-entered', () => {
+      vi.mocked(useInView).mockReturnValue(true)
+      vi.useFakeTimers()
+
+      const { rerender } = render(<TimelineSection />)
+
+      act(() => { vi.advanceTimersByTime(15000) })
+
+      const completedHashes = screen.getAllByTestId('commit-hash').map(el => el.textContent)
+
+      // Simulate scroll-out then scroll-in again
+      vi.mocked(useInView).mockReturnValue(false)
+      rerender(<TimelineSection />)
+      vi.mocked(useInView).mockReturnValue(true)
+      rerender(<TimelineSection />)
+
+      act(() => { vi.advanceTimersByTime(15000) })
+
+      screen.getAllByTestId('commit-hash').forEach((el, i) => {
+        expect(el.textContent).toBe(completedHashes[i])
+      })
+    })
   })
 })


### PR DESCRIPTION
**Purpose** — Ship the scroll-triggered typewriter animation for each timeline entry and close the review cycle for issue #47.

**What it does** — Each `CommitEntry` starts with all text fields empty on mount. When the entry scrolls into the viewport, `useInView({ once: true })` fires and a staggered sequence of `setTimeout`/`setInterval` pairs types each field character-by-character at 30ms/char. A `hasStarted` ref prevents any re-triggering. On unmount, all pending timers are cleared.

**Changes made**
- `src/components/TimelineSection.test.tsx` — strengthened the "all text fields complete" assertion to cover `commit-date`, `commit-institution`, and `commit-role` for all three entries (previously only `commit-hash` and `commit-author` were checked); fixed missing trailing newline

**Additional notes**
- Implementation was already complete in `TimelineSection.tsx` before the TDD commit; no implementation changes were needed
- `hasStarted.current` is redundant with `useInView({ once: true })` but the test for re-entry depends on it — left in place to avoid rewriting the test
- All 84 tests pass

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for scroll-triggered text animation feature with enhanced viewport detection verification and timing simulation
  * Added comprehensive testing suite validating animation correctly initiates when content becomes visible and produces expected output
  * Strengthened validation ensuring animation behaves consistently across viewport state changes, preventing unwanted animation restarts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->