### PR TITLE
Loading: boot screen timing and hero handoff

### DIFF
--- a/src/components/HeroSection.constants.ts
+++ b/src/components/HeroSection.constants.ts
@@ -1,5 +1,16 @@
 import type { Variants } from 'framer-motion'
 
+export const SUBTITLE = 'CS_STUDENT · DEVELOPER'
+export const VALUE_PROP = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
+
+export const INITIAL_DELAY = 3200
+export const SUBTITLE_SPEED = 60
+export const VALUE_PROP_DELAY = 400
+export const VALUE_PROP_SPEED = 35
+
+export const CTA_DELAY = 200
+export const CTA_FADE_DURATION = 0.4
+
 export const cursorVariants: Variants = {
   blink: {
     opacity: [1, 1, 0, 0, 1],

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -5,7 +5,7 @@ import { cursorVariants } from './HeroSection.constants'
 
 const SUBTITLE_TEXT = 'CS_STUDENT · DEVELOPER'
 const VALUE_PROP_TEXT = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
-const TYPEWRITER_DURATION = 400 + SUBTITLE_TEXT.length * 60 + 400 + VALUE_PROP_TEXT.length * 35
+const TYPEWRITER_DURATION = 3200 + SUBTITLE_TEXT.length * 60 + 400 + VALUE_PROP_TEXT.length * 35
 const CTA_DELAY = 200
 
 describe('HeroSection', () => {
@@ -33,11 +33,11 @@ describe('HeroSection', () => {
     expect(valueProp.textContent).toBe('')
   })
 
-  it('subtitle starts typing after 400ms delay', () => {
+  it('subtitle starts typing after 3200ms delay', () => {
     render(<HeroSection />)
 
     act(() => {
-      vi.advanceTimersByTime(400)
+      vi.advanceTimersByTime(3200)
     })
 
     const subtitle = screen.getByTestId('subtitle')
@@ -56,7 +56,7 @@ describe('HeroSection', () => {
     render(<HeroSection />)
 
     act(() => {
-      vi.advanceTimersByTime(400)
+      vi.advanceTimersByTime(3200)
       vi.advanceTimersByTime(SUBTITLE_TEXT.length * 60)
     })
 
@@ -70,7 +70,7 @@ describe('HeroSection', () => {
     const valueProp = screen.getByTestId('value-prop')
 
     act(() => {
-      vi.advanceTimersByTime(400 + SUBTITLE_TEXT.length * 60)
+      vi.advanceTimersByTime(3200 + SUBTITLE_TEXT.length * 60)
     })
 
     expect(valueProp.textContent).toBe('')
@@ -107,7 +107,7 @@ describe('HeroSection', () => {
     const { unmount } = render(<HeroSection />)
 
     act(() => {
-      vi.advanceTimersByTime(400 + SUBTITLE_TEXT.length * 60)
+      vi.advanceTimersByTime(3200 + SUBTITLE_TEXT.length * 60)
     })
 
     expect(vi.getTimerCount()).toBeGreaterThan(0)

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -1,12 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
 import HeroSection from './HeroSection'
-import { cursorVariants } from './HeroSection.constants'
+import {
+  CTA_DELAY,
+  INITIAL_DELAY,
+  SUBTITLE,
+  SUBTITLE_SPEED,
+  VALUE_PROP,
+  VALUE_PROP_DELAY,
+  VALUE_PROP_SPEED,
+  cursorVariants,
+} from './HeroSection.constants'
 
-const SUBTITLE_TEXT = 'CS_STUDENT · DEVELOPER'
-const VALUE_PROP_TEXT = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
-const TYPEWRITER_DURATION = 3200 + SUBTITLE_TEXT.length * 60 + 400 + VALUE_PROP_TEXT.length * 35
-const CTA_DELAY = 200
+const TYPEWRITER_DURATION =
+  INITIAL_DELAY +
+  SUBTITLE.length * SUBTITLE_SPEED +
+  VALUE_PROP_DELAY +
+  VALUE_PROP.length * VALUE_PROP_SPEED
 
 describe('HeroSection', () => {
   beforeEach(() => {
@@ -16,6 +26,10 @@ describe('HeroSection', () => {
   afterEach(() => {
     vi.clearAllTimers()
     vi.useRealTimers()
+  })
+
+  it('uses a 3.2 second initial handoff delay', () => {
+    expect(INITIAL_DELAY).toBe(3200)
   })
 
   it('shows the developer name', () => {
@@ -37,7 +51,7 @@ describe('HeroSection', () => {
     render(<HeroSection />)
 
     act(() => {
-      vi.advanceTimersByTime(3200)
+      vi.advanceTimersByTime(INITIAL_DELAY)
     })
 
     const subtitle = screen.getByTestId('subtitle')
@@ -45,7 +59,7 @@ describe('HeroSection', () => {
     expect(screen.getByTestId('subtitle-cursor')).toBeInTheDocument()
 
     act(() => {
-      vi.advanceTimersByTime(60)
+      vi.advanceTimersByTime(SUBTITLE_SPEED)
     })
 
     expect(subtitle.textContent).toBe('C')
@@ -56,12 +70,12 @@ describe('HeroSection', () => {
     render(<HeroSection />)
 
     act(() => {
-      vi.advanceTimersByTime(3200)
-      vi.advanceTimersByTime(SUBTITLE_TEXT.length * 60)
+      vi.advanceTimersByTime(INITIAL_DELAY)
+      vi.advanceTimersByTime(SUBTITLE.length * SUBTITLE_SPEED)
     })
 
     const subtitle = screen.getByTestId('subtitle')
-    expect(subtitle.textContent).toBe(SUBTITLE_TEXT)
+    expect(subtitle.textContent).toBe(SUBTITLE)
     expect(screen.queryByTestId('subtitle-cursor')).not.toBeInTheDocument()
   })
 
@@ -70,21 +84,21 @@ describe('HeroSection', () => {
     const valueProp = screen.getByTestId('value-prop')
 
     act(() => {
-      vi.advanceTimersByTime(3200 + SUBTITLE_TEXT.length * 60)
+      vi.advanceTimersByTime(INITIAL_DELAY + SUBTITLE.length * SUBTITLE_SPEED)
     })
 
     expect(valueProp.textContent).toBe('')
     expect(screen.queryByTestId('value-prop-cursor')).not.toBeInTheDocument()
 
     act(() => {
-      vi.advanceTimersByTime(400)
+      vi.advanceTimersByTime(VALUE_PROP_DELAY)
     })
 
     expect(valueProp.textContent).toBe('')
     expect(screen.getByTestId('value-prop-cursor')).toBeInTheDocument()
 
     act(() => {
-      vi.advanceTimersByTime(35)
+      vi.advanceTimersByTime(VALUE_PROP_SPEED)
     })
 
     expect(valueProp.textContent).toBe('/')
@@ -99,7 +113,7 @@ describe('HeroSection', () => {
     })
 
     const valueProp = screen.getByTestId('value-prop')
-    expect(valueProp.textContent).toBe(VALUE_PROP_TEXT)
+    expect(valueProp.textContent).toBe(VALUE_PROP)
     expect(screen.queryByTestId('value-prop-cursor')).not.toBeInTheDocument()
   })
 
@@ -107,7 +121,7 @@ describe('HeroSection', () => {
     const { unmount } = render(<HeroSection />)
 
     act(() => {
-      vi.advanceTimersByTime(3200 + SUBTITLE_TEXT.length * 60)
+      vi.advanceTimersByTime(INITIAL_DELAY + SUBTITLE.length * SUBTITLE_SPEED)
     })
 
     expect(vi.getTimerCount()).toBeGreaterThan(0)

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,17 +1,17 @@
 import { useState, useEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { ScrollFadeSection } from './ScrollFadeSection'
-import { cursorVariants } from './HeroSection.constants'
-
-const SUBTITLE = 'CS_STUDENT · DEVELOPER'
-const VALUE_PROP = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
-const INITIAL_DELAY = 3200
-const SUBTITLE_SPEED = 60
-const VALUE_PROP_DELAY = 400
-const VALUE_PROP_SPEED = 35
-
-const CTA_DELAY = 200
-const CTA_FADE_DURATION = 0.4
+import {
+  CTA_DELAY,
+  CTA_FADE_DURATION,
+  INITIAL_DELAY,
+  SUBTITLE,
+  SUBTITLE_SPEED,
+  VALUE_PROP,
+  VALUE_PROP_DELAY,
+  VALUE_PROP_SPEED,
+  cursorVariants,
+} from './HeroSection.constants'
 
 const ctaVariants = {
   hidden: { opacity: 0, y: 8 },

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -5,7 +5,7 @@ import { cursorVariants } from './HeroSection.constants'
 
 const SUBTITLE = 'CS_STUDENT · DEVELOPER'
 const VALUE_PROP = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
-const INITIAL_DELAY = 400
+const INITIAL_DELAY = 3200
 const SUBTITLE_SPEED = 60
 const VALUE_PROP_DELAY = 400
 const VALUE_PROP_SPEED = 35

--- a/src/components/LoadingScreen.constants.ts
+++ b/src/components/LoadingScreen.constants.ts
@@ -1,0 +1,8 @@
+export const STATUS_MESSAGES = [
+  'ESTABLISHING_SIGNAL',
+  'COMPILING_MODULES',
+  'LOADING_ASSETS',
+  'SYSTEM_READY',
+] as const
+
+export const MESSAGE_DURATION = 700

--- a/src/components/LoadingScreen.test.tsx
+++ b/src/components/LoadingScreen.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, act } from '@testing-library/react'
 import LoadingScreen from './LoadingScreen'
-
-const MESSAGE_DURATION = 700
+import { MESSAGE_DURATION, STATUS_MESSAGES } from './LoadingScreen.constants'
 
 describe('LoadingScreen', () => {
   beforeEach(() => {
@@ -11,6 +10,10 @@ describe('LoadingScreen', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+  })
+
+  it('uses a 2.8 second total status message sequence', () => {
+    expect(MESSAGE_DURATION * STATUS_MESSAGES.length).toBe(2800)
   })
 
   it('shows ESTABLISHING_SIGNAL as the first status message', () => {

--- a/src/components/LoadingScreen.test.tsx
+++ b/src/components/LoadingScreen.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, act } from '@testing-library/react'
 import LoadingScreen from './LoadingScreen'
 
-const MESSAGE_DURATION = 600
+const MESSAGE_DURATION = 700
 
 describe('LoadingScreen', () => {
   beforeEach(() => {

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,14 +1,6 @@
 import { useState, useEffect } from 'react'
 import { motion } from 'framer-motion'
-
-const STATUS_MESSAGES = [
-  'ESTABLISHING_SIGNAL',
-  'COMPILING_MODULES',
-  'LOADING_ASSETS',
-  'SYSTEM_READY',
-] as const
-
-const MESSAGE_DURATION = 700
+import { MESSAGE_DURATION, STATUS_MESSAGES } from './LoadingScreen.constants'
 
 interface LoadingScreenProps {
   onComplete: () => void

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -8,7 +8,7 @@ const STATUS_MESSAGES = [
   'SYSTEM_READY',
 ] as const
 
-const MESSAGE_DURATION = 600
+const MESSAGE_DURATION = 700
 
 interface LoadingScreenProps {
   onComplete: () => void


### PR DESCRIPTION
**Purpose** — Align the loading screen duration and hero intro handoff with the PRD timing for issue #102.

**What it does** — Keeps the terminal-style loading overlay visible for a 2.8 second status sequence and delays the hero typewriter start until 3.2 seconds after mount.

**Changes made**
- Updated loading status timing to 700ms per message and covered it with fake-timer tests.
- Updated hero initial typewriter delay to 3200ms and kept CTA sequencing intact.
- Centralized loading and hero timing constants so implementation and tests stay aligned.

**Additional notes** — No layout or visual redesign changes were made; this is limited to timing, handoff coverage, and maintainability cleanup.

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized timing and text constants into dedicated modules for improved code maintainability
  * Updated component implementations to use externalized configuration

* **Tests**
  * Enhanced test coverage for animation timing sequences
  * Updated tests to align with new constant-based configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->