### PR TITLE
Content: skills bento — add resume skills tiles

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -102,6 +102,9 @@ describe('SkillsSection', () => {
       'FastAPI',
       'Docker', 'Git', 'Ansible', 'Linux',
       'NumPy', 'Pandas',
+      'Transformers', 'Attention Mechanisms', 'Gradient Optimization', 'Model Training / Fine-tuning',
+      'Matplotlib', 'Mixed-Precision Training',
+      'Jupyter',
     ]
     for (const skill of required) {
       expect(screen.getByText(skill)).toBeInTheDocument()
@@ -116,15 +119,15 @@ describe('SkillsSection', () => {
     }
   })
 
-  it('renders 15 skill tiles with no accent tile', () => {
+  it('renders 22 skill tiles (15 original + 7 new from resume)', () => {
     render(<SkillsSection />)
 
     const categoryLabels = screen.getAllByText(/^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/)
-    expect(categoryLabels).toHaveLength(15)
+    expect(categoryLabels).toHaveLength(22)
 
     const gridContainer = document.querySelector('.grid')
     const children = gridContainer?.children || []
-    expect(children.length).toBe(15)
+    expect(children.length).toBe(22)
   })
 
   it('desktop grid has an explicit grid-rows class with varied row heights', () => {
@@ -156,10 +159,10 @@ describe('SkillsSection', () => {
     expect(pythonTile!.className).toMatch(/md:row-span-[3-9]/)
   })
 
-  it('grid defines at least 8 explicit rows to accommodate Python row-span-3 layout', () => {
+  it('grid defines at least 10 explicit rows to accommodate all skill tiles', () => {
     render(<SkillsSection />)
     const heights = getExplicitGridRows()
-    expect(heights.length).toBeGreaterThanOrEqual(8)
+    expect(heights.length).toBeGreaterThanOrEqual(10)
   })
 
   it('grid container has min-h-screen or min-h-svh class', () => {
@@ -193,13 +196,23 @@ describe('SkillsSection', () => {
     const children = Array.from(gridContainer?.children || [])
 
     const lastChild = children[children.length - 1]
-    expect(lastChild.textContent).toContain('SQL')
+    expect(lastChild.textContent).toContain('Jupyter')
     expect(lastChild.textContent).not.toMatch(/^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/)
+
+    const allSkills = [
+      'Python', 'TypeScript', 'JavaScript', 'C / C++', 'SQL',
+      'PyTorch', 'Hugging Face', 'Scikit-learn',
+      'FastAPI', 'Docker', 'Git', 'Ansible', 'Linux',
+      'NumPy', 'Pandas',
+      'Transformers', 'Attention Mechanisms', 'Gradient Optimization', 'Model Training / Fine-tuning',
+      'Matplotlib', 'Mixed-Precision Training', 'Jupyter',
+    ]
 
     const allHaveCategoryOrSkill = children.every(child => {
       const text = child.textContent || ''
-      return /^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/.test(text) ||
-             /Python|TypeScript|JavaScript|C \/ C\+\+|SQL|Docker|Git|Ansible|Linux|NumPy|Pandas|FastAPI|PyTorch|Hugging Face|Scikit-learn/.test(text)
+      const isCategory = /^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/.test(text)
+      const isKnownSkill = allSkills.some(skill => text.includes(skill))
+      return isCategory || isKnownSkill
     })
     expect(allHaveCategoryOrSkill).toBe(true)
   })
@@ -209,7 +222,7 @@ describe('SkillsSection', () => {
 
     const tileAnimations = motionMock.divProps.filter(props => props.text !== undefined && props.text !== '')
 
-    expect(tileAnimations).toHaveLength(15)
+    expect(tileAnimations).toHaveLength(22)
 
     for (const tileAnimation of tileAnimations) {
       expect(tileAnimation.variants).toMatchObject({

--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -80,6 +80,12 @@ function getExplicitGridRows() {
   return match![1].split('_')
 }
 
+function getSkillTile(name: string) {
+  const tile = screen.getByText(name).closest('div')
+  expect(tile).not.toBeNull()
+  return tile!
+}
+
 describe('SkillsSection', () => {
   beforeEach(() => {
     motionMock.isInView = false
@@ -159,10 +165,22 @@ describe('SkillsSection', () => {
     expect(pythonTile!.className).toMatch(/md:row-span-[3-9]/)
   })
 
-  it('grid defines at least 10 explicit rows to accommodate all skill tiles', () => {
+  it('grid defines at least 11 explicit rows to accommodate all skill tiles', () => {
     render(<SkillsSection />)
     const heights = getExplicitGridRows()
-    expect(heights.length).toBeGreaterThanOrEqual(10)
+    expect(heights.length).toBeGreaterThanOrEqual(11)
+  })
+
+  it('new resume skills keep an asymmetric desktop layout', () => {
+    render(<SkillsSection />)
+
+    expect(getSkillTile('Transformers').className).toContain('md:col-span-2')
+    expect(getSkillTile('Attention Mechanisms').className).not.toContain('md:col-span-2')
+    expect(getSkillTile('Gradient Optimization').className).toContain('md:row-span-2')
+    expect(getSkillTile('Model Training / Fine-tuning').className).toContain('md:col-span-3')
+    expect(getSkillTile('Matplotlib').className).not.toContain('md:col-span-2')
+    expect(getSkillTile('Mixed-Precision Training').className).toContain('md:col-span-2')
+    expect(getSkillTile('Jupyter').className).toContain('md:col-span-1')
   })
 
   it('grid container has min-h-screen or min-h-svh class', () => {

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -35,15 +35,19 @@ interface SkillTile {
   fg: string
 }
 
-// Desktop (4-col, 8 rows — no two adjacent rows share the same span pattern):
-//   R1: Python(2) TypeScript(2)          [2,2]
-//   R2: Python(2) Docker(1) C/C++(1)     [2,1,1]
-//   R3: Python(2) JavaScript(2)          [2,2]
-//   R4: FastAPI(1) PyTorch(3)            [1,3]
-//   R5: NumPy(2) Pandas(1) Ansible(1)    [2,1,1]
-//   R6: NumPy(2) HuggingFace(2)          [2,2]
-//   R7: Scikit-learn(3) Linux(1)         [3,1]
-//   R8: Git(1) SQL(3)                    [1,3]
+// Desktop (4-col, 10 rows — no two adjacent rows share the same span pattern):
+//   R1: Python(2) TypeScript(2)                    [2,2]
+//   R2: Python(2) Docker(1) C/C++(1)               [2,1,1]
+//   R3: Python(2) JavaScript(2)                    [2,2]
+//   R4: FastAPI(1) PyTorch(3)                      [1,3]
+//   R5: NumPy(2) Pandas(1) Ansible(1)              [2,1,1]
+//   R6: NumPy(2) HuggingFace(2)                    [2,2]
+//   R7: Scikit-learn(3) Linux(1)                   [3,1]
+//   R8: Git(1) SQL(3)                               [1,3]
+//   R9: Transformers(2) Attention Mechanisms(2)    [2,2]
+//   R10: Gradient Opt(2) Model Training(2)         [2,2]
+//   R11: Matplotlib(2) Mixed-Precision(2)          [2,2]
+//   R12: Jupyter(4)                                 [4]
 //
 // Mobile (2-col):
 //   R1: Python(2)
@@ -57,6 +61,10 @@ interface SkillTile {
 //   R9: HuggingFace(1) Scikit-learn(1)
 //   R10: Linux(1) Git(1)
 //   R11: SQL(2)
+//   R12: Transformers(1) Attention Mechanisms(1)
+//   R13: Gradient Opt(1) Model Training(1)
+//   R14: Matplotlib(1) Mixed-Precision(1)
+//   R15: Jupyter(2)
 const tiles: SkillTile[] = [
   { category: 'LANGUAGE',  name: 'Python',       colSpan: 'col-span-2',                rowSpan: 'row-span-2 md:row-span-3', bg: '#FF8547', fg: '#050609' },
   { category: 'LANGUAGE',  name: 'TypeScript',   colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-2 md:row-span-1', bg: '#5200E0', fg: '#EFF1F3' },
@@ -73,6 +81,13 @@ const tiles: SkillTile[] = [
   { category: 'TOOL',      name: 'Linux',        colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
   { category: 'TOOL',      name: 'Git',          colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
   { category: 'LANGUAGE',  name: 'SQL',          colSpan: 'col-span-2 md:col-span-3',  rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
+  { category: 'ML / DL',   name: 'Transformers', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Attention Mechanisms', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Gradient Optimization', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Model Training / Fine-tuning', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'DATA',      name: 'Matplotlib',   colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
+  { category: 'DATA',      name: 'Mixed-Precision Training', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
+  { category: 'TOOL',      name: 'Jupyter',      colSpan: 'col-span-2 md:col-span-4',  rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
 ]
 
 function SkillTileCard({ tile }: { tile: SkillTile }) {
@@ -112,7 +127,7 @@ export function SkillsSection() {
           variants={gridStagger}
           initial="hidden"
           animate={isInView ? 'visible' : 'hidden'}
-          className="grid grid-cols-2 md:grid-cols-4 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr]"
+          className="grid grid-cols-2 md:grid-cols-4 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr]"
         >
           {tiles.map((tile) => (
             <SkillTileCard key={tile.name} tile={tile} />

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -35,7 +35,7 @@ interface SkillTile {
   fg: string
 }
 
-// Desktop (4-col, 10 rows — no two adjacent rows share the same span pattern):
+// Desktop (4-col, 11 rows — no two adjacent rows share the same span pattern):
 //   R1: Python(2) TypeScript(2)                    [2,2]
 //   R2: Python(2) Docker(1) C/C++(1)               [2,1,1]
 //   R3: Python(2) JavaScript(2)                    [2,2]
@@ -44,10 +44,9 @@ interface SkillTile {
 //   R6: NumPy(2) HuggingFace(2)                    [2,2]
 //   R7: Scikit-learn(3) Linux(1)                   [3,1]
 //   R8: Git(1) SQL(3)                               [1,3]
-//   R9: Transformers(2) Attention Mechanisms(2)    [2,2]
-//   R10: Gradient Opt(2) Model Training(2)         [2,2]
-//   R11: Matplotlib(2) Mixed-Precision(2)          [2,2]
-//   R12: Jupyter(4)                                 [4]
+//   R9: Transformers(2) Attention Mechanisms(1) Gradient Opt(1) [2,1,1]
+//   R10: Model Training(3) Gradient Opt(1)        [3,1]
+//   R11: Matplotlib(1) Mixed-Precision(2) Jupyter(1) [1,2,1]
 //
 // Mobile (2-col):
 //   R1: Python(2)
@@ -82,12 +81,12 @@ const tiles: SkillTile[] = [
   { category: 'TOOL',      name: 'Git',          colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
   { category: 'LANGUAGE',  name: 'SQL',          colSpan: 'col-span-2 md:col-span-3',  rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
   { category: 'ML / DL',   name: 'Transformers', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Attention Mechanisms', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Gradient Optimization', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Model Training / Fine-tuning', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'DATA',      name: 'Matplotlib',   colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
+  { category: 'ML / DL',   name: 'Attention Mechanisms', colSpan: 'col-span-1',        rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Gradient Optimization', colSpan: 'col-span-1',       rowSpan: 'row-span-1 md:row-span-2', bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Model Training / Fine-tuning', colSpan: 'col-span-1 md:col-span-3',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'DATA',      name: 'Matplotlib',   colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
   { category: 'DATA',      name: 'Mixed-Precision Training', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'TOOL',      name: 'Jupyter',      colSpan: 'col-span-2 md:col-span-4',  rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
+  { category: 'TOOL',      name: 'Jupyter',      colSpan: 'col-span-2 md:col-span-1',  rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
 ]
 
 function SkillTileCard({ tile }: { tile: SkillTile }) {
@@ -127,7 +126,7 @@ export function SkillsSection() {
           variants={gridStagger}
           initial="hidden"
           animate={isInView ? 'visible' : 'hidden'}
-          className="grid grid-cols-2 md:grid-cols-4 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr]"
+          className="grid grid-cols-2 md:grid-cols-4 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr]"
         >
           {tiles.map((tile) => (
             <SkillTileCard key={tile.name} tile={tile} />


### PR DESCRIPTION
**Purpose** — Add the resume skills missing from the skills bento grid so the portfolio skills section matches the source resume.

**What it does** — Adds seven resume-derived skill tiles and keeps the desktop/mobile grid arrangement intentional and asymmetric.

**Changes made**
- Updated `src/components/SkillsSection.tsx` with Transformers, Attention Mechanisms, Gradient Optimization, Model Training / Fine-tuning, Matplotlib, Mixed-Precision Training, and Jupyter tiles.
- Revised the explicit desktop grid rows and source layout comment to match the final 11-row layout.
- Updated `src/components/SkillsSection.test.tsx` for the 22-tile count and added coverage for the asymmetric desktop spans.

**Additional notes** — The requested `.prompts/CODING_STANDARDS.md` file is not present in this checkout; lint, typecheck, and tests are passing.

Closes #84


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded skills grid with 7 new skills: Transformers, Attention Mechanisms, Gradient Optimization, Model Training/Fine-tuning, Matplotlib, Mixed-Precision Training, and Jupyter.
  * Skills section now displays 22 total tiles (up from 15).
  
* **Style**
  * Enhanced desktop layout with improved grid row configuration for better visual organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->