### PR TITLE
Content: contact email — confirm school vs personal address

### DIFF
--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, within } from '@testing-library/react'
 import ContactSection from './ContactSection'
 
 describe('ContactSection', () => {
+  const canonicalEmailHref = 'mailto:famohammed@shockers.wichita.edu'
+
   it('renders a contact section with only the CTA heading and contact links', () => {
     render(<ContactSection />)
     const section = document.querySelector('#contact') as HTMLElement
@@ -30,8 +32,8 @@ describe('ContactSection', () => {
     const emailLink = screen.getByRole('link', { name: '// EMAIL' })
     const resumeLink = screen.getByRole('link', { name: '// RESUME' })
 
-    expect(sendMessageLink).toHaveAttribute('href', expect.stringMatching(/^mailto:/))
-    expect(emailLink).toHaveAttribute('href', expect.stringMatching(/^mailto:/))
+    expect(sendMessageLink).toHaveAttribute('href', canonicalEmailHref)
+    expect(emailLink).toHaveAttribute('href', canonicalEmailHref)
     expect(resumeLink).toHaveAttribute('href', '/resume.pdf')
     expect(resumeLink).toHaveAttribute('target', '_blank')
   })

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -2,7 +2,7 @@ import { motion } from 'framer-motion'
 import { hoverEase } from '../animations/variants'
 import { ScrollFadeSection } from './ScrollFadeSection'
 
-const EMAIL = 'mfa200312@gmail.com'
+const EMAIL = 'famohammed@shockers.wichita.edu'
 
 const footerLinks = [
   { label: '// GITHUB', href: 'https://github.com/Nemesis-12' },


### PR DESCRIPTION
**Purpose** — Align the portfolio contact email with the canonical address selected from the resume.

**What it does** — Updates the contact CTA and footer email link to use the school email address, then locks that behavior with test coverage.

**Changes made**
- `src/components/ContactSection.tsx`: uses `famohammed@shockers.wichita.edu` as the shared canonical email constant.
- `src/components/ContactSection.test.tsx`: asserts both email links render the exact canonical `mailto:` href.

**Additional notes** — The school email was chosen because `resume.pdf` is the canonical content reference for this issue. The requested coding standards file was not present at `.prompts/CODING_STANDARDS.md` in this checkout.

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened email validation assertions in contact section tests for improved accuracy.

* **Bug Fixes**
  * Updated contact email address used in footer links and send-message functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->