### PR TITLE
Contact: footer social links — // prefix orange + white hover

### DIFF
--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -29,8 +29,8 @@ describe('ContactSection', () => {
   it('renders contact links with the expected destinations', () => {
     render(<ContactSection />)
     const sendMessageLink = screen.getByRole('link', { name: 'SEND_MESSAGE →' })
-    const emailLink = screen.getByRole('link', { name: '// EMAIL' })
-    const resumeLink = screen.getByRole('link', { name: '// RESUME' })
+    const emailLink = screen.getByRole('link', { name: '//EMAIL' })
+    const resumeLink = screen.getByRole('link', { name: '//RESUME' })
 
     expect(sendMessageLink).toHaveAttribute('href', canonicalEmailHref)
     expect(emailLink).toHaveAttribute('href', canonicalEmailHref)

--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -29,13 +29,42 @@ describe('ContactSection', () => {
   it('renders contact links with the expected destinations', () => {
     render(<ContactSection />)
     const sendMessageLink = screen.getByRole('link', { name: 'SEND_MESSAGE →' })
-    const emailLink = screen.getByRole('link', { name: '//EMAIL' })
-    const resumeLink = screen.getByRole('link', { name: '//RESUME' })
+    const githubLink = screen.getByRole('link', { name: '// GITHUB' })
+    const linkedInLink = screen.getByRole('link', { name: '// LINKEDIN' })
+    const emailLink = screen.getByRole('link', { name: '// EMAIL' })
+    const resumeLink = screen.getByRole('link', { name: '// RESUME' })
 
     expect(sendMessageLink).toHaveAttribute('href', canonicalEmailHref)
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/Nemesis-12')
+    expect(githubLink).not.toHaveAttribute('target')
+    expect(githubLink).not.toHaveAttribute('rel')
+    expect(linkedInLink).toHaveAttribute('href', 'https://linkedin.com/in/fa-mohammed')
+    expect(linkedInLink).not.toHaveAttribute('target')
+    expect(linkedInLink).not.toHaveAttribute('rel')
     expect(emailLink).toHaveAttribute('href', canonicalEmailHref)
+    expect(emailLink).not.toHaveAttribute('target')
+    expect(emailLink).not.toHaveAttribute('rel')
     expect(resumeLink).toHaveAttribute('href', '/resume.pdf')
     expect(resumeLink).toHaveAttribute('target', '_blank')
+    expect(resumeLink).toHaveAttribute('rel', 'noopener noreferrer')
+  })
+
+  it('renders footer link prefixes in orange and transitions the full link to white on hover', () => {
+    render(<ContactSection />)
+    const footerLinks = ['// GITHUB', '// LINKEDIN', '// EMAIL', '// RESUME'].map((name) =>
+      screen.getByRole('link', { name }),
+    )
+
+    footerLinks.forEach((link) => {
+      const spans = link.querySelectorAll('span')
+      const [prefix, label] = spans
+
+      expect(link).toHaveClass('group')
+      expect(spans).toHaveLength(2)
+      expect(prefix).toHaveTextContent('//')
+      expect(prefix).toHaveClass('text-atomic-tangerine', 'group-hover:text-white', 'transition-colors')
+      expect(label).toHaveClass('text-periwinkle', 'group-hover:text-white', 'transition-colors')
+    })
   })
 })
 

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -5,10 +5,10 @@ import { ScrollFadeSection } from './ScrollFadeSection'
 const EMAIL = 'famohammed@shockers.wichita.edu'
 
 const footerLinks = [
-  { label: '// GITHUB', href: 'https://github.com/Nemesis-12' },
-  { label: '// LINKEDIN', href: 'https://linkedin.com/in/fa-mohammed' },
-  { label: '// EMAIL', href: `mailto:${EMAIL}` },
-  { label: '// RESUME', href: '/resume.pdf', target: '_blank' as const },
+  { prefix: '//', label: 'GITHUB', href: 'https://github.com/Nemesis-12' },
+  { prefix: '//', label: 'LINKEDIN', href: 'https://linkedin.com/in/fa-mohammed' },
+  { prefix: '//', label: 'EMAIL', href: `mailto:${EMAIL}` },
+  { prefix: '//', label: 'RESUME', href: '/resume.pdf', target: '_blank' as const },
 ]
 
 export default function ContactSection() {
@@ -31,7 +31,7 @@ export default function ContactSection() {
           </motion.a>
 
           <div className="flex flex-wrap gap-6">
-            {footerLinks.map(({ label, href, target }) => (
+            {footerLinks.map(({ prefix, label, href, target }) => (
               <motion.a
                 key={label}
                 href={href}
@@ -40,9 +40,10 @@ export default function ContactSection() {
                 variants={hoverEase}
                 initial="idle"
                 whileHover="hover"
-                className="font-body text-sm text-periwinkle hover:text-atomic-tangerine transition-colors"
+                className="group font-body text-sm"
               >
-                {label}
+                <span className="text-atomic-tangerine group-hover:text-white transition-colors">{prefix}{' '}</span>
+                <span className="text-periwinkle group-hover:text-white transition-colors">{label}</span>
               </motion.a>
             ))}
           </div>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -36,6 +36,7 @@ export default function ContactSection() {
                 key={label}
                 href={href}
                 target={target}
+                aria-label={`${prefix} ${label}`}
                 rel={target === '_blank' ? 'noopener noreferrer' : undefined}
                 variants={hoverEase}
                 initial="idle"


### PR DESCRIPTION
**Purpose** — Update the contact footer social links so the terminal `//` prefix rests in orange and the full link hovers white.

**What it does** — Splits footer link text into prefix and label spans, applies the requested color transitions, and preserves the original spaced accessible link names.

**Changes made**
- `src/components/ContactSection.tsx`: styles the `//` prefix separately, adds full-link white hover behavior, and keeps external resume rel handling intact.
- `src/components/ContactSection.test.tsx`: covers footer link hrefs, target/rel attributes, prefix styling, full hover styling, and accessible names.

**Additional notes** — `npm run typecheck` and `npm run test` pass. The requested `.prompts/CODING_STANDARDS.md` file was not present in this workspace.

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened link destination assertions for contact footer links (GitHub, LinkedIn, email, resume).
  * Added tests verifying footer link styling behavior and markup structure.

* **Improvements**
  * Enhanced footer link styling with improved visual presentation.
  * Improved accessibility with updated aria-labels for contact footer links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->