### PR TITLE
Timeline: // EXPERIENCE / // EDUCATION label typography

### DIFF
--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -24,7 +24,7 @@ describe('TimelineSection', () => {
 
   it('entries start empty (typewriter effect)', () => {
     render(<TimelineSection />)
-    
+
     const hashElements = screen.getAllByTestId('commit-hash')
     const authorElements = screen.getAllByTestId('commit-author')
     const dateElements = screen.getAllByTestId('commit-date')
@@ -45,6 +45,24 @@ describe('TimelineSection', () => {
     institutionElements.forEach(el => expect(el).toHaveTextContent(''))
     roleElements.forEach(el => expect(el).toHaveTextContent(''))
     descriptionElements.forEach(el => expect(el).toHaveTextContent(''))
+  })
+
+  it('renders timeline section labels in pixel display typography', () => {
+    render(<TimelineSection />)
+
+    const labels = ['EDUCATION', 'EXPERIENCE']
+
+    labels.forEach(label => {
+      const labelElement = screen.getByText(label)
+      const slashElement = labelElement.previousElementSibling
+
+      expect(slashElement).toHaveTextContent('//')
+      expect(slashElement).toHaveClass('font-display', 'text-xs', 'text-atomic-tangerine')
+      expect(slashElement).not.toHaveClass('font-body')
+
+      expect(labelElement).toHaveClass('font-display', 'text-sm', 'text-atomic-tangerine')
+      expect(labelElement).not.toHaveClass('font-body')
+    })
   })
 
   describe('issue #47 - scroll-triggered typewriter', () => {

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -135,17 +135,19 @@ const TimelineSection: React.FC = () => {
 
         <div className="space-y-12">
           <div>
-            <p className="font-body text-sm text-periwinkle tracking-widest mb-2 uppercase">
-              Education
-            </p>
+            <div className="flex items-center gap-1 mb-2">
+              <span className="font-display text-xs text-atomic-tangerine">//</span>
+              <span className="font-display text-sm text-atomic-tangerine">EDUCATION</span>
+            </div>
             <hr className="border-periwinkle/10 mb-0" />
             <EntryList entries={education} />
           </div>
 
           <div>
-            <p className="font-body text-sm text-periwinkle tracking-widest mb-2 uppercase">
-              Experience
-            </p>
+            <div className="flex items-center gap-1 mb-2">
+              <span className="font-display text-xs text-atomic-tangerine">//</span>
+              <span className="font-display text-sm text-atomic-tangerine">EXPERIENCE</span>
+            </div>
             <hr className="border-periwinkle/10 mb-0" />
             <EntryList entries={experience} />
           </div>

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -123,6 +123,15 @@ function EntryList({ entries }: { entries: TimelineEntry[] }) {
   )
 }
 
+function SectionLabel({ label }: { label: 'EDUCATION' | 'EXPERIENCE' }) {
+  return (
+    <div className="flex items-center gap-1 mb-2">
+      <span className="font-display text-xs text-atomic-tangerine">//</span>
+      <span className="font-display text-sm text-atomic-tangerine">{label}</span>
+    </div>
+  )
+}
+
 const TimelineSection: React.FC = () => {
   return (
     <ScrollFadeSection id="timeline" className="min-h-screen flex flex-col justify-center py-14 px-8 bg-graphite-light">
@@ -135,19 +144,13 @@ const TimelineSection: React.FC = () => {
 
         <div className="space-y-12">
           <div>
-            <div className="flex items-center gap-1 mb-2">
-              <span className="font-display text-xs text-atomic-tangerine">//</span>
-              <span className="font-display text-sm text-atomic-tangerine">EDUCATION</span>
-            </div>
+            <SectionLabel label="EDUCATION" />
             <hr className="border-periwinkle/10 mb-0" />
             <EntryList entries={education} />
           </div>
 
           <div>
-            <div className="flex items-center gap-1 mb-2">
-              <span className="font-display text-xs text-atomic-tangerine">//</span>
-              <span className="font-display text-sm text-atomic-tangerine">EXPERIENCE</span>
-            </div>
+            <SectionLabel label="EXPERIENCE" />
             <hr className="border-periwinkle/10 mb-0" />
             <EntryList entries={experience} />
           </div>


### PR DESCRIPTION
**Purpose** — Update the timeline panel section labels so they match the requested pixel display typography and orange color treatment.

**What it does** — Applies `font-display` and `text-atomic-tangerine` to both `//` and the section words, with `//` rendered smaller than `EDUCATION` / `EXPERIENCE`.

**Changes made**
- Updated `src/components/TimelineSection.tsx` to render timeline labels through a shared `SectionLabel` component.
- Added a regression test in `src/components/TimelineSection.test.tsx` covering font family, color, size hierarchy, and absence of `font-body`.

**Additional notes** — `npm run typecheck` and `npm run test` pass locally. The referenced `.prompts/CODING_STANDARDS.md` file was not present in the workspace.

Closes #80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for timeline section labels to verify correct formatting and styling of "EDUCATION" and "EXPERIENCE" sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->