### PR TITLE
Foundation: full-width full-viewport v4 shell

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,6 +3,13 @@ import { render } from '@testing-library/react'
 import App from './App'
 
 const sections = ['home', 'projects', 'skills', 'timeline', 'contact'] as const
+const shellConstraintClasses = ['container', 'max-w-7xl', 'mx-auto'] as const
+
+function expectNoShellConstraint(element: Element) {
+  shellConstraintClasses.forEach((className) => {
+    expect(element.classList).not.toContain(className)
+  })
+}
 
 describe('App shell', () => {
   it.each(sections)('renders %s section', (id) => {
@@ -18,12 +25,12 @@ describe('App shell', () => {
     expect(Array.from(sectionIds).map((s) => s.id)).toEqual([...sections])
   })
 
-  it('sections span full browser width (no max-width constraint)', () => {
+  it('section surfaces span the full browser width', () => {
     render(<App />)
     const sectionIds = document.querySelectorAll('section[id]')
     sectionIds.forEach((section) => {
-      const style = window.getComputedStyle(section)
-      expect(style.maxWidth).toBe('none')
+      expectNoShellConstraint(section)
+      expect(section.className).toContain('min-h-screen')
     })
   })
 
@@ -31,15 +38,7 @@ describe('App shell', () => {
     render(<App />)
     const main = document.querySelector('main')
     expect(main).toBeInTheDocument()
-    const style = window.getComputedStyle(main as Element)
-    expect(style.display).toBe('block')
-  })
-
-  it('sections use full-viewport min-height for card-deck stacking', () => {
-    render(<App />)
-    const sectionIds = document.querySelectorAll('section[id]')
-    sectionIds.forEach((section) => {
-      expect(section.className).toContain('min-h-screen')
-    })
+    expect(main).not.toHaveAttribute('class')
+    expectNoShellConstraint(main as Element)
   })
 })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -17,4 +17,29 @@ describe('App shell', () => {
     const sectionIds = document.querySelectorAll('section[id]')
     expect(Array.from(sectionIds).map((s) => s.id)).toEqual([...sections])
   })
+
+  it('sections span full browser width (no max-width constraint)', () => {
+    render(<App />)
+    const sectionIds = document.querySelectorAll('section[id]')
+    sectionIds.forEach((section) => {
+      const style = window.getComputedStyle(section)
+      expect(style.maxWidth).toBe('none')
+    })
+  })
+
+  it('main element has no centered shell constraint', () => {
+    render(<App />)
+    const main = document.querySelector('main')
+    expect(main).toBeInTheDocument()
+    const style = window.getComputedStyle(main as Element)
+    expect(style.display).toBe('block')
+  })
+
+  it('sections use full-viewport min-height for card-deck stacking', () => {
+    render(<App />)
+    const sectionIds = document.querySelectorAll('section[id]')
+    sectionIds.forEach((section) => {
+      expect(section.className).toContain('min-h-screen')
+    })
+  })
 })

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -15,7 +15,7 @@ export default function ContactSection() {
   return (
     <>
       <ScrollFadeSection id="contact" className="min-h-screen flex flex-col justify-center px-8 py-14 bg-graphite">
-        <div className="max-w-7xl mx-auto w-full">
+        <div className="w-full">
           <h2 className="font-display text-3xl md:text-5xl text-platinum leading-tight mb-12">
             LET'S CONNECT.
           </h2>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -84,7 +84,7 @@ const HeroSection: React.FC = () => {
         <div className="absolute inset-0 bg-[radial-gradient(#3A3B3A_1px,transparent_1px)] bg-[size:20px_20px]"></div>
       </div>
 
-      <div className="relative z-10 px-8 max-w-7xl mx-auto space-y-6">
+      <div className="relative z-10 px-8 w-full space-y-6">
         <div className="space-y-2">
           <p className="font-body text-xs text-atomic-tangerine tracking-widest">
             // PORTFOLIO_INIT

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -24,7 +24,7 @@ function getTagStyle(tagIndex: number) {
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
   return (
     <ScrollFadeSection id="projects" className="min-h-screen flex flex-col justify-center py-14 px-8 bg-graphite-light">
-      <div className="max-w-7xl mx-auto w-full">
+      <div className="w-full">
         <div className="flex items-center gap-3 mb-8">
           <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 01</span>
           <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">PROJECTS</span>

--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -198,12 +198,12 @@ describe('SkillsSection', () => {
     expect(rows.every(row => /^(\d+|\d*\.\d+)fr$/.test(row))).toBe(true)
   })
 
-  it('grid stays within the max-w-7xl section container', () => {
+  it('grid spans full-width section (no max-w constraint)', () => {
     render(<SkillsSection />)
     const grid = screen.getByTestId('skills-grid')
 
     expect(grid.parentElement).not.toBeNull()
-    expect(grid.parentElement!.classList).toContain('max-w-7xl')
+    expect(grid.parentElement!.classList).not.toContain('max-w-7xl')
     expect(grid.parentElement!.classList).toContain('w-full')
   })
 

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -113,7 +113,7 @@ export function SkillsSection() {
 
   return (
     <ScrollFadeSection id="skills" className="min-h-screen flex flex-col justify-center py-14 px-8 bg-graphite">
-      <div className="max-w-7xl mx-auto w-full">
+      <div className="w-full">
         <div className="flex items-center gap-3 mb-12">
           <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 02</span>
           <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">SKILLS</span>

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -135,7 +135,7 @@ function SectionLabel({ label }: { label: 'EDUCATION' | 'EXPERIENCE' }) {
 const TimelineSection: React.FC = () => {
   return (
     <ScrollFadeSection id="timeline" className="min-h-screen flex flex-col justify-center py-14 px-8 bg-graphite-light">
-      <div className="max-w-7xl mx-auto w-full">
+      <div className="w-full">
         <div className="flex items-center gap-3 mb-12">
           <span className="font-body text-sm text-atomic-tangerine tracking-widest whitespace-nowrap">// 03</span>
           <span className="font-body text-sm text-periwinkle tracking-widest whitespace-nowrap">TIMELINE</span>


### PR DESCRIPTION
**Purpose** — Establish the v4 portfolio shell so each major section spans the full browser width and composes as a full-viewport surface.

**What it does** — Removes centered section-shell constraints, keeps full-viewport section sizing, and strengthens regression tests around the rendered shell contract.

**Changes made**
- Updated Hero, Projects, Skills, Timeline, and Contact section wrappers to use full-width inner containers.
- Kept section surfaces on `min-h-screen` with viewport-spanning backgrounds.
- Added App shell coverage for section ordering, full-viewport surfaces, and absence of centered shell constraints.
- Updated Skills section coverage for the full-width grid container.

**Additional notes** — Navbar alignment remains independently constrained by its existing nav container; this slice only changes the portfolio section shell.

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated layout behavior across multiple sections (Contact, Hero, Projects, Skills, Timeline) to adjust width constraints.

* **Tests**
  * Enhanced test coverage to verify section layout structure and constraint validation across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->