### PR TITLE
useHorizontalScroll hook

### DIFF
--- a/src/hooks/useHorizontalScroll.test.tsx
+++ b/src/hooks/useHorizontalScroll.test.tsx
@@ -35,14 +35,15 @@ function renderHorizontalScrollHook({
   outerHeight,
   innerScrollWidth,
 }: {
-  outerTop: number
+  outerTop: number | (() => number)
   outerHeight: number
   innerScrollWidth: number
 }) {
   const outer = document.createElement('section')
   const inner = document.createElement('div')
+  const getOuterTop = typeof outerTop === 'function' ? outerTop : () => outerTop
 
-  outer.getBoundingClientRect = vi.fn(() => createRect(outerTop, outerHeight))
+  outer.getBoundingClientRect = vi.fn(() => createRect(getOuterTop(), outerHeight))
   Object.defineProperty(inner, 'scrollWidth', {
     configurable: true,
     value: innerScrollWidth,
@@ -98,5 +99,52 @@ describe('useHorizontalScroll', () => {
     act(() => window.dispatchEvent(new Event('scroll')))
 
     expect(result.current).toEqual({ progress: 1, tx: -1600 })
+  })
+
+  it('returns zero translate when the inner track does not overflow the viewport', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: -800,
+      outerHeight: 2400,
+      innerScrollWidth: 800,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current).toEqual({ progress: 0.5, tx: 0 })
+  })
+
+  it('returns zero progress when the outer container has no vertical scroll range', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: -300,
+      outerHeight: 600,
+      innerScrollWidth: 2600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current).toEqual({ progress: 0, tx: 0 })
+  })
+
+  it('recalculates translate from the current viewport width on resize', () => {
+    setViewport(1000, 800)
+    const outerTop = -800
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: () => outerTop,
+      outerHeight: 2400,
+      innerScrollWidth: 2600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+    expect(result.current).toEqual({ progress: 0.5, tx: -800 })
+
+    setViewport(1200, 800)
+    act(() => window.dispatchEvent(new Event('resize')))
+
+    expect(result.current).toEqual({ progress: 0.5, tx: -700 })
   })
 })

--- a/src/hooks/useHorizontalScroll.test.tsx
+++ b/src/hooks/useHorizontalScroll.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useRef } from 'react'
+import { useHorizontalScroll } from './useHorizontalScroll'
+
+function setViewport(width: number, height: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value: height,
+  })
+}
+
+function createRect(top: number, height: number): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: window.innerWidth,
+    width: window.innerWidth,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
+function renderHorizontalScrollHook({
+  outerTop,
+  outerHeight,
+  innerScrollWidth,
+}: {
+  outerTop: number
+  outerHeight: number
+  innerScrollWidth: number
+}) {
+  const outer = document.createElement('section')
+  const inner = document.createElement('div')
+
+  outer.getBoundingClientRect = vi.fn(() => createRect(outerTop, outerHeight))
+  Object.defineProperty(inner, 'scrollWidth', {
+    configurable: true,
+    value: innerScrollWidth,
+  })
+
+  return renderHook(() => {
+    const outerRef = useRef<HTMLElement>(outer)
+    const innerRef = useRef<HTMLElement>(inner)
+
+    return useHorizontalScroll(outerRef, innerRef)
+  })
+}
+
+describe('useHorizontalScroll', () => {
+  it('returns 0.5 progress and half the horizontal offset midway through the section', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: -800,
+      outerHeight: 2400,
+      innerScrollWidth: 2600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current.progress).toBe(0.5)
+    expect(result.current.tx).toBe(-800)
+  })
+
+  it('returns zero progress and translate before the outer container enters the viewport', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: 800,
+      outerHeight: 2400,
+      innerScrollWidth: 2600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current).toEqual({ progress: 0, tx: 0 })
+  })
+
+  it('returns full progress and max translate after the outer container scrolls fully past', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: -1600,
+      outerHeight: 2400,
+      innerScrollWidth: 2600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current).toEqual({ progress: 1, tx: -1600 })
+  })
+})

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState, type RefObject } from 'react'
+
+interface HorizontalScrollState {
+  tx: number
+  progress: number
+}
+
+function clamp01(value: number) {
+  return Math.min(Math.max(value, 0), 1)
+}
+
+function getHorizontalScrollState(
+  outer: HTMLElement | null,
+  inner: HTMLElement | null
+): HorizontalScrollState {
+  if (!outer || !inner) {
+    return { tx: 0, progress: 0 }
+  }
+
+  const rect = outer.getBoundingClientRect()
+  const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
+  const scrollRange = Math.max(rect.height - viewportHeight, 0)
+  const progress = scrollRange === 0 ? 0 : clamp01(-rect.top / scrollRange)
+  const trackWidth = Math.max(inner.scrollWidth - viewportWidth, 0)
+  const tx = progress === 0 ? 0 : -(progress * trackWidth)
+
+  return {
+    progress,
+    tx,
+  }
+}
+
+export function useHorizontalScroll(
+  outerRef: RefObject<HTMLElement>,
+  innerRef: RefObject<HTMLElement>
+): HorizontalScrollState {
+  const [state, setState] = useState<HorizontalScrollState>({ tx: 0, progress: 0 })
+
+  useEffect(() => {
+    const update = () => {
+      setState(getHorizontalScrollState(outerRef.current, innerRef.current))
+    }
+
+    update()
+
+    window.addEventListener('scroll', update, { passive: true })
+    window.addEventListener('resize', update)
+
+    return () => {
+      window.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+    }
+  }, [outerRef, innerRef])
+
+  return state
+}

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -23,7 +23,7 @@ function getHorizontalScrollState(
   const scrollRange = Math.max(rect.height - viewportHeight, 0)
   const progress = scrollRange === 0 ? 0 : clamp01(-rect.top / scrollRange)
   const trackWidth = Math.max(inner.scrollWidth - viewportWidth, 0)
-  const tx = progress === 0 ? 0 : -(progress * trackWidth)
+  const tx = progress === 0 || trackWidth === 0 ? 0 : -(progress * trackWidth)
 
   return {
     progress,


### PR DESCRIPTION
**Purpose** — Add a reusable hook that maps vertical section scroll progress to horizontal carousel translation.

**What it does** — Implements `useHorizontalScroll` with clamped raw progress and translateX derived from inner track overflow, plus focused tests for acceptance criteria and edge cases.

**Changes made**
- Added `src/hooks/useHorizontalScroll.ts` for scroll/resize-driven progress and tx state.
- Added `src/hooks/useHorizontalScroll.test.tsx` covering midpoint, pre-entry, fully scrolled, no overflow, no vertical scroll range, and resize recalculation behavior.
- Normalized zero-width track translation to `0` instead of JavaScript `-0`.

**Additional notes** — The hook returns raw clamped progress; callers remain responsible for any dead-zone clamping.

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added horizontal scroll tracking to enable scroll-based visual effects and dynamic content interactions across varying viewport sizes.

* **Tests**
  * Introduced comprehensive test suite validating scroll progress computation, translate calculations, and viewport resize handling to ensure consistent behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->