### PR TITLE
Hero: // PORTFOLIO_INIT label clearance + underline alignment

### DIFF
--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -37,6 +37,22 @@ describe('HeroSection', () => {
     expect(screen.getByText('FARHAN MOHAMMED')).toBeInTheDocument()
   })
 
+  it('keeps the init label clear of the navbar and aligns its underline to the leading slashes', () => {
+    render(<HeroSection />)
+
+    const content = screen.getByTestId('hero-content')
+    const labelUnit = screen.getByTestId('hero-init-label-unit')
+    const label = screen.getByText('// PORTFOLIO_INIT')
+    const underline = screen.getByTestId('hero-init-label-underline')
+
+    expect(content).toHaveClass('pt-16')
+    expect(labelUnit).toContainElement(label)
+    expect(labelUnit).toContainElement(underline)
+    expect(label.textContent?.startsWith('//')).toBe(true)
+    expect(label.nextElementSibling).toBe(underline)
+    expect(underline).toHaveClass('ml-0')
+  })
+
   it('subtitle and value prop are empty initially', () => {
     render(<HeroSection />)
 

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -46,6 +46,7 @@ describe('HeroSection', () => {
     const underline = screen.getByTestId('hero-init-label-underline')
 
     expect(content).toHaveClass('pt-16')
+    expect(labelUnit).toHaveClass('w-fit')
     expect(labelUnit).toContainElement(label)
     expect(labelUnit).toContainElement(underline)
     expect(label.textContent?.startsWith('//')).toBe(true)

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -84,12 +84,12 @@ const HeroSection: React.FC = () => {
         <div className="absolute inset-0 bg-[radial-gradient(#3A3B3A_1px,transparent_1px)] bg-[size:20px_20px]"></div>
       </div>
 
-      <div className="relative z-10 px-8 w-full space-y-6">
-        <div className="space-y-2">
+      <div data-testid="hero-content" className="relative z-10 px-8 pt-16 w-full space-y-6">
+        <div data-testid="hero-init-label-unit" className="space-y-2 w-fit">
           <p className="font-body text-xs text-atomic-tangerine tracking-widest">
             // PORTFOLIO_INIT
           </p>
-          <div className="w-8 h-0.5 bg-atomic-tangerine" />
+          <div data-testid="hero-init-label-underline" className="ml-0 w-8 h-0.5 bg-atomic-tangerine" />
         </div>
 
         <h1 className="font-display text-5xl text-platinum leading-tight">


### PR DESCRIPTION
**Purpose** — Fix the hero init label so it reads as hero content and its underline aligns with the leading slashes.

**What it does** — Adds top clearance to the hero content column, keeps the init label and underline in one fitted unit, and locks the underline to the same left origin.

**Changes made**
- Updated `src/components/HeroSection.tsx` with hero content padding and a paired init label unit.
- Updated `src/components/HeroSection.test.tsx` to cover navbar clearance, shared label unit ownership, and underline alignment.

**Additional notes** — Review pass tightened the test around the fitted label unit; no functional behavior was changed beyond the issue fix. Verified with `npm run typecheck` and `npm run test`.

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for HeroSection component layout and markup structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->