### PR TITLE
Navbar: active link — orange text + underline scoped to label element only

### DIFF
--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -104,6 +104,7 @@ describe('Navbar', () => {
     afterEach(() => {
       vi.unstubAllGlobals()
       document.body.removeChild(section)
+      document.getElementById('projects')?.remove()
     })
 
     it('scopes active color and underline to the label span only', () => {
@@ -126,6 +127,40 @@ describe('Navbar', () => {
       expect(skillsLabel).toHaveClass('border-b-2')
       expect(skillsLabel).toHaveClass('border-atomic-tangerine')
       expect(skillsLink!.querySelector('[data-testid="nav-caret"]')).toBeNull()
+    })
+
+    it('restores inactive link caret and removes label underline when active section changes', () => {
+      const projectsSection = document.createElement('section')
+      projectsSection.id = 'projects'
+      document.body.appendChild(projectsSection)
+
+      render(<Navbar />)
+
+      act(() => {
+        observerCallback(
+          [{ target: section, isIntersecting: true } as unknown as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        )
+      })
+
+      act(() => {
+        observerCallback(
+          [{ target: projectsSection, isIntersecting: true } as unknown as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        )
+      })
+
+      const skillsLink = screen.getByText('SKILLS').closest('a')
+      const skillsLabel = screen.getByText('SKILLS')
+      const projectsLink = screen.getByText('PROJECTS').closest('a')
+      const projectsLabel = screen.getByText('PROJECTS')
+
+      expect(skillsLink!.querySelector('[data-testid="nav-caret"]')).not.toBeNull()
+      expect(skillsLabel).not.toHaveClass('text-atomic-tangerine')
+      expect(skillsLabel).not.toHaveClass('border-b-2')
+      expect(projectsLink!.querySelector('[data-testid="nav-caret"]')).toBeNull()
+      expect(projectsLabel).toHaveClass('text-atomic-tangerine')
+      expect(projectsLabel).toHaveClass('border-b-2')
     })
   })
 

--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -106,7 +106,7 @@ describe('Navbar', () => {
       document.body.removeChild(section)
     })
 
-    it('applies active underline class to link matching the intersecting section', () => {
+    it('scopes active color and underline to the label span only', () => {
       render(<Navbar />)
 
       act(() => {
@@ -118,8 +118,14 @@ describe('Navbar', () => {
 
       const skillsLink = screen.getByText('SKILLS').closest('a')
       expect(skillsLink).not.toBeNull()
-      expect(skillsLink!.className).toContain('border-b-2')
-      expect(skillsLink!.className).toContain('border-atomic-tangerine')
+      const skillsLabel = screen.getByText('SKILLS')
+
+      expect(skillsLink!.className).not.toContain('border-b-2')
+      expect(skillsLink!.className).not.toContain('border-atomic-tangerine')
+      expect(skillsLabel).toHaveClass('text-atomic-tangerine')
+      expect(skillsLabel).toHaveClass('border-b-2')
+      expect(skillsLabel).toHaveClass('border-atomic-tangerine')
+      expect(skillsLink!.querySelector('[data-testid="nav-caret"]')).toBeNull()
     })
   })
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -53,15 +53,20 @@ export default function Navbar() {
                     whileHover="hover"
                     onMouseEnter={() => setHoveredLink(label)}
                     onMouseLeave={() => setHoveredLink(null)}
-                    className={`group font-body text-sm no-underline pb-0.5 transition-colors duration-150${isActive ? ' text-atomic-tangerine border-b-2 border-atomic-tangerine' : ' text-platinum'}`}
+                    className="group font-body text-sm no-underline pb-0.5 text-platinum transition-colors duration-150"
                   >
-                    <span
-                      style={{ opacity: isHovered ? 1 : 0 }}
-                      className="transition-opacity duration-200"
-                    >
-                      &gt;{' '}
+                    {!isActive && (
+                      <span
+                        data-testid="nav-caret"
+                        style={{ opacity: isHovered ? 1 : 0 }}
+                        className="transition-opacity duration-200"
+                      >
+                        &gt;{' '}
+                      </span>
+                    )}
+                    <span className={isActive ? 'text-atomic-tangerine border-b-2 border-atomic-tangerine' : undefined}>
+                      {label}
                     </span>
-                    {label}
                   </motion.a>
                 </li>
               )


### PR DESCRIPTION
**Purpose** — Fix the desktop navbar active-link styling so the orange underline applies only to the nav label text.

**What it does** — Moves active text color and underline styling to the label span while keeping the caret hover-only and absent for active links.

**Changes made**
- Updated src/components/Navbar.tsx to render the active underline on the label span instead of the anchor.
- Updated src/components/Navbar.test.tsx to verify active label styling, anchor underline absence, active caret absence, and active-state transitions.

**Additional notes** — The caret span is not rendered for active links, so the active underline cannot extend into the caret gutter. Verified with npm run typecheck and npm run test.

Closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated active-section tests to verify visual styling is applied to navigation labels and caret visibility toggles with section changes.
  * Added coverage for switching active sections and DOM cleanup after tests.

* **Refactor**
  * Simplified desktop navigation rendering and moved active/inactive styling into a dedicated label element for clearer, more consistent visuals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->