### PR TITLE
Global: orange scrollbar thumb + ::selection styling

### DIFF
--- a/src/index-css.test.ts
+++ b/src/index-css.test.ts
@@ -1,0 +1,32 @@
+/// <reference types="node" />
+
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const cssPath = join(dirname(fileURLToPath(import.meta.url)), 'index.css')
+const css = readFileSync(cssPath, 'utf8')
+
+function blockFor(selector: string) {
+  const match = css.match(new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{([^}]*)\\}`))
+  expect(match).not.toBeNull()
+  return match?.[1] ?? ''
+}
+
+describe('global CSS brand chrome', () => {
+  it('keeps canonical color tokens available', () => {
+    expect(blockFor('@theme')).toContain('--color-graphite: #2A2B2A;')
+    expect(blockFor('@theme')).toContain('--color-atomic-tangerine: #FF8547;')
+    expect(css).toContain('--graphite: var(--color-graphite);')
+    expect(css).toContain('--orange: var(--color-atomic-tangerine);')
+  })
+
+  it('uses orange and graphite tokens for scrollbar and selection styling', () => {
+    expect(blockFor('::-webkit-scrollbar')).toContain('width: 8px;')
+    expect(blockFor('::-webkit-scrollbar-track')).toContain('background: var(--graphite);')
+    expect(blockFor('::-webkit-scrollbar-thumb')).toContain('background: var(--orange);')
+    expect(blockFor('::selection')).toContain('background-color: var(--orange);')
+    expect(blockFor('::selection')).toContain('color: var(--graphite);')
+  })
+})

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,11 @@
   --font-body: 'Space Mono', monospace;
 }
 
+:root {
+  --graphite: var(--color-graphite);
+  --orange: var(--color-atomic-tangerine);
+}
+
 html {
   scroll-behavior: smooth;
 }
@@ -23,12 +28,17 @@ html {
 }
 
 ::-webkit-scrollbar-track {
-  background: #2A2B2A;
+  background: var(--graphite);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #FF8547;
+  background: var(--orange);
   border-radius: 4px;
+}
+
+::selection {
+  background-color: var(--orange);
+  color: var(--graphite);
 }
 
 body {


### PR DESCRIPTION
**Purpose** — Add global brand styling for scrollbars and text selection.

**What it does** — Uses existing graphite and atomic tangerine theme colors through global aliases for scrollbar track/thumb styling and `::selection`.

**Changes made**
- `src/index.css`: adds `--graphite` and `--orange` aliases, applies them to WebKit scrollbar chrome, and adds orange-on-graphite text selection styling.
- `src/index-css.test.ts`: adds coverage for preserved canonical color tokens plus scrollbar and selection CSS rules.

**Additional notes** — No review refinements were needed after testing; `.prompts/CODING_STANDARDS.md` was not present in this checkout.

Closes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added styling validation tests to verify color variables and visual elements are properly configured.

* **Style**
  * Updated color variable handling in stylesheets for improved maintainability and consistency across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->