### PR TITLE
Hero: dot-grid parallax + app-level RAF scroll listener

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { act, render } from '@testing-library/react'
 import App from './App'
 
 const sections = ['home', 'projects', 'skills', 'timeline', 'contact'] as const
@@ -12,6 +12,10 @@ function expectNoShellConstraint(element: Element) {
 }
 
 describe('App shell', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it.each(sections)('renders %s section', (id) => {
     render(<App />)
     const section = document.getElementById(id)
@@ -52,5 +56,65 @@ describe('App shell', () => {
       expect(section.className).toContain('sticky')
       expect(Number((section as HTMLElement).style.zIndex)).toBeLessThan(40)
     })
+  })
+
+  it('initializes one RAF-batched parallax scroll listener and cleans it up', () => {
+    let nextFrameId = 1
+    const frameCallbacks = new Map<number, FrameRequestCallback>()
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        const frameId = nextFrameId
+        nextFrameId += 1
+        frameCallbacks.set(frameId, callback)
+        return frameId
+      })
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation((frameId) => {
+        frameCallbacks.delete(frameId)
+      })
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener')
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
+
+    const { unmount } = render(<App />)
+    const dotGrid = document.querySelector('[data-testid="hero-dot-grid"]') as HTMLElement
+    const homeSection = document.getElementById('home') as HTMLElement
+
+    vi.spyOn(homeSection, 'getBoundingClientRect').mockReturnValue({
+      top: -120,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: -120,
+      toJSON: () => ({}),
+    })
+
+    act(() => {
+      frameCallbacks.get(1)?.(0)
+      frameCallbacks.delete(1)
+    })
+
+    expect(dotGrid.style.transform).toBe('translate3d(0, 36px, 0)')
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(2)
+    expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true })
+    expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function), { passive: true })
+
+    const scrollHandler = addEventListenerSpy.mock.calls.find(([eventName]) => eventName === 'scroll')?.[1]
+    act(() => {
+      window.dispatchEvent(new Event('scroll'))
+      window.dispatchEvent(new Event('scroll'))
+    })
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(2)
+
+    unmount()
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', scrollHandler)
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(2)
   })
 })

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,6 +11,20 @@ function expectNoShellConstraint(element: Element) {
   })
 }
 
+function rectAtTop(top: number): DOMRect {
+  return {
+    top,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    width: 0,
+    height: 0,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
 describe('App shell', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -81,17 +95,7 @@ describe('App shell', () => {
     const dotGrid = document.querySelector('[data-testid="hero-dot-grid"]') as HTMLElement
     const homeSection = document.getElementById('home') as HTMLElement
 
-    vi.spyOn(homeSection, 'getBoundingClientRect').mockReturnValue({
-      top: -120,
-      right: 0,
-      bottom: 0,
-      left: 0,
-      width: 0,
-      height: 0,
-      x: 0,
-      y: -120,
-      toJSON: () => ({}),
-    })
+    vi.spyOn(homeSection, 'getBoundingClientRect').mockReturnValue(rectAtTop(-120))
 
     act(() => {
       frameCallbacks.get(1)?.(0)
@@ -116,5 +120,55 @@ describe('App shell', () => {
     expect(removeEventListenerSpy).toHaveBeenCalledWith('scroll', scrollHandler)
     expect(removeEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function))
     expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(2)
+  })
+
+  it('uses element geometry for parallax layers outside sections', () => {
+    const frameCallbacks = new Map<number, FrameRequestCallback>()
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallbacks.set(1, callback)
+      return 1
+    })
+
+    render(<App />)
+    const footerText = document.querySelector('footer [data-parallax]') as HTMLElement
+
+    vi.spyOn(footerText, 'getBoundingClientRect').mockReturnValue(rectAtTop(-80))
+
+    act(() => {
+      frameCallbacks.get(1)?.(0)
+    })
+
+    expect(footerText.style.transform).toBe('translate3d(0, 40px, 0)')
+  })
+
+  it('treats missing and invalid parallax factors as zero movement', () => {
+    const frameCallbacks = new Map<number, FrameRequestCallback>()
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallbacks.set(1, callback)
+      return 1
+    })
+
+    render(<App />)
+    const missingFactorLayer = document.createElement('div')
+    const invalidFactorLayer = document.createElement('div')
+    missingFactorLayer.dataset.parallax = ''
+    invalidFactorLayer.dataset.parallax = ''
+    invalidFactorLayer.dataset.parallaxFactor = 'not-a-number'
+    document.body.append(missingFactorLayer, invalidFactorLayer)
+
+    vi.spyOn(missingFactorLayer, 'getBoundingClientRect').mockReturnValue(rectAtTop(-120))
+    vi.spyOn(invalidFactorLayer, 'getBoundingClientRect').mockReturnValue(rectAtTop(-120))
+
+    try {
+      act(() => {
+        frameCallbacks.get(1)?.(0)
+      })
+
+      expect(missingFactorLayer.style.transform).toBe('translate3d(0, 0px, 0)')
+      expect(invalidFactorLayer.style.transform).toBe('translate3d(0, 0px, 0)')
+    } finally {
+      missingFactorLayer.remove()
+      invalidFactorLayer.remove()
+    }
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/react'
@@ -14,6 +14,53 @@ import { projects } from './data/projects'
 
 function App() {
   const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let frameId: number | null = null
+
+    const updateParallax = () => {
+      const parallaxLayers = Array.from(document.querySelectorAll<HTMLElement>('[data-parallax]'))
+      const layerUpdates = parallaxLayers.map((layer) => {
+        const factor = Number(layer.dataset.parallaxFactor ?? 0)
+        const section = layer.closest('section')
+        const sectionRect = section?.getBoundingClientRect()
+        const scrollOffset = sectionRect ? -sectionRect.top : -layer.getBoundingClientRect().top
+
+        return {
+          layer,
+          offset: scrollOffset * (Number.isFinite(factor) ? factor : 0),
+        }
+      })
+
+      layerUpdates.forEach(({ layer, offset }) => {
+        layer.style.transform = `translate3d(0, ${offset}px, 0)`
+      })
+    }
+
+    const requestParallaxUpdate = () => {
+      if (frameId !== null) {
+        return
+      }
+
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null
+        updateParallax()
+      })
+    }
+
+    window.addEventListener('scroll', requestParallaxUpdate, { passive: true })
+    window.addEventListener('resize', requestParallaxUpdate, { passive: true })
+    requestParallaxUpdate()
+
+    return () => {
+      window.removeEventListener('scroll', requestParallaxUpdate)
+      window.removeEventListener('resize', requestParallaxUpdate)
+
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId)
+      }
+    }
+  }, [])
 
   return (
     <>

--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -86,4 +86,14 @@ describe('Footer', () => {
     expect(footer).not.toHaveTextContent('SEND_MESSAGE →')
     expect(footer?.querySelectorAll('a, button, input, select, textarea, [tabindex]').length).toBe(0)
   })
+
+  it('marks footer text as a stronger parallax layer', () => {
+    render(<ContactSection />)
+    const footerText = Array.from(document.querySelectorAll('footer [data-parallax]'))
+
+    expect(footerText).toHaveLength(2)
+    footerText.forEach((item) => {
+      expect(item).toHaveAttribute('data-parallax-factor', '0.5')
+    })
+  })
 })

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -52,8 +52,12 @@ export default function ContactSection() {
       </StickySection>
 
       <footer className="flex justify-between items-center px-8 py-8 border-t border-periwinkle/20 text-xs font-body text-periwinkle bg-graphite">
-        <span>FARHAN_MOHAMMED © 2026</span>
-        <span>PORTFOLIO.EXE</span>
+        <span data-parallax data-parallax-factor="0.5">
+          FARHAN_MOHAMMED © 2026
+        </span>
+        <span data-parallax data-parallax-factor="0.5">
+          PORTFOLIO.EXE
+        </span>
       </footer>
     </>
   )

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -54,6 +54,14 @@ describe('HeroSection', () => {
     expect(underline).toHaveClass('ml-0')
   })
 
+  it('marks the dot grid as a slow parallax layer', () => {
+    render(<HeroSection />)
+    const dotGrid = screen.getByTestId('hero-dot-grid')
+
+    expect(dotGrid).toHaveAttribute('data-parallax')
+    expect(dotGrid).toHaveAttribute('data-parallax-factor', '0.3')
+  })
+
   it('subtitle and value prop are empty initially', () => {
     render(<HeroSection />)
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -81,7 +81,12 @@ const HeroSection: React.FC = () => {
   return (
     <StickySection id="home" className="relative flex flex-col justify-center bg-graphite">
       <div className="absolute inset-0 pointer-events-none">
-        <div className="absolute inset-0 bg-[radial-gradient(#3A3B3A_1px,transparent_1px)] bg-[size:20px_20px]"></div>
+        <div
+          data-testid="hero-dot-grid"
+          data-parallax
+          data-parallax-factor="0.3"
+          className="absolute inset-0 bg-[radial-gradient(#3A3B3A_1px,transparent_1px)] bg-[size:20px_20px]"
+        ></div>
       </div>
 
       <div data-testid="hero-content" className="relative z-10 px-8 pt-16 w-full space-y-6">


### PR DESCRIPTION
**Purpose** — Add depth to the hero and footer by driving parallax transforms from one App-level scroll pipeline.

**What it does** — Initializes a single passive scroll/resize listener in `App.tsx`, batches updates through `requestAnimationFrame`, reads parallax layer geometry before writing `translate3d` transforms, and marks the hero dot grid plus footer text with parallax factors.

**Changes made**
- `src/App.tsx`: adds App-level RAF-batched parallax listener with cleanup.
- `src/components/HeroSection.tsx`: marks the dot grid as a slow parallax layer.
- `src/components/ContactSection.tsx`: marks footer text as stronger parallax layers.
- `src/App.test.tsx`: covers listener setup/cleanup, section-relative movement, non-section fallback geometry, and invalid factor handling.
- `src/components/HeroSection.test.tsx` and `src/components/ContactSection.test.tsx`: verify parallax layer attributes.

**Additional notes** — Review added edge coverage only; no implementation changes were needed after stress-testing the current behavior. Verified with `npm run typecheck` and `npm run test`.

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parallax scrolling added: hero dot grid and footer items now shift at distinct speeds for added visual depth and motion.

* **Tests**
  * Test coverage expanded to verify parallax initialization, layer-specific movement, handling of missing/invalid parallax factors, and proper cleanup on unmount.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->