### PR TITLE
fix: implement newest-first timeline ordering (issue #78)

### DIFF
--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -60,15 +60,18 @@ describe('TimelineSection', () => {
 
     const commitEntries = screen.getAllByTestId('commit-entry')
 
-    expect(commitEntries[0].querySelector('ul')).not.toBeInTheDocument()
-    expect(commitEntries[0].querySelectorAll('li')).toHaveLength(0)
+    // NetApp (index 0) has 4 bullets
+    expect(commitEntries[0].querySelectorAll('ul')).toHaveLength(1)
+    expect(commitEntries[0].querySelectorAll('li')).toHaveLength(4)
+    expect(commitEntries[0].querySelectorAll('ul p')).toHaveLength(0)
 
-    expect(commitEntries[1].querySelectorAll('ul')).toHaveLength(1)
-    expect(commitEntries[1].querySelectorAll('li')).toHaveLength(2)
-    expect(commitEntries[1].querySelectorAll('ul p')).toHaveLength(0)
+    // M.S. (index 1) has 0 bullets
+    expect(commitEntries[1].querySelector('ul')).not.toBeInTheDocument()
+    expect(commitEntries[1].querySelectorAll('li')).toHaveLength(0)
 
+    // B.S. (index 2) has 2 bullets
     expect(commitEntries[2].querySelectorAll('ul')).toHaveLength(1)
-    expect(commitEntries[2].querySelectorAll('li')).toHaveLength(4)
+    expect(commitEntries[2].querySelectorAll('li')).toHaveLength(2)
     expect(commitEntries[2].querySelectorAll('ul p')).toHaveLength(0)
   })
 
@@ -81,31 +84,41 @@ describe('TimelineSection', () => {
 
     const bulletTexts = screen.getAllByTestId('commit-description').map(li => li.textContent)
 
+    // Newest-first: NetApp bullets first, then B.S. bullets
     expect(bulletTexts).toEqual([
-      "Dean's List: Spring 2022 – Fall 2025",
-      'Relevant Coursework: Machine Learning, Artificial Intelligence, Fundamentals of AI Agents, Data Science',
       'Built automated analysis pipeline processing storage telemetry across distributed RAID systems (FC, SAS, NVMe/RoCE), handling terabytes of performance data.',
       'Designed Python automation framework reducing manual configuration tasks by 30% across Linux, Windows, and VMware infrastructure.',
       'Implemented Ansible-based deployment orchestration for 300+ system configurations, streamlining infrastructure provisioning workflows.',
       'Developed interactive visualization dashboard for system performance metrics using Python, analyzing 1M+ database entries for engineering insights.',
+      "Dean's List: Spring 2022 – Fall 2025",
+      'Relevant Coursework: Machine Learning, Artificial Intelligence, Fundamentals of AI Agents, Data Science',
     ])
   })
 
-  it('renders timeline section labels in pixel display typography', () => {
-    render(<TimelineSection />)
+  describe('issue #78 - newest-first ordering', () => {
+    it('entries render in newest-first order (NetApp before M.S. before B.S.)', () => {
+      vi.mocked(useInView).mockReturnValue(true)
+      vi.useFakeTimers()
 
-    const labels = ['EDUCATION', 'EXPERIENCE']
+      render(<TimelineSection />)
+      act(() => { vi.advanceTimersByTime(15000) })
 
-    labels.forEach(label => {
-      const labelElement = screen.getByText(label)
-      const slashElement = labelElement.previousElementSibling
+      const institutions = screen.getAllByTestId('commit-institution')
+      expect(institutions[0].textContent).toBe('NETAPP INC.')
+      expect(institutions[1].textContent).toBe('WICHITA STATE UNIVERSITY')
+      expect(institutions[2].textContent).toBe('WICHITA STATE UNIVERSITY')
 
-      expect(slashElement).toHaveTextContent('//')
-      expect(slashElement).toHaveClass('font-display', 'text-xs', 'text-atomic-tangerine')
-      expect(slashElement).not.toHaveClass('font-body')
+      const roles = screen.getAllByTestId('commit-role')
+      expect(roles[0].textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+      expect(roles[1].textContent).toBe('ACCELERATED_M.S._COMPUTER_SCIENCE')
+      expect(roles[2].textContent).toBe('B.S._COMPUTER_SCIENCE')
+    })
 
-      expect(labelElement).toHaveClass('font-display', 'text-sm', 'text-atomic-tangerine')
-      expect(labelElement).not.toHaveClass('font-body')
+    it('does not render Education/Experience subsection headings', () => {
+      render(<TimelineSection />)
+
+      expect(screen.queryByText('EDUCATION')).not.toBeInTheDocument()
+      expect(screen.queryByText('EXPERIENCE')).not.toBeInTheDocument()
     })
   })
 
@@ -134,28 +147,28 @@ describe('TimelineSection', () => {
       act(() => { vi.advanceTimersByTime(15000) })
 
       const hashes = screen.getAllByTestId('commit-hash')
-      expect(hashes[0].textContent).toBe('commit a3f9d2b')
-      expect(hashes[1].textContent).toBe('commit b7c3e1a')
-      expect(hashes[2].textContent).toBe('commit d4e8f2c')
+      expect(hashes[0].textContent).toBe('commit d4e8f2c')
+      expect(hashes[1].textContent).toBe('commit a3f9d2b')
+      expect(hashes[2].textContent).toBe('commit b7c3e1a')
 
       screen.getAllByTestId('commit-author').forEach(el => {
         expect(el.textContent).toBe('Author: Farhan Mohammed')
       })
 
       const dates = screen.getAllByTestId('commit-date')
-      expect(dates[0].textContent).toBe('Date:   JAN 2026 – DEC 2027 (EXPECTED)')
-      expect(dates[1].textContent).toBe('Date:   JAN 2022 – DEC 2025')
-      expect(dates[2].textContent).toBe('Date:   AUG 2024 – PRESENT')
+      expect(dates[0].textContent).toBe('Date:   AUG 2024 – PRESENT')
+      expect(dates[1].textContent).toBe('Date:   JAN 2026 – DEC 2027 (EXPECTED)')
+      expect(dates[2].textContent).toBe('Date:   JAN 2022 – DEC 2025')
 
       const institutions = screen.getAllByTestId('commit-institution')
-      expect(institutions[0].textContent).toBe('WICHITA STATE UNIVERSITY')
+      expect(institutions[0].textContent).toBe('NETAPP INC.')
       expect(institutions[1].textContent).toBe('WICHITA STATE UNIVERSITY')
-      expect(institutions[2].textContent).toBe('NETAPP INC.')
+      expect(institutions[2].textContent).toBe('WICHITA STATE UNIVERSITY')
 
       const roles = screen.getAllByTestId('commit-role')
-      expect(roles[0].textContent).toBe('ACCELERATED_M.S._COMPUTER_SCIENCE')
-      expect(roles[1].textContent).toBe('B.S._COMPUTER_SCIENCE')
-      expect(roles[2].textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+      expect(roles[0].textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+      expect(roles[1].textContent).toBe('ACCELERATED_M.S._COMPUTER_SCIENCE')
+      expect(roles[2].textContent).toBe('B.S._COMPUTER_SCIENCE')
     })
 
     it('does not render the superseded M.S. date range', () => {

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -10,7 +10,19 @@ interface TimelineEntry {
   bullets: string[]
 }
 
-const education: TimelineEntry[] = [
+const timelineEntries: TimelineEntry[] = [
+  {
+    hash: 'd4e8f2c',
+    dateRange: 'AUG 2024 – PRESENT',
+    institution: 'NETAPP INC.',
+    role: 'SOFTWARE_ENGINEER_IN_TEST',
+    bullets: [
+      'Built automated analysis pipeline processing storage telemetry across distributed RAID systems (FC, SAS, NVMe/RoCE), handling terabytes of performance data.',
+      'Designed Python automation framework reducing manual configuration tasks by 30% across Linux, Windows, and VMware infrastructure.',
+      'Implemented Ansible-based deployment orchestration for 300+ system configurations, streamlining infrastructure provisioning workflows.',
+      'Developed interactive visualization dashboard for system performance metrics using Python, analyzing 1M+ database entries for engineering insights.',
+    ],
+  },
   {
     hash: 'a3f9d2b',
     dateRange: 'JAN 2026 – DEC 2027 (EXPECTED)',
@@ -26,21 +38,6 @@ const education: TimelineEntry[] = [
     bullets: [
       "Dean's List: Spring 2022 – Fall 2025",
       "Relevant Coursework: Machine Learning, Artificial Intelligence, Fundamentals of AI Agents, Data Science",
-    ],
-  },
-]
-
-const experience: TimelineEntry[] = [
-  {
-    hash: 'd4e8f2c',
-    dateRange: 'AUG 2024 – PRESENT',
-    institution: 'NETAPP INC.',
-    role: 'SOFTWARE_ENGINEER_IN_TEST',
-    bullets: [
-      'Built automated analysis pipeline processing storage telemetry across distributed RAID systems (FC, SAS, NVMe/RoCE), handling terabytes of performance data.',
-      'Designed Python automation framework reducing manual configuration tasks by 30% across Linux, Windows, and VMware infrastructure.',
-      'Implemented Ansible-based deployment orchestration for 300+ system configurations, streamlining infrastructure provisioning workflows.',
-      'Developed interactive visualization dashboard for system performance metrics using Python, analyzing 1M+ database entries for engineering insights.',
     ],
   },
 ]
@@ -163,14 +160,7 @@ function EntryList({ entries }: { entries: TimelineEntry[] }) {
   )
 }
 
-function SectionLabel({ label }: { label: 'EDUCATION' | 'EXPERIENCE' }) {
-  return (
-    <div className="flex items-center gap-1 mb-2">
-      <span className="font-display text-xs text-atomic-tangerine">//</span>
-      <span className="font-display text-sm text-atomic-tangerine">{label}</span>
-    </div>
-  )
-}
+
 
 const TimelineSection: React.FC = () => {
   return (
@@ -182,19 +172,7 @@ const TimelineSection: React.FC = () => {
           <hr className="flex-1 border-periwinkle/20" />
         </div>
 
-        <div className="space-y-12">
-          <div>
-            <SectionLabel label="EDUCATION" />
-            <hr className="border-periwinkle/10 mb-0" />
-            <EntryList entries={education} />
-          </div>
-
-          <div>
-            <SectionLabel label="EXPERIENCE" />
-            <hr className="border-periwinkle/10 mb-0" />
-            <EntryList entries={experience} />
-          </div>
-        </div>
+        <EntryList entries={timelineEntries} />
       </div>
     </StickySection>
   )


### PR DESCRIPTION
## Summary

Actually implemented issue #78 correctly this time:

- Combined separate `education` and `experience` arrays into single flat `timelineEntries` array
- Ordered entries newest-first: NetApp (Aug 2024-present) → M.S. (Jan 2026-Dec 2027) → B.S. (Jan 2022-Dec 2025)
- Removed Education/Experience subsection labels per issue requirements
- Updated tests to verify correct ordering and no subsection headings

## Changes

- `TimelineSection.tsx`: Combined arrays, removed section labels
- `TimelineSection.test.tsx`: Added new tests, fixed old tests to match correct behavior

## Verification

- `npm run typecheck` ✓
- `npm run test` ✓ (10 tests passed)

## Related Issue

Fixes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Timeline is now displayed as a single combined list instead of separate education and experience sections
  * Timeline entries are now ordered newest-first
  * Commit descriptions now render as bullet lists for improved readability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->