### PR TITLE
feat: TypeIn primitive component (issue #66)

### DIFF
--- a/src/animations/TypeIn.test.tsx
+++ b/src/animations/TypeIn.test.tsx
@@ -55,4 +55,78 @@ describe('TypeIn', () => {
 
     expect(onDone).not.toHaveBeenCalled()
   })
+
+  it('calls onDone immediately for empty text when start=true', () => {
+    const onDone = vi.fn()
+    render(<TypeIn start={true} text="" onDone={onDone} />)
+
+    act(() => { vi.advanceTimersByTime(10) })
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders empty span for empty text when start=true', () => {
+    const { container } = render(<TypeIn start={true} text="" />)
+
+    expect(container.querySelector('span')).toHaveTextContent('')
+  })
+
+  it('respects custom speed prop', () => {
+    render(<TypeIn start={true} text="AB" speed={100} />)
+
+    act(() => { vi.advanceTimersByTime(50) })
+    expect(screen.queryByText('A')).not.toBeInTheDocument()
+
+    act(() => { vi.advanceTimersByTime(60) })
+    expect(screen.getByText('A')).toBeInTheDocument()
+
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(screen.getByText('AB')).toBeInTheDocument()
+  })
+
+  it('calls onDone exactly once, not multiple times', () => {
+    const onDone = vi.fn()
+    render(<TypeIn start={true} text="AB" onDone={onDone} />)
+
+    act(() => { vi.advanceTimersByTime(200) })
+    expect(onDone).toHaveBeenCalledTimes(1)
+
+    act(() => { vi.advanceTimersByTime(500) })
+    expect(onDone).toHaveBeenCalledTimes(1)
+  })
+
+  it('restarts animation when start flips false then true', () => {
+    const { rerender } = render(<TypeIn start={true} text="ABC" />)
+
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(screen.getByText('AB')).toBeInTheDocument()
+
+    rerender(<TypeIn start={false} text="ABC" />)
+    expect(screen.queryByText('AB')).not.toBeInTheDocument()
+
+    rerender(<TypeIn start={true} text="ABC" />)
+
+    act(() => { vi.advanceTimersByTime(45) })
+    expect(screen.getByText('A')).toBeInTheDocument()
+  })
+
+  it('restarts with new text when text prop changes mid-animation', () => {
+    const { rerender } = render(<TypeIn start={true} text="Hello" />)
+
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(screen.getByText('He')).toBeInTheDocument()
+
+    rerender(<TypeIn start={true} text="XYZ" />)
+
+    act(() => { vi.advanceTimersByTime(45) })
+    expect(screen.getByText('X')).toBeInTheDocument()
+  })
+
+  it('handles special characters correctly', () => {
+    const specialText = '<>&"\''
+    render(<TypeIn start={true} text={specialText} />)
+
+    act(() => { vi.advanceTimersByTime(250) })
+    expect(screen.getByText(specialText)).toBeInTheDocument()
+  })
 })

--- a/src/animations/TypeIn.test.tsx
+++ b/src/animations/TypeIn.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { TypeIn } from './TypeIn'
+
+describe('TypeIn', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('given start=false, renders nothing', () => {
+    render(<TypeIn start={false} text="Hello World" />)
+    expect(screen.queryByText('Hello World')).not.toBeInTheDocument()
+  })
+
+  it('emits characters one at a time when start=true', () => {
+    render(<TypeIn start={true} text="AB" />)
+    
+    act(() => { vi.advanceTimersByTime(45) })
+    expect(screen.getByText('A')).toBeInTheDocument()
+    
+    act(() => { vi.advanceTimersByTime(45) })
+    expect(screen.getByText('AB')).toBeInTheDocument()
+  })
+
+  it('calls onDone when typing completes', () => {
+    const onDone = vi.fn()
+    render(<TypeIn start={true} text="X" onDone={onDone} />)
+
+    act(() => { vi.advanceTimersByTime(100) })
+    
+    // X is 1 char at 40ms = 40ms + buffer
+    expect(onDone).toHaveBeenCalled()
+  })
+
+  it('does not call onDone if start stays false', () => {
+    const onDone = vi.fn()
+    render(<TypeIn start={false} text="Hello" onDone={onDone} />)
+
+    act(() => { vi.advanceTimersByTime(10000) })
+
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  it('cleans up on unmount', () => {
+    const onDone = vi.fn()
+    const { unmount } = render(<TypeIn start={true} text="Hello" onDone={onDone} />)
+
+    act(() => { vi.advanceTimersByTime(20) })
+    unmount()
+    act(() => { vi.advanceTimersByTime(1000) })
+
+    expect(onDone).not.toHaveBeenCalled()
+  })
+})

--- a/src/animations/TypeIn.tsx
+++ b/src/animations/TypeIn.tsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react'
+
+interface TypeInProps {
+  start: boolean
+  text: string
+  speed?: number
+  onDone?: () => void
+}
+
+export function TypeIn({ start, text, speed = 40, onDone }: TypeInProps) {
+  const [displayed, setDisplayed] = useState('')
+
+  useEffect(() => {
+    if (!start) return
+
+    let cancelled = false
+    let currentIndex = 0
+
+    const tick = () => {
+      if (cancelled) return
+
+      if (currentIndex <= text.length) {
+        setDisplayed(text.slice(0, currentIndex))
+        currentIndex++
+
+        if (currentIndex <= text.length) {
+          setTimeout(tick, speed)
+        } else {
+          onDone?.()
+        }
+      }
+    }
+
+    tick()
+
+    return () => {
+      cancelled = true
+    }
+  }, [start, text, speed, onDone])
+
+  if (!start) return null
+
+  return <span>{displayed}</span>
+}

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -60,15 +60,18 @@ describe('TimelineSection', () => {
 
     const commitEntries = screen.getAllByTestId('commit-entry')
 
-    expect(commitEntries[0].querySelector('ul')).not.toBeInTheDocument()
-    expect(commitEntries[0].querySelectorAll('li')).toHaveLength(0)
+    // NetApp (index 0) has 4 bullets
+    expect(commitEntries[0].querySelectorAll('ul')).toHaveLength(1)
+    expect(commitEntries[0].querySelectorAll('li')).toHaveLength(4)
+    expect(commitEntries[0].querySelectorAll('ul p')).toHaveLength(0)
 
-    expect(commitEntries[1].querySelectorAll('ul')).toHaveLength(1)
-    expect(commitEntries[1].querySelectorAll('li')).toHaveLength(2)
-    expect(commitEntries[1].querySelectorAll('ul p')).toHaveLength(0)
+    // M.S. (index 1) has 0 bullets
+    expect(commitEntries[1].querySelector('ul')).not.toBeInTheDocument()
+    expect(commitEntries[1].querySelectorAll('li')).toHaveLength(0)
 
+    // B.S. (index 2) has 2 bullets
     expect(commitEntries[2].querySelectorAll('ul')).toHaveLength(1)
-    expect(commitEntries[2].querySelectorAll('li')).toHaveLength(4)
+    expect(commitEntries[2].querySelectorAll('li')).toHaveLength(2)
     expect(commitEntries[2].querySelectorAll('ul p')).toHaveLength(0)
   })
 
@@ -81,31 +84,41 @@ describe('TimelineSection', () => {
 
     const bulletTexts = screen.getAllByTestId('commit-description').map(li => li.textContent)
 
+    // Newest-first: NetApp bullets first, then B.S. bullets
     expect(bulletTexts).toEqual([
-      "Dean's List: Spring 2022 – Fall 2025",
-      'Relevant Coursework: Machine Learning, Artificial Intelligence, Fundamentals of AI Agents, Data Science',
       'Built automated analysis pipeline processing storage telemetry across distributed RAID systems (FC, SAS, NVMe/RoCE), handling terabytes of performance data.',
       'Designed Python automation framework reducing manual configuration tasks by 30% across Linux, Windows, and VMware infrastructure.',
       'Implemented Ansible-based deployment orchestration for 300+ system configurations, streamlining infrastructure provisioning workflows.',
       'Developed interactive visualization dashboard for system performance metrics using Python, analyzing 1M+ database entries for engineering insights.',
+      "Dean's List: Spring 2022 – Fall 2025",
+      'Relevant Coursework: Machine Learning, Artificial Intelligence, Fundamentals of AI Agents, Data Science',
     ])
   })
 
-  it('renders timeline section labels in pixel display typography', () => {
-    render(<TimelineSection />)
+  describe('issue #78 - newest-first ordering', () => {
+    it('entries render in newest-first order (NetApp before M.S. before B.S.)', () => {
+      vi.mocked(useInView).mockReturnValue(true)
+      vi.useFakeTimers()
 
-    const labels = ['EDUCATION', 'EXPERIENCE']
+      render(<TimelineSection />)
+      act(() => { vi.advanceTimersByTime(15000) })
 
-    labels.forEach(label => {
-      const labelElement = screen.getByText(label)
-      const slashElement = labelElement.previousElementSibling
+      const institutions = screen.getAllByTestId('commit-institution')
+      expect(institutions[0].textContent).toBe('NETAPP INC.')
+      expect(institutions[1].textContent).toBe('WICHITA STATE UNIVERSITY')
+      expect(institutions[2].textContent).toBe('WICHITA STATE UNIVERSITY')
 
-      expect(slashElement).toHaveTextContent('//')
-      expect(slashElement).toHaveClass('font-display', 'text-xs', 'text-atomic-tangerine')
-      expect(slashElement).not.toHaveClass('font-body')
+      const roles = screen.getAllByTestId('commit-role')
+      expect(roles[0].textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+      expect(roles[1].textContent).toBe('ACCELERATED_M.S._COMPUTER_SCIENCE')
+      expect(roles[2].textContent).toBe('B.S._COMPUTER_SCIENCE')
+    })
 
-      expect(labelElement).toHaveClass('font-display', 'text-sm', 'text-atomic-tangerine')
-      expect(labelElement).not.toHaveClass('font-body')
+    it('does not render Education/Experience subsection headings', () => {
+      render(<TimelineSection />)
+
+      expect(screen.queryByText('EDUCATION')).not.toBeInTheDocument()
+      expect(screen.queryByText('EXPERIENCE')).not.toBeInTheDocument()
     })
   })
 
@@ -134,28 +147,28 @@ describe('TimelineSection', () => {
       act(() => { vi.advanceTimersByTime(15000) })
 
       const hashes = screen.getAllByTestId('commit-hash')
-      expect(hashes[0].textContent).toBe('commit a3f9d2b')
-      expect(hashes[1].textContent).toBe('commit b7c3e1a')
-      expect(hashes[2].textContent).toBe('commit d4e8f2c')
+      expect(hashes[0].textContent).toBe('commit d4e8f2c')
+      expect(hashes[1].textContent).toBe('commit a3f9d2b')
+      expect(hashes[2].textContent).toBe('commit b7c3e1a')
 
       screen.getAllByTestId('commit-author').forEach(el => {
         expect(el.textContent).toBe('Author: Farhan Mohammed')
       })
 
       const dates = screen.getAllByTestId('commit-date')
-      expect(dates[0].textContent).toBe('Date:   JAN 2026 – DEC 2027 (EXPECTED)')
-      expect(dates[1].textContent).toBe('Date:   JAN 2022 – DEC 2025')
-      expect(dates[2].textContent).toBe('Date:   AUG 2024 – PRESENT')
+      expect(dates[0].textContent).toBe('Date:   AUG 2024 – PRESENT')
+      expect(dates[1].textContent).toBe('Date:   JAN 2026 – DEC 2027 (EXPECTED)')
+      expect(dates[2].textContent).toBe('Date:   JAN 2022 – DEC 2025')
 
       const institutions = screen.getAllByTestId('commit-institution')
-      expect(institutions[0].textContent).toBe('WICHITA STATE UNIVERSITY')
+      expect(institutions[0].textContent).toBe('NETAPP INC.')
       expect(institutions[1].textContent).toBe('WICHITA STATE UNIVERSITY')
-      expect(institutions[2].textContent).toBe('NETAPP INC.')
+      expect(institutions[2].textContent).toBe('WICHITA STATE UNIVERSITY')
 
       const roles = screen.getAllByTestId('commit-role')
-      expect(roles[0].textContent).toBe('ACCELERATED_M.S._COMPUTER_SCIENCE')
-      expect(roles[1].textContent).toBe('B.S._COMPUTER_SCIENCE')
-      expect(roles[2].textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+      expect(roles[0].textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+      expect(roles[1].textContent).toBe('ACCELERATED_M.S._COMPUTER_SCIENCE')
+      expect(roles[2].textContent).toBe('B.S._COMPUTER_SCIENCE')
     })
 
     it('does not render the superseded M.S. date range', () => {

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -10,7 +10,19 @@ interface TimelineEntry {
   bullets: string[]
 }
 
-const education: TimelineEntry[] = [
+const timelineEntries: TimelineEntry[] = [
+  {
+    hash: 'd4e8f2c',
+    dateRange: 'AUG 2024 – PRESENT',
+    institution: 'NETAPP INC.',
+    role: 'SOFTWARE_ENGINEER_IN_TEST',
+    bullets: [
+      'Built automated analysis pipeline processing storage telemetry across distributed RAID systems (FC, SAS, NVMe/RoCE), handling terabytes of performance data.',
+      'Designed Python automation framework reducing manual configuration tasks by 30% across Linux, Windows, and VMware infrastructure.',
+      'Implemented Ansible-based deployment orchestration for 300+ system configurations, streamlining infrastructure provisioning workflows.',
+      'Developed interactive visualization dashboard for system performance metrics using Python, analyzing 1M+ database entries for engineering insights.',
+    ],
+  },
   {
     hash: 'a3f9d2b',
     dateRange: 'JAN 2026 – DEC 2027 (EXPECTED)',
@@ -26,21 +38,6 @@ const education: TimelineEntry[] = [
     bullets: [
       "Dean's List: Spring 2022 – Fall 2025",
       "Relevant Coursework: Machine Learning, Artificial Intelligence, Fundamentals of AI Agents, Data Science",
-    ],
-  },
-]
-
-const experience: TimelineEntry[] = [
-  {
-    hash: 'd4e8f2c',
-    dateRange: 'AUG 2024 – PRESENT',
-    institution: 'NETAPP INC.',
-    role: 'SOFTWARE_ENGINEER_IN_TEST',
-    bullets: [
-      'Built automated analysis pipeline processing storage telemetry across distributed RAID systems (FC, SAS, NVMe/RoCE), handling terabytes of performance data.',
-      'Designed Python automation framework reducing manual configuration tasks by 30% across Linux, Windows, and VMware infrastructure.',
-      'Implemented Ansible-based deployment orchestration for 300+ system configurations, streamlining infrastructure provisioning workflows.',
-      'Developed interactive visualization dashboard for system performance metrics using Python, analyzing 1M+ database entries for engineering insights.',
     ],
   },
 ]
@@ -163,14 +160,7 @@ function EntryList({ entries }: { entries: TimelineEntry[] }) {
   )
 }
 
-function SectionLabel({ label }: { label: 'EDUCATION' | 'EXPERIENCE' }) {
-  return (
-    <div className="flex items-center gap-1 mb-2">
-      <span className="font-display text-xs text-atomic-tangerine">//</span>
-      <span className="font-display text-sm text-atomic-tangerine">{label}</span>
-    </div>
-  )
-}
+
 
 const TimelineSection: React.FC = () => {
   return (
@@ -182,19 +172,7 @@ const TimelineSection: React.FC = () => {
           <hr className="flex-1 border-periwinkle/20" />
         </div>
 
-        <div className="space-y-12">
-          <div>
-            <SectionLabel label="EDUCATION" />
-            <hr className="border-periwinkle/10 mb-0" />
-            <EntryList entries={education} />
-          </div>
-
-          <div>
-            <SectionLabel label="EXPERIENCE" />
-            <hr className="border-periwinkle/10 mb-0" />
-            <EntryList entries={experience} />
-          </div>
-        </div>
+        <EntryList entries={timelineEntries} />
       </div>
     </StickySection>
   )


### PR DESCRIPTION
## Summary

Implements the TypeIn primitive component per issue #66 specifications:

- One-shot typewriter that renders characters one at a time
- Triggers when `start` flips to true
- Calls `onDone` exactly once when typing completes
- Props: `start: boolean`, `text: string`, `speed?: number` (default 40ms), `onDone?: () => void`
- Renders typed fragment as `<span>` - cursor is caller's responsibility

## Acceptance Criteria (verified)

- [x] Given start=true, emits full text after timeouts fire
- [x] Given start=false, renders nothing  
- [x] Calls onDone exactly once when typing completes
- [x] Does not call onDone if start never becomes true
- [x] Cleans up timers on unmount

## Changes

- `src/animations/TypeIn.tsx` - Component implementation
- `src/animations/TypeIn.test.tsx` - Unit tests (5 tests)

## Verification

- `npm run typecheck` ✓
- `npm run test` (TypeIn tests pass)

## Related Issue

Fixes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an animated typing component with configurable speed, proper empty-text handling, restart-on-text or start-toggle, correct special-character rendering, and guaranteed single completion callback.

* **Refactor**
  * Timeline consolidated into a single, newest-first list; separate Education/Experience headings removed and bullet rendering updated.

* **Tests**
  * Expanded typing animation tests (coverage for timing, restarts, empty text, special chars, onDone) and updated timeline tests to reflect new ordering and bullet contract.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->