### PR TITLE
Projects: text-led notched card content layout

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -13,7 +13,11 @@ const mockProjects = [
       { label: 'GitHub', url: 'https://github.com/project1' },
       { label: 'Demo', url: 'https://demo.project1.com' }
     ],
-    image: 'https://example.com/image1.png'
+    image: 'https://example.com/image1.png',
+    bullets: [
+      'First bullet point for project one',
+      'Second bullet point for project one'
+    ]
   },
   {
     id: '2',
@@ -123,5 +127,40 @@ describe('ProjectsSection', () => {
 
     expect(headerLabel.closest('[data-carousel-track="true"]')).toBeNull()
     expect(carouselTrack).toBeInTheDocument()
+  })
+
+  it('renders resume bullets when provided', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    expect(screen.getByText('First bullet point for project one')).toBeInTheDocument()
+    expect(screen.getByText('Second bullet point for project one')).toBeInTheDocument()
+  })
+
+  it('omits bullets section when project has no bullets', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const projectTwoCard = screen.getByRole('heading', { name: 'Project Two' }).closest('[data-testid="project-card"]')
+    expect(projectTwoCard).not.toBeNull()
+
+    const bulletsList = projectTwoCard?.querySelector('ul')
+    expect(bulletsList).not.toBeInTheDocument()
+  })
+
+  it('renders bullets as a list structure', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const lists = document.querySelectorAll('[data-testid="project-card"] ul')
+    expect(lists).toHaveLength(1)
+    expect(lists[0].querySelectorAll('li')).toHaveLength(2)
+  })
+
+  it('card has explicit width constraint to prevent full-width collapse', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const card = document.querySelector('[data-testid="project-card"]')
+    expect(card).not.toBeNull()
+    const style = window.getComputedStyle(card!)
+    expect(style.maxWidth).not.toBe('none')
+    expect(style.maxWidth).not.toBe('')
   })
 })

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -58,7 +58,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
       animate={{ y: isHovered ? -4 : 0 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
       data-testid="project-card"
-      className="relative flex-shrink-0"
+      className="relative shrink-0"
       style={{ clipPath: NOTCH, maxWidth: '480px', width: '480px' }}
     >
       <div className="relative bg-platinum p-5">

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -58,8 +58,8 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
       animate={{ y: isHovered ? -4 : 0 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
       data-testid="project-card"
-      className="relative"
-      style={{ clipPath: NOTCH }}
+      className="relative flex-shrink-0"
+      style={{ clipPath: NOTCH, maxWidth: '480px', width: '480px' }}
     >
       <div className="relative bg-platinum p-5">
         {project.image && (
@@ -96,6 +96,14 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
             </span>
           ))}
         </div>
+
+        {project.bullets && project.bullets.length > 0 && (
+          <ul className="list-disc list-inside text-graphite/70 text-sm font-body leading-relaxed mb-4 space-y-1">
+            {project.bullets.map((bullet, index) => (
+              <li key={index}>{bullet}</li>
+            ))}
+          </ul>
+        )}
 
         <div className="flex flex-col gap-1">
           {project.links.map((link) => (


### PR DESCRIPTION
**Purpose** — Add resume-backed bullets to project cards and enforce card width to prevent full-width collapse in the carousel.

**What it does** — Renders optional bullets field from project data as a list within each card, and constrains cards to 480px width so they maintain their notched card shape.

**Changes made**
- `src/components/ProjectsSection.tsx`: Added bullets rendering, width constraint (`maxWidth: 480px`), and `flex-shrink-0` to ProjectCard
- `src/components/ProjectsSection.test.tsx`: Added 4 tests for bullets rendering, omission when absent, list structure, and width constraint

**Additional notes**
- Bullets are only rendered when present in project data (conditional rendering)
- Card width matches the text-led treatment requirement — cards remain card-shaped, not full-width rows
- All 15 ProjectsSection tests pass

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects now display resume-style bullet points to highlight key accomplishments when available.
  * Project cards updated with tighter sizing constraints to ensure consistent presentation and prevent unwanted width expansion.

* **Tests**
  * Added tests validating bullet list rendering, correct list structure and conditional omission, and visual sizing/constraint behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->