### PR TITLE
Skills: v4 bento layout and mobile adaptation

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -136,7 +136,19 @@ describe('SkillsSection', () => {
     expect(children.length).toBe(22)
   })
 
-  it('desktop grid has an explicit grid-rows class with varied row heights', () => {
+  it('desktop grid uses 6-column bento layout (md:grid-cols-6)', () => {
+    render(<SkillsSection />)
+    const grid = screen.getByTestId('skills-grid')
+    expect(grid.classList).toContain('md:grid-cols-6')
+  })
+
+  it('mobile grid uses 2-column bento layout (grid-cols-2)', () => {
+    render(<SkillsSection />)
+    const grid = screen.getByTestId('skills-grid')
+    expect(grid.classList).toContain('grid-cols-2')
+  })
+
+  it('desktop grid has varied row heights creating asymmetric bento rhythm', () => {
     render(<SkillsSection />)
     const heights = getExplicitGridRows()
     expect(new Set(heights).size).toBeGreaterThanOrEqual(2)
@@ -165,6 +177,22 @@ describe('SkillsSection', () => {
     expect(pythonTile!.className).toMatch(/md:row-span-[3-9]/)
   })
 
+  it('anchor skills (Python, PyTorch) have visibly stronger layout weight with larger spans', () => {
+    render(<SkillsSection />)
+    
+    // Python should be the largest tile (3 cols × 3 rows)
+    const pythonTile = screen.getByText('Python').closest('div')
+    expect(pythonTile).not.toBeNull()
+    expect(pythonTile!.className).toContain('md:col-span-3')
+    expect(pythonTile!.className).toContain('md:row-span-3')
+    
+    // PyTorch should be second largest (3 cols × 2 rows)
+    const pytorchTile = screen.getByText('PyTorch').closest('div')
+    expect(pytorchTile).not.toBeNull()
+    expect(pytorchTile!.className).toContain('md:col-span-3')
+    expect(pytorchTile!.className).toContain('md:row-span-2')
+  })
+
   it('grid defines at least 11 explicit rows to accommodate all skill tiles', () => {
     render(<SkillsSection />)
     const heights = getExplicitGridRows()
@@ -175,12 +203,12 @@ describe('SkillsSection', () => {
     render(<SkillsSection />)
 
     expect(getSkillTile('Transformers').className).toContain('md:col-span-2')
-    expect(getSkillTile('Attention Mechanisms').className).not.toContain('md:col-span-2')
-    expect(getSkillTile('Gradient Optimization').className).toContain('md:row-span-2')
+    expect(getSkillTile('Attention Mechanisms').className).toContain('md:col-span-2')
+    expect(getSkillTile('Gradient Optimization').className).toContain('md:col-span-2')
     expect(getSkillTile('Model Training / Fine-tuning').className).toContain('md:col-span-3')
     expect(getSkillTile('Matplotlib').className).not.toContain('md:col-span-2')
     expect(getSkillTile('Mixed-Precision Training').className).toContain('md:col-span-2')
-    expect(getSkillTile('Jupyter').className).toContain('md:col-span-1')
+    expect(getSkillTile('Jupyter').className).not.toContain('md:col-span-3')
   })
 
   it('grid container has min-h-screen or min-h-svh class', () => {

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -65,28 +65,28 @@ interface SkillTile {
 //   R14: Matplotlib(1) Mixed-Precision(1)
 //   R15: Jupyter(2)
 const tiles: SkillTile[] = [
-  { category: 'LANGUAGE',  name: 'Python',       colSpan: 'col-span-2',                rowSpan: 'row-span-2 md:row-span-3', bg: '#FF8547', fg: '#050609' },
-  { category: 'LANGUAGE',  name: 'TypeScript',   colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-2 md:row-span-1', bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'TOOL',      name: 'Docker',       colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
-  { category: 'LANGUAGE',  name: 'C / C++',      colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'LANGUAGE',  name: 'JavaScript',   colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
-  { category: 'FRAMEWORK', name: 'FastAPI',      colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'ML / DL',   name: 'PyTorch',      colSpan: 'col-span-2 md:col-span-3',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'DATA',      name: 'NumPy',        colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-2',               bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'DATA',      name: 'Pandas',       colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'TOOL',      name: 'Ansible',      colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Hugging Face', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Scikit-learn', colSpan: 'col-span-1 md:col-span-3',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'TOOL',      name: 'Linux',        colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
-  { category: 'TOOL',      name: 'Git',          colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
-  { category: 'LANGUAGE',  name: 'SQL',          colSpan: 'col-span-2 md:col-span-3',  rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'ML / DL',   name: 'Transformers', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Attention Mechanisms', colSpan: 'col-span-1',        rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Gradient Optimization', colSpan: 'col-span-1',       rowSpan: 'row-span-1 md:row-span-2', bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Model Training / Fine-tuning', colSpan: 'col-span-1 md:col-span-3',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'DATA',      name: 'Matplotlib',   colSpan: 'col-span-1',                rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'DATA',      name: 'Mixed-Precision Training', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'TOOL',      name: 'Jupyter',      colSpan: 'col-span-2 md:col-span-1',  rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
+  { category: 'LANGUAGE',  name: 'Python',       colSpan: 'col-span-2 md:col-span-3',          rowSpan: 'row-span-2 md:row-span-3', bg: '#FF8547', fg: '#050609' },
+  { category: 'LANGUAGE',  name: 'TypeScript',   colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-2 md:row-span-2', bg: '#5200E0', fg: '#EFF1F3' },
+  { category: 'TOOL',      name: 'Docker',       colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
+  { category: 'LANGUAGE',  name: 'C / C++',      colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
+  { category: 'LANGUAGE',  name: 'JavaScript',   colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
+  { category: 'FRAMEWORK', name: 'FastAPI',      colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
+  { category: 'ML / DL',   name: 'PyTorch',      colSpan: 'col-span-2 md:col-span-3',          rowSpan: 'row-span-1 md:row-span-2', bg: '#FFCE47', fg: '#050609' },
+  { category: 'DATA',      name: 'NumPy',        colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
+  { category: 'DATA',      name: 'Pandas',       colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
+  { category: 'TOOL',      name: 'Ansible',      colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Hugging Face', colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Scikit-learn', colSpan: 'col-span-1 md:col-span-3',          rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'TOOL',      name: 'Linux',        colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
+  { category: 'TOOL',      name: 'Git',          colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
+  { category: 'LANGUAGE',  name: 'SQL',          colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
+  { category: 'ML / DL',   name: 'Transformers', colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Attention Mechanisms', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Gradient Optimization', colSpan: 'col-span-1 md:col-span-2', rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Model Training / Fine-tuning', colSpan: 'col-span-1 md:col-span-3', rowSpan: 'row-span-1',        bg: '#FFCE47', fg: '#050609' },
+  { category: 'DATA',      name: 'Matplotlib',   colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
+  { category: 'DATA',      name: 'Mixed-Precision Training', colSpan: 'col-span-1 md:col-span-2', rowSpan: 'row-span-1',            bg: '#E0007F', fg: '#EFF1F3' },
+  { category: 'TOOL',      name: 'Jupyter',      colSpan: 'col-span-2',                        rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
 ]
 
 function SkillTileCard({ tile }: { tile: SkillTile }) {
@@ -126,7 +126,7 @@ export function SkillsSection() {
           variants={gridStagger}
           initial="hidden"
           animate={isInView ? 'visible' : 'hidden'}
-          className="grid grid-cols-2 md:grid-cols-4 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr]"
+          className="grid grid-cols-2 md:grid-cols-6 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr]"
         >
           {tiles.map((tile) => (
             <SkillTileCard key={tile.name} tile={tile} />


### PR DESCRIPTION
**Purpose** — Implement the v4 Skills bento layout as a real section layout with 6-column desktop asymmetric grid and 2-column mobile adaptation.

**What it does** — Transforms the Skills section from a 4-column desktop grid to a 6-column asymmetric bento layout with clear visual hierarchy, where anchor skills (Python, PyTorch) have visibly stronger layout weight through larger spans.

**Changes made** — 
- Updated desktop grid from `md:grid-cols-4` to `md:grid-cols-6`
- Redesigned all 22 tile spans for 6-column asymmetric bento rhythm
- Python tile: 3 cols × 3 rows (largest anchor)
- PyTorch tile: 3 cols × 2 rows (secondary anchor)
- Mobile retains 2-column bento grid (`grid-cols-2`)
- Added tests for 6-column desktop, 2-column mobile, and anchor skill weights
- Updated existing test assertions to match new layout

**Additional notes** — 
- Layout remains stable before, during, and after reveal animations
- Tests verify expected tiles render without depending on animation internals
- Uses existing v4 brand palette (graphite/orange/fuchsia/blue/yellow/platinum)

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for skills section responsive grid layout on desktop and mobile devices.

* **Style**
  * Refined skills section grid layout with adjusted responsive column configuration and improved tile positioning for featured skills on various screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->