### PR TITLE
fix: update Navbar active-link test to match component DOM structure

### DIFF
--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -269,10 +269,10 @@ describe('Navbar', () => {
         })
 
         const skillsLink = screen.getByRole('link', { name: /skills/i })
-        const prefixSpan = skillsLink.querySelector('span')
-        expect(skillsLink.className).toContain('border-b-2')
-        expect(prefixSpan).not.toBeNull()
-        expect(prefixSpan!.style.opacity).toBe('0')
+        const labelSpan = skillsLink.querySelector('span:last-child')
+        const caretSpan = skillsLink.querySelector('[data-testid="nav-caret"]')
+        expect(labelSpan?.className).toContain('border-b-2')
+        expect(caretSpan).toBeNull()
       } finally {
         vi.unstubAllGlobals()
         document.body.removeChild(section)


### PR DESCRIPTION
## Summary

- The test was checking `skillsLink.className` for `border-b-2`, but the component puts that class on the inner label `<span>`, not the `<a>` element
- The test expected a caret `<span>` with `opacity: '0'` for active links, but the component conditionally omits the caret span entirely when `isActive` is true (`{!isActive && <span>...`)
- Updated assertions to check `span:last-child` for the border class and assert the caret span is absent

Pre-existing failure on `main` (noted in PR #137 description).

## Test plan
- [x] `npm run test` — 171/171 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for navigation link active state behavior to reflect current DOM implementation.

**Note:** This release contains internal testing updates with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->