### PR TITLE
Projects: diagonal orange notch fill animation

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -84,7 +84,7 @@ describe('ProjectsSection', () => {
     expect(screen.getByText('// Docs ↗')).toBeInTheDocument()
   })
 
-  it('project title changes to atomic-tangerine on hover', async () => {
+  it('keeps the project title readable during hover fill', async () => {
     const user = userEvent.setup()
     render(<ProjectsSection projects={mockProjects} />)
 
@@ -95,10 +95,82 @@ describe('ProjectsSection', () => {
     expect(title).toHaveClass('text-graphite')
 
     await user.hover(card!)
-    expect(title).toHaveClass('text-atomic-tangerine')
+    expect(title).toHaveClass('text-graphite')
 
     await user.unhover(card!)
     expect(title).toHaveClass('text-graphite')
+  })
+
+  it('activates a diagonal orange fill layer when a project card is hovered', async () => {
+    const user = userEvent.setup()
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const card = screen.getByRole('heading', { name: 'Project One' }).closest('[data-testid="project-card"]')
+    expect(card).not.toBeNull()
+
+    const fill = card!.querySelector('[data-testid="project-card-fill"]')
+    expect(fill).toBeInTheDocument()
+    expect(fill).toHaveAttribute('aria-hidden', 'true')
+    expect(fill).toHaveAttribute('data-active', 'false')
+
+    await user.hover(card!)
+    expect(fill).toHaveAttribute('data-active', 'true')
+
+    await user.unhover(card!)
+    expect(fill).toHaveAttribute('data-active', 'false')
+  })
+
+  it('activates the diagonal orange fill while a project card link has focus', async () => {
+    const user = userEvent.setup()
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const link = screen.getByRole('link', { name: '// GitHub ↗' })
+    const card = link.closest('[data-testid="project-card"]')
+    expect(card).not.toBeNull()
+
+    const fill = card!.querySelector('[data-testid="project-card-fill"]')
+    expect(fill).toHaveAttribute('data-active', 'false')
+
+    await user.tab()
+    expect(link).toHaveFocus()
+    expect(fill).toHaveAttribute('data-active', 'true')
+  })
+
+  it('switches project card content to readable graphite text during the orange fill', async () => {
+    const user = userEvent.setup()
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const title = screen.getByRole('heading', { name: 'Project One' })
+    const card = title.closest('[data-testid="project-card"]')
+    expect(card).not.toBeNull()
+
+    const description = screen.getByText('Description for project one')
+    const bullet = screen.getByText('First bullet point for project one')
+    const link = screen.getByRole('link', { name: '// GitHub ↗' })
+
+    await user.hover(card!)
+
+    expect(title).toHaveClass('text-graphite')
+    expect(description).toHaveClass('text-graphite')
+    expect(bullet.closest('ul')).toHaveClass('text-graphite')
+    expect(link).toHaveClass('text-graphite')
+  })
+
+  it('inverts project tags and ghost number during the orange fill', async () => {
+    const user = userEvent.setup()
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const title = screen.getByRole('heading', { name: 'Project One' })
+    const card = title.closest('[data-testid="project-card"]')
+    expect(card).not.toBeNull()
+
+    const ghostNumber = screen.getByText('_01')
+    const tag = screen.getByText('React')
+
+    await user.hover(card!)
+
+    expect(ghostNumber).toHaveClass('text-graphite')
+    expect(tag).toHaveAttribute('data-inverted', 'true')
   })
 
   it('renders cards in a horizontal track structure for carousel scrolling', () => {

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -173,6 +173,42 @@ describe('ProjectsSection', () => {
     expect(tag).toHaveAttribute('data-inverted', 'true')
   })
 
+  it('fill stays active when tabbing between links within the same card', async () => {
+    const user = userEvent.setup()
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const githubLink = screen.getByRole('link', { name: '// GitHub ↗' })
+    const demoLink = screen.getByRole('link', { name: '// Demo ↗' })
+    const card = githubLink.closest('[data-testid="project-card"]')!
+    const fill = card.querySelector('[data-testid="project-card-fill"]')!
+
+    await user.tab()
+    expect(githubLink).toHaveFocus()
+    expect(fill).toHaveAttribute('data-active', 'true')
+
+    await user.tab()
+    expect(demoLink).toHaveFocus()
+    expect(fill).toHaveAttribute('data-active', 'true')
+  })
+
+  it('fill deactivates when focus leaves the project card', async () => {
+    const user = userEvent.setup()
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const githubLink = screen.getByRole('link', { name: '// GitHub ↗' })
+    const card = githubLink.closest('[data-testid="project-card"]')!
+    const fill = card.querySelector('[data-testid="project-card-fill"]')!
+
+    await user.tab()
+    expect(githubLink).toHaveFocus()
+    expect(fill).toHaveAttribute('data-active', 'true')
+
+    // Tab past Demo link, then out of the card entirely
+    await user.tab()
+    await user.tab()
+    expect(fill).toHaveAttribute('data-active', 'false')
+  })
+
   it('renders cards in a horizontal track structure for carousel scrolling', () => {
     render(<ProjectsSection projects={mockProjects} />)
 

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -66,7 +66,11 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onFocusCapture={() => setHasFocus(true)}
-      onBlurCapture={() => setHasFocus(false)}
+      onBlurCapture={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+          setHasFocus(false)
+        }
+      }}
       animate={{ y: isFillActive ? -4 : 0 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
       data-testid="project-card"

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -19,16 +19,13 @@ const NOTCH = 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px)
 const FILL_CLOSED = 'polygon(0 0, 0 0, 0 0, 0 0)'
 const FILL_OPEN = 'polygon(0 0, 220% 0, 100% 220%, 0 100%)'
 const FILL_TRANSITION = { duration: 0.32, ease: 'easeOut' } as const
+const INVERTED_TAG_STYLE = {
+  backgroundColor: 'rgba(42, 43, 42, 0.14)',
+  color: '#2A2B2A',
+  borderColor: 'rgba(42, 43, 42, 0.38)',
+} as const
 
-function getTagStyle(tagIndex: number, isInverted = false) {
-  if (isInverted) {
-    return {
-      backgroundColor: 'rgba(42, 43, 42, 0.14)',
-      color: '#2A2B2A',
-      borderColor: 'rgba(42, 43, 42, 0.38)',
-    }
-  }
-
+function getTagStyle(tagIndex: number) {
   const color = TAG_COLORS[tagIndex % TAG_COLORS.length]
   return { backgroundColor: color.bg, color: color.fg }
 }
@@ -116,7 +113,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
               key={tag}
               data-inverted={isFillActive}
               className="text-xs px-2 py-0.5 font-body rounded border border-transparent transition-colors duration-200"
-              style={getTagStyle(tagIndex, isFillActive)}
+              style={isFillActive ? INVERTED_TAG_STYLE : getTagStyle(tagIndex)}
             >
               {tag}
             </span>

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -16,8 +16,19 @@ const TAG_COLORS = [
 ]
 
 const NOTCH = 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)'
+const FILL_CLOSED = 'polygon(0 0, 0 0, 0 0, 0 0)'
+const FILL_OPEN = 'polygon(0 0, 220% 0, 100% 220%, 0 100%)'
+const FILL_TRANSITION = { duration: 0.32, ease: 'easeOut' } as const
 
-function getTagStyle(tagIndex: number) {
+function getTagStyle(tagIndex: number, isInverted = false) {
+  if (isInverted) {
+    return {
+      backgroundColor: 'rgba(42, 43, 42, 0.14)',
+      color: '#2A2B2A',
+      borderColor: 'rgba(42, 43, 42, 0.38)',
+    }
+  }
+
   const color = TAG_COLORS[tagIndex % TAG_COLORS.length]
   return { backgroundColor: color.bg, color: color.fg }
 }
@@ -50,18 +61,32 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
 
 const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
   const [isHovered, setIsHovered] = useState(false)
+  const [hasFocus, setHasFocus] = useState(false)
+  const isFillActive = isHovered || hasFocus
 
   return (
     <motion.div
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      animate={{ y: isHovered ? -4 : 0 }}
+      onFocusCapture={() => setHasFocus(true)}
+      onBlurCapture={() => setHasFocus(false)}
+      animate={{ y: isFillActive ? -4 : 0 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
       data-testid="project-card"
-      className="relative shrink-0"
+      className="relative shrink-0 bg-platinum"
       style={{ clipPath: NOTCH, maxWidth: '480px', width: '480px' }}
     >
-      <div className="relative bg-platinum p-5">
+      <motion.div
+        data-testid="project-card-fill"
+        aria-hidden="true"
+        data-active={isFillActive}
+        className="absolute inset-0 bg-atomic-tangerine"
+        initial={false}
+        animate={{ clipPath: isFillActive ? FILL_OPEN : FILL_CLOSED }}
+        transition={FILL_TRANSITION}
+      />
+
+      <div className="relative z-10 p-5">
         {project.image && (
           <div className="mb-4 overflow-hidden" style={{ backgroundColor: '#3A3B3A' }}>
             <img
@@ -73,15 +98,15 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
         )}
 
         <div className="flex items-center gap-3 mb-2">
-          <span className="font-body text-xs text-graphite/50">
+          <span className={`font-body text-xs transition-colors duration-200 ${isFillActive ? 'text-graphite' : 'text-graphite/50'}`}>
             _{project.id.padStart(2, '0')}
           </span>
-          <h3 className={`font-body font-bold text-base transition-colors duration-200 ${isHovered ? 'text-atomic-tangerine' : 'text-graphite'}`}>
+          <h3 className="font-body font-bold text-base text-graphite transition-colors duration-200">
             {project.title}
           </h3>
         </div>
 
-        <p className="text-graphite/70 text-sm font-body leading-relaxed mb-4">
+        <p className={`text-sm font-body leading-relaxed mb-4 transition-colors duration-200 ${isFillActive ? 'text-graphite' : 'text-graphite/70'}`}>
           {project.description}
         </p>
 
@@ -89,8 +114,9 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
           {project.tags.map((tag, tagIndex) => (
             <span
               key={tag}
-              className="text-xs px-2 py-0.5 font-body rounded"
-              style={getTagStyle(tagIndex)}
+              data-inverted={isFillActive}
+              className="text-xs px-2 py-0.5 font-body rounded border border-transparent transition-colors duration-200"
+              style={getTagStyle(tagIndex, isFillActive)}
             >
               {tag}
             </span>
@@ -98,7 +124,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
         </div>
 
         {project.bullets && project.bullets.length > 0 && (
-          <ul className="list-disc list-inside text-graphite/70 text-sm font-body leading-relaxed mb-4 space-y-1">
+          <ul className={`list-disc list-inside text-sm font-body leading-relaxed mb-4 space-y-1 transition-colors duration-200 ${isFillActive ? 'text-graphite' : 'text-graphite/70'}`}>
             {project.bullets.map((bullet, index) => (
               <li key={index}>{bullet}</li>
             ))}
@@ -112,7 +138,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="font-mono text-xs text-ultrasonic-blue hover:text-atomic-tangerine transition-colors"
+              className={`font-mono text-xs transition-colors ${isFillActive ? 'text-graphite hover:text-graphite' : 'text-ultrasonic-blue hover:text-atomic-tangerine'}`}
             >
               // {link.label} ↗
             </a>
@@ -124,7 +150,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
       <motion.div
         className="absolute left-0 top-0 bottom-0 w-[3px] bg-atomic-tangerine"
         initial={{ scaleY: 0, opacity: 0 }}
-        animate={{ scaleY: isHovered ? 1 : 0, opacity: isHovered ? 1 : 0 }}
+        animate={{ scaleY: isFillActive ? 1 : 0, opacity: isFillActive ? 1 : 0 }}
         style={{ transformOrigin: 'bottom' }}
         transition={{ duration: 0.25, ease: 'easeOut' }}
       />


### PR DESCRIPTION
**Purpose** — Add the issue #75 hover/focus fill interaction to project cards so the notched card has a clear orange active affordance.

**What it does** — Adds a clipped diagonal orange fill animation on hover and keyboard focus while switching card content to readable graphite contrast.

**Changes made**
- Updated src/components/ProjectsSection.tsx with the diagonal fill layer, shared hover/focus active state, and inverted content/tag styling.
- Updated src/components/ProjectsSection.test.tsx with TDD coverage for hover activation, focus activation, readable content, and tag/ghost-number inversion.

**Additional notes** — The fill transition is 320ms, within the <=350ms acceptance target. The existing #105 notched card layout was already present. Sandboxed npm run test fails on .mochi tsx IPC permissions; rerunning outside the sandbox passes.

Closes #75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project cards now activate their fill and edge animations for both hover and keyboard focus (treated as a single active state)
  * Card content (title, description, bullets, links) maintains improved contrast and visual inversion while active; fill persists when tabbing within a card and deactivates when focus leaves

* **Tests**
  * Expanded coverage for hover, focus, keyboard navigation, and visual inversion behaviors
  * Added assertions ensuring styling consistency during and after interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->