### PR TITLE
Skills: deterministic reveal order + slower speed

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -38,6 +38,7 @@ vi.mock('framer-motion', async () => {
       const {
         animate,
         children,
+        custom,
         initial,
         transition,
         variants,
@@ -48,6 +49,7 @@ vi.mock('framer-motion', async () => {
       if (tagName === 'div') {
         motionMock.divProps.push({
           animate,
+          custom,
           initial,
           text: getText(children),
           transition,
@@ -84,6 +86,12 @@ function getSkillTile(name: string) {
   const tile = screen.getByText(name).closest('div')
   expect(tile).not.toBeNull()
   return tile!
+}
+
+function getSkillAnimation(name: string) {
+  const animation = motionMock.divProps.find(props => String(props.text).includes(name))
+  expect(animation).toBeDefined()
+  return animation!
 }
 
 describe('SkillsSection', () => {
@@ -193,6 +201,33 @@ describe('SkillsSection', () => {
     expect(pytorchTile!.className).toContain('md:row-span-2')
   })
 
+  it('reveals larger anchor skill tiles before smaller supporting tiles', () => {
+    render(<SkillsSection />)
+
+    expect(getSkillAnimation('Python').custom).toBeLessThan(getSkillAnimation('Docker').custom as number)
+    expect(getSkillAnimation('PyTorch').custom).toBeLessThan(getSkillAnimation('FastAPI').custom as number)
+  })
+
+  it('assigns every skill tile one deterministic reveal position across renders', () => {
+    const { unmount } = render(<SkillsSection />)
+
+    const firstOrder = motionMock.divProps
+      .filter(props => props.text !== undefined && props.text !== '')
+      .map(props => [props.text, props.custom])
+
+    unmount()
+    motionMock.divProps = []
+
+    render(<SkillsSection />)
+
+    const secondOrder = motionMock.divProps
+      .filter(props => props.text !== undefined && props.text !== '')
+      .map(props => [props.text, props.custom])
+
+    expect(new Set(firstOrder.map(([, order]) => order)).size).toBe(22)
+    expect(firstOrder).toEqual(secondOrder)
+  })
+
   it('grid defines at least 11 explicit rows to accommodate all skill tiles', () => {
     render(<SkillsSection />)
     const heights = getExplicitGridRows()
@@ -271,20 +306,25 @@ describe('SkillsSection', () => {
     expect(tileAnimations).toHaveLength(22)
 
     for (const tileAnimation of tileAnimations) {
-      expect(tileAnimation.variants).toMatchObject({
+      const variants = tileAnimation.variants as {
+        hidden: unknown
+        visible: (order: number) => unknown
+      }
+
+      expect(variants).toMatchObject({
         hidden: { opacity: 0, scale: 0.95 },
-        visible: {
-          opacity: 1,
-          scale: 1,
-          transition: { duration: 0.4, ease: 'easeOut' },
-        },
+      })
+      expect(variants.visible(tileAnimation.custom as number)).toMatchObject({
+        opacity: 1,
+        scale: 1,
+        transition: { delay: (tileAnimation.custom as number) * 0.12, duration: 0.5, ease: 'easeOut' },
       })
       expect(tileAnimation.initial).toBeUndefined()
       expect(tileAnimation.whileHover).toBe('hover')
     }
   })
 
-  it('grid staggers tile animation and switches to visible on viewport entry once', () => {
+  it('grid switches to visible on viewport entry once while tiles handle their own reveal delays', () => {
     motionMock.isInView = true
 
     render(<SkillsSection />)
@@ -296,7 +336,7 @@ describe('SkillsSection', () => {
       initial: 'hidden',
       variants: {
         hidden: {},
-        visible: { transition: { staggerChildren: 0.05 } },
+        visible: {},
       },
     })
     expect(motionMock.useInView).toHaveBeenCalledWith(

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -3,20 +3,21 @@ import { useRef } from 'react'
 import { hoverEase } from '../animations/variants'
 import { StickySection } from './StickySection'
 
+const TILE_REVEAL_STEP = 0.12
+const TILE_REVEAL_DURATION = 0.5
+
 const tileStagger = {
   hidden: { opacity: 0, scale: 0.95 },
-  visible: {
+  visible: (order: number) => ({
     opacity: 1,
     scale: 1,
-    transition: { duration: 0.4, ease: 'easeOut' as const },
-  },
+    transition: { delay: order * TILE_REVEAL_STEP, duration: TILE_REVEAL_DURATION, ease: 'easeOut' as const },
+  }),
 }
 
 const gridStagger = {
   hidden: {},
-  visible: {
-    transition: { staggerChildren: 0.05 },
-  },
+  visible: {},
 }
 
 const tileVariants = {
@@ -35,7 +36,7 @@ interface SkillTile {
   fg: string
 }
 
-// Desktop (4-col, 11 rows — no two adjacent rows share the same span pattern):
+// Desktop (6-col, 11 rows — no two adjacent rows share the same span pattern):
 //   R1: Python(2) TypeScript(2)                    [2,2]
 //   R2: Python(2) Docker(1) C/C++(1)               [2,1,1]
 //   R3: Python(2) JavaScript(2)                    [2,2]
@@ -89,10 +90,31 @@ const tiles: SkillTile[] = [
   { category: 'TOOL',      name: 'Jupyter',      colSpan: 'col-span-2',                        rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
 ]
 
+function getResponsiveSpan(span: string, axis: 'col' | 'row') {
+  const mdMatch = span.match(new RegExp(`md:${axis}-span-(\\d+)`))
+  if (mdMatch) return Number(mdMatch[1])
+
+  const baseMatch = span.match(new RegExp(`${axis}-span-(\\d+)`))
+  return baseMatch ? Number(baseMatch[1]) : 1
+}
+
+function getTileArea(tile: SkillTile) {
+  return getResponsiveSpan(tile.colSpan, 'col') * getResponsiveSpan(tile.rowSpan, 'row')
+}
+
+const revealOrderByName = new Map(
+  [...tiles]
+    .sort((a, b) => getTileArea(b) - getTileArea(a) || tiles.indexOf(a) - tiles.indexOf(b))
+    .map((tile, index) => [tile.name, index]),
+)
+
 function SkillTileCard({ tile }: { tile: SkillTile }) {
+  const revealOrder = revealOrderByName.get(tile.name) ?? 0
+
   return (
     <motion.div
       variants={tileVariants}
+      custom={revealOrder}
       whileHover="hover"
       className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-5 rounded-lg flex flex-col justify-between cursor-default`}
       style={{ backgroundColor: tile.bg, color: tile.fg }}


### PR DESCRIPTION
**Purpose** — Make the Skills bento reveal read deliberately by prioritizing anchor tiles and slowing the reveal rhythm.

**What it does** — Replaces the grid-level 50ms uniform stagger with deterministic per-tile reveal positions derived from the desktop bento layout weight.

**Changes made**
- Updated src/components/SkillsSection.tsx to compute reveal order from responsive tile area, pass each tile a Framer Motion custom reveal position, and use 120ms delay steps with 500ms fade duration.
- Updated src/components/SkillsSection.test.tsx to cover anchor-first ordering, deterministic one-position-per-tile sequencing, and the removal of grid-level stagger timing.

**Additional notes** — #84 resume-backed skills content is already present in the branch base. Required checks passed before commit: npm run typecheck and npm run test.

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced skill tile reveal animation with intelligent sequencing—larger anchor skills and core technologies are now revealed before smaller supporting tiles for improved visual hierarchy
  * Adjusted desktop grid layout structure for skill tiles
  * Refined animation timing and stagger parameters for a smoother, more polished reveal effect

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->