### PR TITLE
Skills: re-animate reveal on every re-entry

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -94,6 +94,20 @@ function getSkillAnimation(name: string) {
   return animation!
 }
 
+function getLatestGridAnimation() {
+  const gridAnimations = motionMock.divProps.filter(props => props.text === '')
+  const animation = gridAnimations[gridAnimations.length - 1]
+  expect(animation).toBeDefined()
+  return animation!
+}
+
+function getLatestTileRevealOrder() {
+  return motionMock.divProps
+    .filter(props => props.text !== undefined && props.text !== '')
+    .slice(-22)
+    .map(props => [props.text, props.custom])
+}
+
 describe('SkillsSection', () => {
   beforeEach(() => {
     motionMock.isInView = false
@@ -324,7 +338,7 @@ describe('SkillsSection', () => {
     }
   })
 
-  it('grid switches to visible on viewport entry once while tiles handle their own reveal delays', () => {
+  it('grid switches to visible on viewport entry while tiles handle their own reveal delays', () => {
     motionMock.isInView = true
 
     render(<SkillsSection />)
@@ -341,18 +355,37 @@ describe('SkillsSection', () => {
     })
     expect(motionMock.useInView).toHaveBeenCalledWith(
       expect.objectContaining({ current: expect.any(HTMLElement) }),
-      { once: true, margin: '-10% 0px -10% 0px' },
+      { margin: '-10% 0px -10% 0px' },
     )
   })
 
   it('keeps tile animation hidden until the skills grid enters the viewport', () => {
     render(<SkillsSection />)
 
-    const gridAnimation = motionMock.divProps.find(props => props.text === '')
+    const gridAnimation = getLatestGridAnimation()
 
     expect(gridAnimation).toMatchObject({
       animate: 'hidden',
       initial: 'hidden',
     })
+  })
+
+  it('resets to hidden after leaving the viewport and replays the deterministic order on re-entry', () => {
+    motionMock.isInView = true
+    const { rerender } = render(<SkillsSection />)
+
+    const firstRevealOrder = getLatestTileRevealOrder()
+    expect(getLatestGridAnimation()).toMatchObject({ animate: 'visible' })
+
+    motionMock.isInView = false
+    rerender(<SkillsSection />)
+
+    expect(getLatestGridAnimation()).toMatchObject({ animate: 'hidden' })
+
+    motionMock.isInView = true
+    rerender(<SkillsSection />)
+
+    expect(getLatestGridAnimation()).toMatchObject({ animate: 'visible' })
+    expect(getLatestTileRevealOrder()).toEqual(firstRevealOrder)
   })
 })

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -131,7 +131,7 @@ function SkillTileCard({ tile }: { tile: SkillTile }) {
 
 export function SkillsSection() {
   const gridRef = useRef<HTMLDivElement>(null)
-  const isInView = useInView(gridRef, { once: true, margin: '-10% 0px -10% 0px' })
+  const isInView = useInView(gridRef, { margin: '-10% 0px -10% 0px' })
 
   return (
     <StickySection id="skills" className="flex flex-col justify-center py-14 px-8 bg-graphite">


### PR DESCRIPTION
Purpose: Replay the Skills tile reveal whenever the section re-enters the viewport instead of only on first entry.

What it does: Removes one-shot viewport observation so the grid animates back to hidden after leaving view and replays the existing deterministic reveal sequence on re-entry.

Changes made:
- Updated src/components/SkillsSection.tsx to call useInView without once: true.
- Updated src/components/SkillsSection.test.tsx with viewport re-entry coverage for visible-hidden-visible replay and stable reveal order.

Additional notes: Builds on the deterministic reveal sequence from #76 already present on main.

Closes #77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skills grid animation to replay when re-entering the viewport instead of playing only once.

* **Tests**
  * Updated test utilities and assertions for viewport behavior and tile reveal animations.
  * Added test coverage for viewport re-entry animation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->