### PR TITLE
Hero: value-prop TypeIn + CTA fade sequencing

### DIFF
--- a/src/animations/RotatingRole.test.tsx
+++ b/src/animations/RotatingRole.test.tsx
@@ -94,6 +94,32 @@ it('completes type -> hold -> erase cycle and shows second role', () => {
     expect(text).toBe(DEVELOPER)
   })
 
+  it('fires onFirstCycleComplete once after the second role finishes typing', () => {
+    const onFirstCycleComplete = vi.fn()
+
+    render(
+      <RotatingRole
+        roles={[CS_STUDENT, DEVELOPER]}
+        active={true}
+        typeSpeed={40}
+        eraseSpeed={40}
+        holdMs={50}
+        onFirstCycleComplete={onFirstCycleComplete}
+      />
+    )
+
+    for (let i = 0; i <= CS_STUDENT.length; i++) act(() => { vi.advanceTimersByTime(40) })
+    act(() => { vi.advanceTimersByTime(50) })
+    for (let i = 0; i <= CS_STUDENT.length; i++) act(() => { vi.advanceTimersByTime(40) })
+    expect(onFirstCycleComplete).not.toHaveBeenCalled()
+
+    for (let i = 0; i <= DEVELOPER.length; i++) act(() => { vi.advanceTimersByTime(40) })
+    expect(onFirstCycleComplete).toHaveBeenCalledTimes(1)
+
+    act(() => { vi.advanceTimersByTime(5000) })
+    expect(onFirstCycleComplete).toHaveBeenCalledTimes(1)
+  })
+
   it('cleans up timers on unmount', () => {
     const { unmount } = render(<RotatingRole roles={roles} active={true} />)
 

--- a/src/animations/RotatingRole.test.tsx
+++ b/src/animations/RotatingRole.test.tsx
@@ -27,7 +27,7 @@ describe('RotatingRole', () => {
     expect(screen.getByText(new RegExp(`^${CS_STUDENT}$`))).toBeInTheDocument()
   })
 
-it('completes type -> hold -> erase cycle and shows second role', () => {
+  it('completes type -> hold -> erase cycle and shows second role', () => {
     const { container } = render(<RotatingRole roles={roles} active={true} typeSpeed={40} eraseSpeed={40} holdMs={100} />)
 
     for (let i = 0; i <= CS_STUDENT.length; i++) {
@@ -118,6 +118,71 @@ it('completes type -> hold -> erase cycle and shows second role', () => {
 
     act(() => { vi.advanceTimersByTime(5000) })
     expect(onFirstCycleComplete).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls the latest onFirstCycleComplete after the callback changes mid-cycle', () => {
+    const firstCallback = vi.fn()
+    const latestCallback = vi.fn()
+    const { rerender } = render(
+      <RotatingRole
+        roles={[CS_STUDENT, DEVELOPER]}
+        active={true}
+        typeSpeed={40}
+        eraseSpeed={40}
+        holdMs={50}
+        onFirstCycleComplete={firstCallback}
+      />
+    )
+
+    for (let i = 0; i <= CS_STUDENT.length; i++) act(() => { vi.advanceTimersByTime(40) })
+
+    rerender(
+      <RotatingRole
+        roles={[CS_STUDENT, DEVELOPER]}
+        active={true}
+        typeSpeed={40}
+        eraseSpeed={40}
+        holdMs={50}
+        onFirstCycleComplete={latestCallback}
+      />
+    )
+
+    act(() => { vi.advanceTimersByTime(50) })
+    for (let i = 0; i <= CS_STUDENT.length; i++) act(() => { vi.advanceTimersByTime(40) })
+    for (let i = 0; i <= DEVELOPER.length; i++) act(() => { vi.advanceTimersByTime(40) })
+
+    expect(firstCallback).not.toHaveBeenCalled()
+    expect(latestCallback).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire onFirstCycleComplete after becoming inactive before completion', () => {
+    const onFirstCycleComplete = vi.fn()
+    const { rerender } = render(
+      <RotatingRole
+        roles={[CS_STUDENT, DEVELOPER]}
+        active={true}
+        typeSpeed={40}
+        eraseSpeed={40}
+        holdMs={50}
+        onFirstCycleComplete={onFirstCycleComplete}
+      />
+    )
+
+    for (let i = 0; i <= CS_STUDENT.length; i++) act(() => { vi.advanceTimersByTime(40) })
+    rerender(
+      <RotatingRole
+        roles={[CS_STUDENT, DEVELOPER]}
+        active={false}
+        typeSpeed={40}
+        eraseSpeed={40}
+        holdMs={50}
+        onFirstCycleComplete={onFirstCycleComplete}
+      />
+    )
+
+    act(() => { vi.advanceTimersByTime(5000) })
+
+    expect(onFirstCycleComplete).not.toHaveBeenCalled()
   })
 
   it('cleans up timers on unmount', () => {

--- a/src/animations/RotatingRole.tsx
+++ b/src/animations/RotatingRole.tsx
@@ -6,6 +6,8 @@ interface RotatingRoleProps {
   typeSpeed?: number
   eraseSpeed?: number
   holdMs?: number
+  /** Fires once after the first role has typed, held, erased, and the second role has typed. */
+  onFirstCycleComplete?: () => void
 }
 
 type Phase = 'idle' | 'typing' | 'holding' | 'erasing'
@@ -16,12 +18,16 @@ export function RotatingRole({
   typeSpeed = 40,
   eraseSpeed = 30,
   holdMs = 2000,
+  onFirstCycleComplete,
 }: RotatingRoleProps) {
   const [displayed, setDisplayed] = useState('')
   const [showCursor, setShowCursor] = useState(true)
   const stateRef = useRef({ roleIndex: 0, charIndex: 0, phase: 'idle' as Phase })
   const timerRef = useRef<number | null>(null)
   const cursorTimerRef = useRef<number | null>(null)
+  const onFirstCycleCompleteRef = useRef(onFirstCycleComplete)
+  const hasCompletedFirstCycleRef = useRef(false)
+  onFirstCycleCompleteRef.current = onFirstCycleComplete
 
   const clearTimers = () => {
     if (timerRef.current) {
@@ -40,6 +46,7 @@ export function RotatingRole({
       setDisplayed('')
       setShowCursor(true)
       stateRef.current = { roleIndex: 0, charIndex: 0, phase: 'idle' }
+      hasCompletedFirstCycleRef.current = false
       return
     }
 
@@ -62,6 +69,10 @@ export function RotatingRole({
           timerRef.current = window.setTimeout(tick, typeSpeed)
         } else {
           stateRef.current.phase = 'holding'
+          if (roleIndex > 0 && !hasCompletedFirstCycleRef.current) {
+            hasCompletedFirstCycleRef.current = true
+            onFirstCycleCompleteRef.current?.()
+          }
           timerRef.current = window.setTimeout(tick, holdMs)
         }
       } else if (phase === 'holding') {

--- a/src/components/HeroSection.constants.ts
+++ b/src/components/HeroSection.constants.ts
@@ -7,10 +7,8 @@ export const FIRST_NAME = 'FARHAN'
 export const LAST_NAME = 'MOHAMMED'
 export const NAME_SPEED = 40
 
-export const VALUE_PROP_DELAY = 400
 export const VALUE_PROP_SPEED = 35
 
-export const CTA_DELAY = 200
 export const CTA_FADE_DURATION = 0.4
 
 export const cursorVariants: Variants = {

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -2,13 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
 import HeroSection from './HeroSection'
 import {
-  CTA_DELAY,
   FIRST_NAME,
   LAST_NAME,
   NAME_SPEED,
   ROLES,
   VALUE_PROP,
-  VALUE_PROP_DELAY,
   VALUE_PROP_SPEED,
   cursorVariants,
 } from './HeroSection.constants'
@@ -16,6 +14,8 @@ import {
 const FIRST_NAME_DURATION = FIRST_NAME.length * NAME_SPEED
 const LAST_NAME_DURATION = ` ${LAST_NAME}`.length * NAME_SPEED
 const ROLE_TYPE_SPEED = 40
+const ROLE_ERASE_SPEED = 30
+const ROLE_HOLD_MS = 2000
 
 function advanceToNameComplete() {
   act(() => {
@@ -29,6 +29,26 @@ function advanceToNameComplete() {
 function advanceRoleTyping(role: string) {
   act(() => {
     vi.advanceTimersByTime((role.length + 1) * ROLE_TYPE_SPEED)
+  })
+}
+
+function advanceFirstRoleCycle() {
+  advanceRoleTyping(ROLES[0])
+  act(() => {
+    vi.advanceTimersByTime(ROLE_HOLD_MS + (ROLES[0].length + 1) * ROLE_ERASE_SPEED)
+  })
+  advanceRoleTyping(ROLES[1])
+}
+
+function advanceToValuePropStart() {
+  advanceToNameComplete()
+  advanceFirstRoleCycle()
+}
+
+function advanceToValuePropComplete() {
+  advanceToValuePropStart()
+  act(() => {
+    vi.advanceTimersByTime(VALUE_PROP.length * VALUE_PROP_SPEED)
   })
 }
 
@@ -79,7 +99,7 @@ describe('HeroSection', () => {
     expect(valueProp.textContent).toBe('')
   })
 
-  it('value prop waits until name completes plus the 400ms gap before typing', () => {
+  it('value prop waits until RotatingRole completes the first role cycle before typing', () => {
     render(<HeroSection />)
     const valueProp = screen.getByTestId('value-prop')
 
@@ -88,28 +108,34 @@ describe('HeroSection', () => {
     expect(valueProp.textContent).toBe('')
     expect(screen.queryByTestId('value-prop-cursor')).not.toBeInTheDocument()
 
+    advanceRoleTyping(ROLES[0])
+    expect(valueProp.textContent).toBe('')
+    expect(screen.queryByTestId('value-prop-cursor')).not.toBeInTheDocument()
+
     act(() => {
-      vi.advanceTimersByTime(VALUE_PROP_DELAY)
+      vi.advanceTimersByTime(ROLE_HOLD_MS + (ROLES[0].length + 1) * ROLE_ERASE_SPEED)
     })
 
     expect(valueProp.textContent).toBe('')
+    expect(screen.queryByTestId('value-prop-cursor')).not.toBeInTheDocument()
+
+    advanceRoleTyping(ROLES[1])
+
     expect(screen.getByTestId('value-prop-cursor')).toBeInTheDocument()
 
     act(() => {
       vi.advanceTimersByTime(VALUE_PROP_SPEED)
     })
 
-    expect(valueProp.textContent).toBe('/')
+    expect(valueProp.textContent.length).toBeGreaterThan(0)
+    expect(valueProp.textContent.length).toBeLessThan(VALUE_PROP.length)
     expect(valueProp.lastElementChild).toBe(screen.getByTestId('value-prop-cursor'))
   })
 
   it('value prop completes at 35ms/char and removes its cursor immediately', () => {
     render(<HeroSection />)
 
-    advanceToNameComplete()
-    act(() => {
-      vi.advanceTimersByTime(VALUE_PROP_DELAY + VALUE_PROP.length * VALUE_PROP_SPEED)
-    })
+    advanceToValuePropComplete()
 
     const valueProp = screen.getByTestId('value-prop')
     expect(valueProp.textContent).toBe(VALUE_PROP)
@@ -131,10 +157,7 @@ describe('HeroSection', () => {
   it('shows the VIEW_WORK call-to-action linking to projects section', () => {
     render(<HeroSection />)
 
-    advanceToNameComplete()
-    act(() => {
-      vi.advanceTimersByTime(VALUE_PROP_DELAY + VALUE_PROP.length * VALUE_PROP_SPEED + CTA_DELAY)
-    })
+    advanceToValuePropComplete()
 
     const link = screen.getByRole('link', { name: /VIEW_WORK →/i })
     expect(link).toBeInTheDocument()
@@ -168,33 +191,33 @@ describe('HeroSection', () => {
   it('CTAs are absent before sequence completes', () => {
     render(<HeroSection />)
 
-    advanceToNameComplete()
+    advanceToValuePropStart()
     act(() => {
-      vi.advanceTimersByTime(VALUE_PROP_DELAY + VALUE_PROP.length * VALUE_PROP_SPEED)
+      vi.advanceTimersByTime(VALUE_PROP.length * VALUE_PROP_SPEED - 1)
     })
 
     expect(screen.queryByRole('link', { name: /VIEW_WORK →/i })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /VIEW_RESUME →/i })).not.toBeInTheDocument()
   })
 
-  it('CTAs remain absent until the full 200ms post-sequence delay elapses', () => {
+  it('CTAs appear as soon as the value prop TypeIn finishes', () => {
     render(<HeroSection />)
 
-    advanceToNameComplete()
-    act(() => {
-      vi.advanceTimersByTime(VALUE_PROP_DELAY + VALUE_PROP.length * VALUE_PROP_SPEED + CTA_DELAY - 1)
-    })
+    advanceToValuePropComplete()
 
-    expect(screen.queryByRole('link', { name: /VIEW_WORK →/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole('link', { name: /VIEW_RESUME →/i })).not.toBeInTheDocument()
+    const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
+    const viewResume = screen.getByRole('link', { name: /VIEW_RESUME →/i })
+
+    expect(viewWork).toBeInTheDocument()
+    expect(viewResume).toBeInTheDocument()
   })
 
-  it('cleans up the pending CTA reveal timer when unmounted', () => {
+  it('cleans up pending intro timers when unmounted', () => {
     const { unmount } = render(<HeroSection />)
 
     advanceToNameComplete()
     act(() => {
-      vi.advanceTimersByTime(VALUE_PROP_DELAY + VALUE_PROP.length * VALUE_PROP_SPEED)
+      vi.advanceTimersByTime(ROLE_TYPE_SPEED)
     })
 
     expect(vi.getTimerCount()).toBeGreaterThan(0)
@@ -204,13 +227,10 @@ describe('HeroSection', () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
-  it('CTAs appear after value prop completes plus 200ms delay', () => {
+  it('CTAs preserve project and resume link targets after value prop completes', () => {
     render(<HeroSection />)
 
-    advanceToNameComplete()
-    act(() => {
-      vi.advanceTimersByTime(VALUE_PROP_DELAY + VALUE_PROP.length * VALUE_PROP_SPEED + CTA_DELAY)
-    })
+    advanceToValuePropComplete()
 
     const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
     const viewResume = screen.getByRole('link', { name: /VIEW_RESUME →/i })
@@ -226,10 +246,7 @@ describe('HeroSection', () => {
   it('VIEW_WORK uses filled tangerine style, VIEW_RESUME uses outlined style', () => {
     render(<HeroSection />)
 
-    advanceToNameComplete()
-    act(() => {
-      vi.advanceTimersByTime(VALUE_PROP_DELAY + VALUE_PROP.length * VALUE_PROP_SPEED + CTA_DELAY)
-    })
+    advanceToValuePropComplete()
 
     const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
     const viewResume = screen.getByRole('link', { name: /VIEW_RESUME →/i })
@@ -271,7 +288,7 @@ describe('HeroSection', () => {
       expect(screen.getByTestId('rotating-role').textContent).toContain(role)
 
       act(() => {
-        vi.advanceTimersByTime(2000 + (role.length + 1) * 30)
+        vi.advanceTimersByTime(ROLE_HOLD_MS + (role.length + 1) * ROLE_ERASE_SPEED)
       })
     })
   })

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,17 +1,15 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { StickySection } from './StickySection'
 import { TypeIn } from '../animations/TypeIn'
 import { RotatingRole } from '../animations/RotatingRole'
 import {
-  CTA_DELAY,
   CTA_FADE_DURATION,
   FIRST_NAME,
   LAST_NAME,
   NAME_SPEED,
   ROLES,
   VALUE_PROP,
-  VALUE_PROP_DELAY,
   VALUE_PROP_SPEED,
   cursorVariants,
 } from './HeroSection.constants'
@@ -25,45 +23,9 @@ const HeroSection: React.FC = () => {
   const [firstNameDone, setFirstNameDone] = useState(false)
   const [nameDone, setNameDone] = useState(false)
   const [showNameCursor, setShowNameCursor] = useState(false)
-  const [valueProp, setValueProp] = useState('')
-  const [showValuePropCursor, setShowValuePropCursor] = useState(false)
+  const [startValueProp, setStartValueProp] = useState(false)
+  const [valuePropDone, setValuePropDone] = useState(false)
   const [showCTAs, setShowCTAs] = useState(false)
-
-  const valuePropRef = useRef(0)
-  const timersRef = useRef<number[]>([])
-
-  useEffect(() => {
-    const schedule = (callback: () => void, delay: number) => {
-      const timer = window.setTimeout(callback, delay)
-      timersRef.current.push(timer)
-    }
-
-    const typeValueProp = () => {
-      setShowValuePropCursor(true)
-
-      schedule(() => {
-        valuePropRef.current += 1
-        setValueProp(VALUE_PROP.slice(0, valuePropRef.current))
-
-        if (valuePropRef.current === VALUE_PROP.length) {
-          setShowValuePropCursor(false)
-          schedule(() => setShowCTAs(true), CTA_DELAY)
-          return
-        }
-
-        typeValueProp()
-      }, VALUE_PROP_SPEED)
-    }
-
-    if (nameDone) {
-      schedule(typeValueProp, VALUE_PROP_DELAY)
-    }
-
-    return () => {
-      timersRef.current.forEach((timer) => window.clearTimeout(timer))
-      timersRef.current = []
-    }
-  }, [nameDone])
 
   return (
     <StickySection id="home" className="relative flex flex-col justify-center bg-graphite">
@@ -113,11 +75,25 @@ const HeroSection: React.FC = () => {
           )}
         </h1>
 
-        <RotatingRole roles={ROLES} active={nameDone} />
+        <RotatingRole
+          roles={ROLES}
+          active={nameDone}
+          onFirstCycleComplete={() => {
+            setStartValueProp(true)
+          }}
+        />
 
         <p className="font-body text-lg text-periwinkle/80" data-testid="value-prop">
-          {valueProp}
-          {showValuePropCursor && (
+          <TypeIn
+            start={startValueProp}
+            text={VALUE_PROP}
+            speed={VALUE_PROP_SPEED}
+            onDone={() => {
+              setValuePropDone(true)
+              setShowCTAs(true)
+            }}
+          />
+          {startValueProp && !valuePropDone && (
             <motion.span
               data-testid="value-prop-cursor"
               aria-hidden="true"


### PR DESCRIPTION
Purpose: Complete the Hero intro sequence so the value prop and CTA reveal are chained from animation callbacks instead of manual timers.

What it does: RotatingRole now reports when the first role cycle has reached the second role, Hero starts the value-prop TypeIn from that callback, and CTAs reveal from the value-prop onDone callback.

Changes made:
- Added a one-shot onFirstCycleComplete callback to src/animations/RotatingRole.tsx.
- Replaced HeroSection manual value-prop timeout sequencing with TypeIn start/onDone composition.
- Removed obsolete Hero delay constants.
- Updated Hero and RotatingRole tests for the new callback-driven sequence.

Additional notes: Builds on #66 TypeIn and #88 RotatingRole already present on main.

Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved animation sequencing in the hero: the value-proposition text now begins only after the rotating role completes its first cycle, and CTAs appear after that text finishes typing; removed prior fixed delay-based timing.

* **Tests**
  * Added/updated tests to verify rotating-role cycle behavior, sequencing transitions, and lifecycle edge cases (prop changes and deactivation).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->