### PR TITLE
Contact/Footer: compact metadata footer region

### DIFF
--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -8,8 +8,9 @@ vi.mock('framer-motion', async () => {
   return { ...actual, useInView: vi.fn().mockReturnValue(false) }
 })
 
+const canonicalEmailHref = 'mailto:famohammed@shockers.wichita.edu'
+
 describe('ContactSection', () => {
-  const canonicalEmailHref = 'mailto:famohammed@shockers.wichita.edu'
 
   beforeEach(() => {
     vi.mocked(useInView).mockReturnValue(false)
@@ -19,7 +20,7 @@ describe('ContactSection', () => {
     vi.useRealTimers()
   })
 
-  it('renders a contact section with only the CTA heading and contact links', () => {
+  it('renders a contact section with only the CTA heading and send message link', () => {
     vi.mocked(useInView).mockReturnValue(true)
     vi.useFakeTimers()
     render(<ContactSection />)
@@ -32,41 +33,24 @@ describe('ContactSection', () => {
     const links = within(section).getAllByRole('link')
     expect(links.map((link) => link.textContent)).toEqual([
       'SEND_MESSAGE →',
-      '// GITHUB',
-      '// LINKEDIN',
-      '// EMAIL',
-      '// RESUME',
     ])
 
-    expect(section).not.toHaveTextContent('// 04 CONTACT')
+    expect(section).not.toHaveTextContent('// GITHUB')
+    expect(section).not.toHaveTextContent('// LINKEDIN')
+    expect(section).not.toHaveTextContent('// EMAIL')
+    expect(section).not.toHaveTextContent('// RESUME')
     expect(section).not.toHaveTextContent('FARHAN_MOHAMMED © 2026')
     expect(section).not.toHaveTextContent('PORTFOLIO.EXE')
   })
 
-  it('renders contact links with the expected destinations', () => {
+  it('renders the send message link with the expected destination', () => {
     vi.mocked(useInView).mockReturnValue(true)
     vi.useFakeTimers()
     render(<ContactSection />)
     act(() => { vi.advanceTimersByTime(1000) })
     const sendMessageLink = screen.getByRole('link', { name: 'SEND_MESSAGE →' })
-    const githubLink = screen.getByRole('link', { name: '// GITHUB' })
-    const linkedInLink = screen.getByRole('link', { name: '// LINKEDIN' })
-    const emailLink = screen.getByRole('link', { name: '// EMAIL' })
-    const resumeLink = screen.getByRole('link', { name: '// RESUME' })
 
     expect(sendMessageLink).toHaveAttribute('href', canonicalEmailHref)
-    expect(githubLink).toHaveAttribute('href', 'https://github.com/Nemesis-12')
-    expect(githubLink).not.toHaveAttribute('target')
-    expect(githubLink).not.toHaveAttribute('rel')
-    expect(linkedInLink).toHaveAttribute('href', 'https://linkedin.com/in/fa-mohammed')
-    expect(linkedInLink).not.toHaveAttribute('target')
-    expect(linkedInLink).not.toHaveAttribute('rel')
-    expect(emailLink).toHaveAttribute('href', canonicalEmailHref)
-    expect(emailLink).not.toHaveAttribute('target')
-    expect(emailLink).not.toHaveAttribute('rel')
-    expect(resumeLink).toHaveAttribute('href', '/resume.pdf')
-    expect(resumeLink).toHaveAttribute('target', '_blank')
-    expect(resumeLink).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
   it('renders footer link prefixes in orange and transitions the full link to white on hover', () => {
@@ -130,7 +114,7 @@ describe('ContactSection', () => {
 })
 
 describe('Footer', () => {
-  it('renders a separate footer with only static labels', () => {
+  it('renders a separate footer with social links and static labels', () => {
     render(<ContactSection />)
     const section = document.querySelector('#contact')
     const footer = document.querySelector('footer')
@@ -139,13 +123,33 @@ describe('Footer', () => {
     expect(section?.nextElementSibling).toBe(footer)
     expect(footer).toHaveTextContent('FARHAN_MOHAMMED © 2026')
     expect(footer).toHaveTextContent('PORTFOLIO.EXE')
-    expect(Array.from(footer?.children ?? []).map((child) => child.textContent)).toEqual([
-      'FARHAN_MOHAMMED © 2026',
-      'PORTFOLIO.EXE',
-    ])
+    expect(footer).toHaveTextContent('// GITHUB')
+    expect(footer).toHaveTextContent('// LINKEDIN')
+    expect(footer).toHaveTextContent('// EMAIL')
+    expect(footer).toHaveTextContent('// RESUME')
     expect(footer).not.toHaveTextContent("LET'S CONNECT.")
     expect(footer).not.toHaveTextContent('SEND_MESSAGE →')
-    expect(footer?.querySelectorAll('a, button, input, select, textarea, [tabindex]').length).toBe(0)
+  })
+
+  it('renders footer social links with the expected destinations', () => {
+    render(<ContactSection />)
+    const githubLink = screen.getByRole('link', { name: '// GITHUB' })
+    const linkedInLink = screen.getByRole('link', { name: '// LINKEDIN' })
+    const emailLink = screen.getByRole('link', { name: '// EMAIL' })
+    const resumeLink = screen.getByRole('link', { name: '// RESUME' })
+
+    expect(githubLink).toHaveAttribute('href', 'https://github.com/Nemesis-12')
+    expect(githubLink).not.toHaveAttribute('target')
+    expect(githubLink).not.toHaveAttribute('rel')
+    expect(linkedInLink).toHaveAttribute('href', 'https://linkedin.com/in/fa-mohammed')
+    expect(linkedInLink).not.toHaveAttribute('target')
+    expect(linkedInLink).not.toHaveAttribute('rel')
+    expect(emailLink).toHaveAttribute('href', canonicalEmailHref)
+    expect(emailLink).not.toHaveAttribute('target')
+    expect(emailLink).not.toHaveAttribute('rel')
+    expect(resumeLink).toHaveAttribute('href', '/resume.pdf')
+    expect(resumeLink).toHaveAttribute('target', '_blank')
+    expect(resumeLink).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
   it('marks footer text as a stronger parallax layer', () => {

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -48,39 +48,41 @@ export default function ContactSection() {
             variants={hoverEase}
             initial="idle"
             whileHover="hover"
-            className="inline-block font-body text-sm border-2 border-platinum text-platinum px-8 py-4 mb-12 hover:bg-platinum hover:text-graphite transition-colors"
+            className="inline-block font-body text-sm border-2 border-platinum text-platinum px-8 py-4 hover:bg-platinum hover:text-graphite transition-colors"
           >
             SEND_MESSAGE →
           </motion.a>
-
-          <div className="flex flex-wrap gap-6">
-            {footerLinks.map(({ prefix, label, href, target }) => (
-              <motion.a
-                key={label}
-                href={href}
-                target={target}
-                aria-label={`${prefix} ${label}`}
-                rel={target === '_blank' ? 'noopener noreferrer' : undefined}
-                variants={hoverEase}
-                initial="idle"
-                whileHover="hover"
-                className="group font-body text-sm"
-              >
-                <span className="text-atomic-tangerine group-hover:text-white transition-colors">{prefix}{' '}</span>
-                <span className="text-periwinkle group-hover:text-white transition-colors">{label}</span>
-              </motion.a>
-            ))}
-          </div>
         </div>
       </StickySection>
 
-      <footer className="flex justify-between items-center px-8 py-8 border-t border-periwinkle/20 text-xs font-body text-periwinkle bg-graphite">
-        <span data-parallax data-parallax-factor="0.5">
-          FARHAN_MOHAMMED © 2026
-        </span>
-        <span data-parallax data-parallax-factor="0.5">
-          PORTFOLIO.EXE
-        </span>
+      <footer className="flex flex-col gap-6 px-8 py-8 border-t border-periwinkle/20 text-xs font-body text-periwinkle bg-graphite">
+        <div className="flex flex-wrap gap-6">
+          {footerLinks.map(({ prefix, label, href, target }) => (
+            <motion.a
+              key={label}
+              href={href}
+              target={target}
+              aria-label={`${prefix} ${label}`}
+              rel={target === '_blank' ? 'noopener noreferrer' : undefined}
+              variants={hoverEase}
+              initial="idle"
+              whileHover="hover"
+              className="group font-body text-sm"
+            >
+              <span className="text-atomic-tangerine group-hover:text-white transition-colors">{prefix}{' '}</span>
+              <span className="text-periwinkle group-hover:text-white transition-colors">{label}</span>
+            </motion.a>
+          ))}
+        </div>
+
+        <div className="flex justify-between items-center">
+          <span data-parallax data-parallax-factor="0.5">
+            FARHAN_MOHAMMED © 2026
+          </span>
+          <span data-parallax data-parallax-factor="0.5">
+            PORTFOLIO.EXE
+          </span>
+        </div>
       </footer>
     </>
   )


### PR DESCRIPTION
**Purpose** — Separate the social/profile links from the full-screen Contact CTA into a compact footer metadata region so the CTA remains uncluttered.

**What it does** — Moves the GITHUB, LINKEDIN, EMAIL, and RESUME links from the CTA section into the footer, which now renders as a compact flex-col layout with links above the copyright/metadata row.

**Changes made** —
- `src/components/ContactSection.tsx`: relocated footer links from StickySection to the footer element; footer uses flex-col with gap-6 spacing; removed `mb-12` from SEND_MESSAGE button since links are no longer below it
- `src/components/ContactSection.test.tsx`: updated CTA test to assert only SEND_MESSAGE link is present; added footer tests for social link presence and href/rel attributes; moved `canonicalEmailHref` constant to module scope for shared use

**Additional notes** — Builds on #81 (footer social link styling) and #87 (Contact CTA typewriter) already present on main. All 9 tests pass and typecheck is clean.

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contact section now displays only the primary CTA heading and send-message link, removing redundant contact labels.
  * Footer social media links now properly integrated into the sticky section with correct styling and destinations.

* **Style**
  * Updated send-message button styling with improved hover states and spacing.
  * Enhanced footer link formatting with improved visual spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->