### PR TITLE
Timeline: typewriter speed calibration for bullet lists

### DIFF
--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -47,7 +47,9 @@ describe('TimelineSection', () => {
       })
 
       const allLines = document.querySelectorAll('[data-typewriter-line]')
-      const texts = Array.from(allLines).map((el) => el.textContent)
+      const texts = Array.from(allLines)
+        .map((el) => el.textContent)
+        .filter((t) => t !== '')
 
       expect(texts[0]).toBe('commit d4e8f2c')
       expect(texts[3]).toBe('NETAPP INC.')
@@ -57,9 +59,9 @@ describe('TimelineSection', () => {
       expect(texts[12]).toBe('WICHITA STATE UNIVERSITY')
       expect(texts[13]).toBe('ACCELERATED_M.S._COMPUTER_SCIENCE')
 
-      expect(texts[15]).toBe('commit b7c3e1a')
-      expect(texts[18]).toBe('WICHITA STATE UNIVERSITY')
-      expect(texts[19]).toBe('B.S._COMPUTER_SCIENCE')
+      expect(texts[14]).toBe('commit b7c3e1a')
+      expect(texts[17]).toBe('WICHITA STATE UNIVERSITY')
+      expect(texts[18]).toBe('B.S._COMPUTER_SCIENCE')
     })
   })
 
@@ -253,6 +255,27 @@ describe('TimelineSection', () => {
 
       const resumedText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
       expect(resumedText.length).toBeGreaterThan(partialText.length)
+    })
+
+    it('issue #98 - longest bullet completes within 2.5s', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      // Metadata takes ~1664ms at 16ms/char, then longest bullet (156 chars) takes ~2496ms
+      act(() => {
+        vi.advanceTimersByTime(4200)
+      })
+
+      const allLines = document.querySelectorAll('[data-typewriter-line]')
+      const texts = Array.from(allLines).map((el) => el.textContent)
+
+      const longestBullet = 'Built automated analysis pipeline processing storage telemetry across distributed RAID systems (FC, SAS, NVMe/RoCE), handling terabytes of performance data.'
+      expect(texts).toContain(longestBullet)
     })
   })
 })

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -58,7 +58,7 @@ function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean 
 
   return (
     <div className="min-h-screen py-6 font-mono" data-testid="commit-entry">
-      <Typewriter active={active} lines={lines} speed={25} />
+      <Typewriter active={active} lines={lines} speed={16} />
     </div>
   )
 }


### PR DESCRIPTION
**Purpose** — Tune the Timeline Typewriter per-character speed so the longest bullet line completes within a comfortable 2.5s window.

**What it does** — Reduces the Typewriter speed from 25ms/char to 16ms/char, bringing the longest bullet (156 chars) from ~3.9s down to ~2.5s of typing time.

**Changes made**
- `src/components/TimelineSection.tsx`: changed Typewriter `speed` prop from 25 to 16
- `src/components/TimelineSection.test.tsx`: added integration test verifying longest NetApp bullet completes within expected timeframe; filtered empty trailing lines in ordering test to handle entries that finish typing before the 15s assertion window; adjusted Entry 2 index assertions after filtering

**Additional notes**
- The speed prop remains configurable via the Typewriter component's `speed` prop for callers who need to override
- 16ms/char was chosen as the midpoint of the 15–18ms range suggested in the issue, giving 156 * 16 = 2496ms for the longest line
- All 177 tests pass, typecheck clean

Closes #98

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved timeline animation rendering speed and optimized bullet point display timing for better overall responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->