### PR TITLE
Card-deck stacking: wire StickySection on all sections

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,6 +11,7 @@ const sectionIds = [
   'timeline-a3f9d2b',
   'timeline-b7c3e1a',
   'contact',
+  'footer',
 ] as const
 const shellConstraintClasses = ['container', 'max-w-7xl', 'mx-auto'] as const
 
@@ -48,16 +49,16 @@ describe('App shell', () => {
 
   it('renders sections in the correct order', () => {
     render(<App />)
-    const renderedSectionIds = document.querySelectorAll('section[id]')
-    expect(Array.from(renderedSectionIds).map((s) => s.id)).toEqual([...sectionIds])
+    const renderedStackIds = document.querySelectorAll('[data-sticky-section="true"][id]')
+    expect(Array.from(renderedStackIds).map((s) => s.id)).toEqual([...sectionIds])
   })
 
-  it('section surfaces span the full browser width', () => {
+  it('stack surfaces span the full browser width', () => {
     render(<App />)
-    const sectionIds = document.querySelectorAll('section[id]')
-    sectionIds.forEach((section) => {
-      expectNoShellConstraint(section)
-      expect(section.className).toContain('min-h-screen')
+    const stackSurfaces = document.querySelectorAll('[data-sticky-section="true"][id]')
+    stackSurfaces.forEach((surface) => {
+      expectNoShellConstraint(surface)
+      expect(surface.className).toContain('min-h-screen')
     })
   })
 
@@ -72,12 +73,12 @@ describe('App shell', () => {
   it('keeps the navbar above the sticky section stack', () => {
     render(<App />)
     const nav = document.querySelector('nav')
-    const sectionIds = document.querySelectorAll('section[id]')
+    const stackSurfaces = document.querySelectorAll('[data-sticky-section="true"][id]')
 
     expect(nav?.className).toContain('z-40')
-    sectionIds.forEach((section) => {
-      expect(section.className).toContain('sticky')
-      expect(Number((section as HTMLElement).style.zIndex)).toBeLessThan(40)
+    stackSurfaces.forEach((surface) => {
+      expect(surface.className).toContain('sticky')
+      expect(Number((surface as HTMLElement).style.zIndex)).toBeLessThan(40)
     })
   })
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -131,7 +131,7 @@ describe('App shell', () => {
     expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(2)
   })
 
-  it('uses element geometry for parallax layers outside sections', () => {
+  it('uses stack surface geometry for footer parallax layers', () => {
     const frameCallbacks = new Map<number, FrameRequestCallback>()
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
       frameCallbacks.set(1, callback)
@@ -139,15 +139,44 @@ describe('App shell', () => {
     })
 
     render(<App />)
+    const footer = document.querySelector('footer') as HTMLElement
     const footerText = document.querySelector('footer [data-parallax]') as HTMLElement
 
-    vi.spyOn(footerText, 'getBoundingClientRect').mockReturnValue(rectAtTop(-80))
+    vi.spyOn(footer, 'getBoundingClientRect').mockReturnValue(rectAtTop(-80))
+    vi.spyOn(footerText, 'getBoundingClientRect').mockReturnValue(rectAtTop(-20))
 
     act(() => {
       frameCallbacks.get(1)?.(0)
     })
 
     expect(footerText.style.transform).toBe('translate3d(0, 40px, 0)')
+  })
+
+  it('uses element geometry for parallax layers outside stack surfaces', () => {
+    const frameCallbacks = new Map<number, FrameRequestCallback>()
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      frameCallbacks.set(1, callback)
+      return 1
+    })
+
+    const orphanLayer = document.createElement('div')
+    orphanLayer.dataset.parallax = ''
+    orphanLayer.dataset.parallaxFactor = '0.5'
+    document.body.append(orphanLayer)
+
+    vi.spyOn(orphanLayer, 'getBoundingClientRect').mockReturnValue(rectAtTop(-80))
+
+    try {
+      render(<App />)
+
+      act(() => {
+        frameCallbacks.get(1)?.(0)
+      })
+
+      expect(orphanLayer.style.transform).toBe('translate3d(0, 40px, 0)')
+    } finally {
+      orphanLayer.remove()
+    }
   })
 
   it('treats missing and invalid parallax factors as zero movement', () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,9 +22,9 @@ function App() {
       const parallaxLayers = Array.from(document.querySelectorAll<HTMLElement>('[data-parallax]'))
       const layerUpdates = parallaxLayers.map((layer) => {
         const factor = Number(layer.dataset.parallaxFactor ?? 0)
-        const section = layer.closest('section')
-        const sectionRect = section?.getBoundingClientRect()
-        const scrollOffset = sectionRect ? -sectionRect.top : -layer.getBoundingClientRect().top
+        const stackSurface = layer.closest('[data-sticky-section="true"]')
+        const surfaceRect = stackSurface?.getBoundingClientRect()
+        const scrollOffset = surfaceRect ? -surfaceRect.top : -layer.getBoundingClientRect().top
 
         return {
           layer,

--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -131,6 +131,17 @@ describe('Footer', () => {
     expect(footer).not.toHaveTextContent('SEND_MESSAGE →')
   })
 
+  it('makes the compact footer a stackable sticky surface after the contact CTA', () => {
+    render(<ContactSection />)
+    const contact = document.querySelector('#contact')
+    const footer = document.querySelector('#footer')
+
+    expect(footer?.tagName.toLowerCase()).toBe('footer')
+    expect(contact?.nextElementSibling).toBe(footer)
+    expect(footer).toHaveAttribute('data-sticky-section', 'true')
+    expect(footer).toHaveClass('sticky', 'top-0', 'min-h-screen')
+  })
+
   it('renders footer social links with the expected destinations', () => {
     render(<ContactSection />)
     const githubLink = screen.getByRole('link', { name: '// GITHUB' })

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -55,7 +55,11 @@ export default function ContactSection() {
         </div>
       </StickySection>
 
-      <footer className="flex flex-col gap-6 px-8 py-8 border-t border-periwinkle/20 text-xs font-body text-periwinkle bg-graphite">
+      <StickySection
+        as="footer"
+        id="footer"
+        className="flex flex-col justify-center gap-6 px-8 py-8 border-t border-periwinkle/20 text-xs font-body text-periwinkle bg-graphite"
+      >
         <div className="flex flex-wrap gap-6">
           {footerLinks.map(({ prefix, label, href, target }) => (
             <motion.a
@@ -83,7 +87,7 @@ export default function ContactSection() {
             PORTFOLIO.EXE
           </span>
         </div>
-      </footer>
+      </StickySection>
     </>
   )
 }

--- a/src/components/StickySection.test.tsx
+++ b/src/components/StickySection.test.tsx
@@ -23,6 +23,16 @@ describe('StickySection', () => {
     expect(screen.getByText('Hello World')).toBeInTheDocument()
   })
 
+  it('can render as a footer surface', () => {
+    render(
+      <StickySection as="footer" id="footer">
+        Footer
+      </StickySection>,
+    )
+
+    expect(document.getElementById('footer')?.tagName.toLowerCase()).toBe('footer')
+  })
+
   it('renders as a sharp sticky full-viewport card layer', async () => {
     render(
       <>
@@ -72,6 +82,35 @@ describe('StickySection', () => {
     expect(outgoing.style.transform).toBe('scale(0.975)')
     expect(outgoing.style.opacity).toBe('0.875')
     expect(outgoing.style.filter).toBe('')
+  })
+
+  it('includes footer surfaces in stack depth calculations', async () => {
+    render(
+      <>
+        <StickySection id="contact">Contact</StickySection>
+        <StickySection as="footer" id="footer">
+          Footer
+        </StickySection>
+      </>,
+    )
+
+    const contact = document.getElementById('contact')!
+    const footer = document.getElementById('footer')!
+    mockRect(footer, 400)
+
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 800,
+    })
+
+    await act(async () => {
+      window.dispatchEvent(new Event('scroll'))
+    })
+
+    expect(contact.style.zIndex).toBe('1')
+    expect(footer.style.zIndex).toBe('2')
+    expect(contact.style.transform).toBe('scale(0.975)')
+    expect(contact.style.opacity).toBe('0.875')
   })
 
   it('keeps the outgoing section at full depth before the next section enters', async () => {

--- a/src/components/StickySection.tsx
+++ b/src/components/StickySection.tsx
@@ -1,9 +1,10 @@
-import { useLayoutEffect, useRef, type ReactNode } from 'react'
+import { useLayoutEffect, useRef, type ElementType, type ReactNode } from 'react'
 
 interface Props {
   id: string
   children: ReactNode
   className?: string
+  as?: 'section' | 'footer'
 }
 
 const MIN_SCALE = 0.95
@@ -18,8 +19,9 @@ function formatNumber(value: number) {
   return Number(value.toFixed(3)).toString()
 }
 
-export function StickySection({ id, children, className = '' }: Props) {
+export function StickySection({ id, children, className = '', as = 'section' }: Props) {
   const sectionRef = useRef<HTMLElement>(null)
+  const Component = as as ElementType
 
   useLayoutEffect(() => {
     const section = sectionRef.current
@@ -61,7 +63,7 @@ export function StickySection({ id, children, className = '' }: Props) {
   }, [])
 
   return (
-    <section
+    <Component
       ref={sectionRef}
       id={id}
       data-sticky-section="true"
@@ -69,6 +71,6 @@ export function StickySection({ id, children, className = '' }: Props) {
       style={{ willChange: 'transform, opacity' }}
     >
       {children}
-    </section>
+    </Component>
   )
 }

--- a/src/components/StickySection.tsx
+++ b/src/components/StickySection.tsx
@@ -9,7 +9,7 @@ interface Props {
 
 const MIN_SCALE = 0.95
 const MIN_OPACITY = 0.75
-const STICKY_SECTION_SELECTOR = 'section[data-sticky-section="true"]'
+const STICKY_SECTION_SELECTOR = '[data-sticky-section="true"]'
 
 function clamp(value: number) {
   return Math.min(Math.max(value, 0), 1)


### PR DESCRIPTION
**Purpose** — Ensure every stackable portfolio surface, including the compact footer, participates in the card-deck scroll model.

**What it does** — Extends StickySection to render semantic footer surfaces and wires the Contact footer into the sticky stack after the Contact CTA.

**Changes made**
- Updated StickySection with an as=footer/section render option while preserving the same depth behavior.
- Converted the compact Contact footer into a sticky stack surface with id footer.
- Added Contact and app shell tests covering footer stack participation, stack order, full-width surfaces, and navbar z-index constraints.

**Additional notes** — The Timeline wrapper remains untouched; existing Timeline panels already own their sticky behavior. Typecheck and full tests pass.

Closes #90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Footer now acts as a sticky surface, remaining visible and spanning full browser width as you scroll.
  * Parallax effects now compute relative to the nearest sticky surface (or the element itself when outside stacks), improving visual consistency for layered content.
  * Navbar stacking preserved so the navigation remains on top.

* **Style**
  * Footer styling refined with improved spacing, smaller text sizing, and border treatment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->