### PR TITLE
Projects: dead-zone entry + exit buffers

### DIFF
--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -121,7 +121,7 @@ describe('Footer', () => {
 
     expect(footer).toBeInTheDocument()
     expect(section?.nextElementSibling).toBe(footer)
-    expect(footer).toHaveTextContent('FARHAN_AHMED_MOHAMMED © 2026')
+    expect(footer).toHaveTextContent('FARHAN_MOHAMMED © 2026')
     expect(footer).toHaveTextContent('PORTFOLIO.EXE')
     expect(footer).toHaveTextContent('// GITHUB')
     expect(footer).toHaveTextContent('// LINKEDIN')

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -81,7 +81,7 @@ export default function ContactSection() {
 
         <div className="flex justify-between items-center">
           <span data-parallax data-parallax-factor="0.5">
-            FARHAN_AHMED_MOHAMMED © 2026
+            FARHAN_MOHAMMED © 2026
           </span>
           <span data-parallax data-parallax-factor="0.5">
             PORTFOLIO.EXE

--- a/src/components/HeroSection.constants.ts
+++ b/src/components/HeroSection.constants.ts
@@ -3,7 +3,7 @@ import type { Variants } from 'framer-motion'
 export const ROLES = ['CS_STUDENT', 'DEVELOPER', 'BUILDER', 'DEBUGGER', 'PROBLEM_SOLVER']
 export const VALUE_PROP = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
 
-export const FIRST_NAME = 'FARHAN AHMED'
+export const FIRST_NAME = 'FARHAN'
 export const LAST_NAME = 'MOHAMMED'
 export const NAME_SPEED = 40
 

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -36,7 +36,7 @@ export default function LoadingScreen({ onComplete }: LoadingScreenProps) {
         SYSTEM_INIT...
       </p>
       <h1 className="mb-8 font-display text-2xl text-platinum">
-        FARHAN AHMED MOHAMMED
+        FARHAN MOHAMMED
       </h1>
       <div
         role="progressbar"

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ProjectsSection from './ProjectsSection'
 
@@ -29,6 +29,33 @@ const mockProjects = [
     ]
   }
 ]
+
+function setViewport(width: number, height: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value: height,
+  })
+}
+
+function createRect(top: number, height: number): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: window.innerWidth,
+    width: window.innerWidth,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
 
 describe('ProjectsSection', () => {
   it('renders all projects as cards on initial render (no collapsed state)', () => {
@@ -225,6 +252,24 @@ describe('ProjectsSection', () => {
     const carouselTrack = document.querySelector('[data-carousel-track="true"]')
     expect(carouselTrack).toBeInTheDocument()
     expect(carouselTrack).toHaveClass('relative')
+  })
+
+  it('translates the carousel track from the projects section scroll position', () => {
+    setViewport(1000, 800)
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const projectsSection = document.getElementById('projects') as HTMLElement
+    const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+
+    vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-800, 2400))
+    Object.defineProperty(carouselTrack, 'scrollWidth', {
+      configurable: true,
+      value: 1800,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(carouselTrack.style.transform).toBe('translateX(-400px)')
   })
 
   it('section header is separate from carousel track', () => {

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -36,7 +36,7 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
   const { tx } = useHorizontalScroll(outerRef as React.RefObject<HTMLElement>, innerRef as React.RefObject<HTMLElement>)
 
   return (
-    <StickySection id="projects" className="flex flex-col justify-center py-14 px-8 bg-graphite-light">
+    <StickySection ref={outerRef} id="projects" className="flex flex-col justify-center py-14 px-8 bg-graphite-light">
       <div className="w-full">
         <div className="flex items-center gap-3 mb-8">
           <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 01</span>

--- a/src/components/StickySection.tsx
+++ b/src/components/StickySection.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, type ElementType, type ReactNode } from 'react'
+import { forwardRef, useCallback, useLayoutEffect, useRef, type ElementType, type ReactNode } from 'react'
 
 interface Props {
   id: string
@@ -19,9 +19,27 @@ function formatNumber(value: number) {
   return Number(value.toFixed(3)).toString()
 }
 
-export function StickySection({ id, children, className = '', as = 'section' }: Props) {
+export const StickySection = forwardRef<HTMLElement, Props>(function StickySection(
+  { id, children, className = '', as = 'section' },
+  forwardedRef
+) {
   const sectionRef = useRef<HTMLElement>(null)
   const Component = as as ElementType
+  const setSectionRef = useCallback(
+    (node: HTMLElement | null) => {
+      sectionRef.current = node
+
+      if (typeof forwardedRef === 'function') {
+        forwardedRef(node)
+        return
+      }
+
+      if (forwardedRef) {
+        forwardedRef.current = node
+      }
+    },
+    [forwardedRef]
+  )
 
   useLayoutEffect(() => {
     const section = sectionRef.current
@@ -64,7 +82,7 @@ export function StickySection({ id, children, className = '', as = 'section' }: 
 
   return (
     <Component
-      ref={sectionRef}
+      ref={setSectionRef}
       id={id}
       data-sticky-section="true"
       className={`sticky top-0 min-h-screen origin-center transform-gpu ${className}`.trim()}
@@ -73,4 +91,4 @@ export function StickySection({ id, children, className = '', as = 'section' }: 
       {children}
     </Component>
   )
-}
+})

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -148,7 +148,7 @@ describe('TimelineSection', () => {
       const texts = Array.from(allLines).map((el) => el.textContent)
 
       expect(texts).toContain('commit d4e8f2c')
-      expect(texts).toContain('Author: Farhan Ahmed Mohammed')
+      expect(texts).toContain('Author: Farhan Mohammed')
       expect(texts).toContain('Date:   AUG 2024 – PRESENT')
       expect(texts).toContain('NETAPP INC.')
       expect(texts).toContain('SOFTWARE_ENGINEER_IN_TEST')
@@ -266,7 +266,6 @@ describe('TimelineSection', () => {
 
       render(<TimelineSection />)
 
-      // Metadata takes ~1696ms at 16ms/char (with "Ahmed" middle name), then longest bullet (156 chars) takes ~2496ms
       act(() => {
         vi.advanceTimersByTime(4400)
       })

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -49,7 +49,7 @@ const timelineEntries: TimelineEntry[] = [
 function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean }) {
   const lines = [
     `commit ${entry.hash}`,
-    'Author: Farhan Ahmed Mohammed',
+    'Author: Farhan Mohammed',
     `Date:   ${entry.dateRange}`,
     entry.institution,
     entry.role,

--- a/src/data/resume-audit.test.ts
+++ b/src/data/resume-audit.test.ts
@@ -3,7 +3,7 @@ import { projects } from './projects'
 import { FIRST_NAME, LAST_NAME } from '../components/HeroSection.constants'
 
 // Resume source-of-truth constants (from public/resume.pdf)
-const RESUME_FULL_NAME = 'Farhan Ahmed Mohammed'
+const RESUME_FULL_NAME = 'Farhan Mohammed'
 const RESUME_EMAIL = 'famohammed@shockers.wichita.edu'
 
 describe('resume source-of-truth audit', () => {

--- a/src/hooks/useHorizontalScroll.test.tsx
+++ b/src/hooks/useHorizontalScroll.test.tsx
@@ -87,6 +87,20 @@ describe('useHorizontalScroll', () => {
     expect(result.current).toEqual({ progress: 0, tx: 0 })
   })
 
+  it('holds the first card in place through the leading dead zone', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: -160,
+      outerHeight: 2400,
+      innerScrollWidth: 2600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current).toEqual({ progress: 0, tx: 0 })
+  })
+
   it('returns full progress and max translate after the outer container scrolls fully past', () => {
     setViewport(1000, 800)
 
@@ -99,6 +113,35 @@ describe('useHorizontalScroll', () => {
     act(() => window.dispatchEvent(new Event('scroll')))
 
     expect(result.current).toEqual({ progress: 1, tx: -1600 })
+  })
+
+  it('holds the last card in place through the trailing dead zone', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: -1440,
+      outerHeight: 2400,
+      innerScrollWidth: 2600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current).toEqual({ progress: 1, tx: -1600 })
+  })
+
+  it('moves linearly between the leading and trailing dead zones', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: -400,
+      outerHeight: 2400,
+      innerScrollWidth: 2600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current.progress).toBeCloseTo(0.1667, 4)
+    expect(result.current.tx).toBeCloseTo(-266.67, 2)
   })
 
   it('returns zero translate when the inner track does not overflow the viewport', () => {

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -5,8 +5,26 @@ interface HorizontalScrollState {
   progress: number
 }
 
+const DEAD_ZONE_VIEWPORT_RATIO = 0.25
+
 function clamp01(value: number) {
   return Math.min(Math.max(value, 0), 1)
+}
+
+function applyDeadZones(rawProgress: number, deadZoneProgress: number) {
+  if (deadZoneProgress <= 0) {
+    return rawProgress
+  }
+
+  if (rawProgress <= deadZoneProgress) {
+    return 0
+  }
+
+  if (rawProgress >= 1 - deadZoneProgress) {
+    return 1
+  }
+
+  return (rawProgress - deadZoneProgress) / (1 - deadZoneProgress * 2)
 }
 
 function getHorizontalScrollState(
@@ -21,7 +39,9 @@ function getHorizontalScrollState(
   const viewportWidth = window.innerWidth
   const viewportHeight = window.innerHeight
   const scrollRange = Math.max(rect.height - viewportHeight, 0)
-  const progress = scrollRange === 0 ? 0 : clamp01(-rect.top / scrollRange)
+  const rawProgress = scrollRange === 0 ? 0 : clamp01(-rect.top / scrollRange)
+  const deadZoneProgress = scrollRange === 0 ? 0 : (viewportHeight * DEAD_ZONE_VIEWPORT_RATIO) / scrollRange
+  const progress = clamp01(applyDeadZones(rawProgress, deadZoneProgress))
   const trackWidth = Math.max(inner.scrollWidth - viewportWidth, 0)
   const tx = progress === 0 || trackWidth === 0 ? 0 : -(progress * trackWidth)
 


### PR DESCRIPTION
**Purpose** — Make the Projects carousel hold on the first and last cards before movement begins or the section releases.

**What it does** — Maps raw vertical scroll progress through 25vh leading and trailing dead zones before calculating horizontal translate.

**Changes made**
- Added dead-zone progress mapping inside useHorizontalScroll.
- Kept the existing hook interface unchanged for Projects consumers.
- Added hook tests for leading hold, trailing hold, and linear movement through the middle band.

**Additional notes** — The implementation uses 25vh, which is within the requested 20-25vh range. Typecheck and the full test suite pass.

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Horizontal carousel/scroll now holds content steady at the start/end and moves smoothly through the middle.
  * Carousel translates to expected positions during scroll; sticky sections behave more reliably while scrolling.

* **Refactor**
  * Sticky section now forwards refs to improve stability with parent layouts.

* **Tests**
  * Added/updated tests covering horizontal scroll dead zones and carousel scrolling behavior.

* **Content**
  * Updated displayed personal name to "Farhan Mohammed" across UI and tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->