### PR TITLE
Loading: match v4 system boot screen

### DIFF
--- a/src/components/LoadingScreen.test.tsx
+++ b/src/components/LoadingScreen.test.tsx
@@ -75,4 +75,34 @@ describe('LoadingScreen', () => {
     await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
     expect(bar).toHaveAttribute('aria-valuenow', '100')
   })
+
+  it('renders FARHAN and MOHAMMED on separate display lines', () => {
+    const { getByText } = render(<LoadingScreen onComplete={vi.fn()} />)
+    expect(getByText('FARHAN')).toBeInTheDocument()
+    expect(getByText('MOHAMMED')).toBeInTheDocument()
+  })
+
+  it('uses graphite background covering the full viewport', () => {
+    const { container } = render(<LoadingScreen onComplete={vi.fn()} />)
+    const overlay = container.firstChild as HTMLElement
+    expect(overlay).toHaveClass('fixed')
+    expect(overlay).toHaveClass('inset-0')
+    expect(overlay).toHaveClass('bg-graphite')
+  })
+
+  it('renders a thin orange progress bar', () => {
+    const { container } = render(<LoadingScreen onComplete={vi.fn()} />)
+    const track = container.querySelector('[role="progressbar"]')
+    expect(track).toHaveClass('h-0.5')
+    const fill = track?.querySelector('.bg-atomic-tangerine')
+    expect(fill).toBeInTheDocument()
+  })
+
+  it('uses display font for identity and mono font for status text', () => {
+    const { getByText } = render(<LoadingScreen onComplete={vi.fn()} />)
+    const firstName = getByText('FARHAN')
+    expect(firstName).toHaveClass('font-display')
+    const status = getByText('ESTABLISHING_SIGNAL')
+    expect(status).toHaveClass('font-body')
+  })
 })

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -36,14 +36,17 @@ export default function LoadingScreen({ onComplete }: LoadingScreenProps) {
         SYSTEM_INIT...
       </p>
       <h1 className="mb-8 font-display text-2xl text-platinum">
-        FARHAN MOHAMMED
+        FARHAN
       </h1>
+      <h2 className="-mt-6 mb-8 font-display text-2xl text-platinum">
+        MOHAMMED
+      </h2>
       <div
         role="progressbar"
         aria-valuemin={0}
         aria-valuemax={100}
         aria-valuenow={progress}
-        className="mb-4 h-2 w-64 overflow-hidden rounded-none bg-periwinkle/20"
+        className="mb-4 h-0.5 w-64 overflow-hidden rounded-none bg-periwinkle/20"
       >
         <motion.div
           className="h-full bg-atomic-tangerine"


### PR DESCRIPTION
**Purpose** — Update the loading screen to match the v4 system-boot terminal initialization concept.

**What it does** — Splits the identity into separate FARHAN/MOHAMMED display lines for a sparse centered layout, thins the orange progress bar to match the v4 reference, and adds tests for the visual structure.

**Changes made** —
- Split name from single-line "FARHAN MOHAMMED" into two display-font lines (FARHAN / MOHAMMED) with tighter spacing
- Thinned progress bar track from `h-2` (8px) to `h-0.5` (2px) for the thin orange treatment
- Added 4 new tests: separate name lines, graphite viewport coverage, thin progress bar, font assignments (display for identity, body/mono for status)

**Additional notes** —
- Loading sequence duration remains 2.8s (within the 2.6s-3.0s acceptance range)
- Fade-out handoff to hero unchanged (AnimatePresence)
- No re-layout jump after loading exits
- All 203 tests pass, typecheck clean

Closes #163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive UI assertions for the loading screen, including text display validation, overlay styling verification, progress bar variant checks, and typography class confirmation.

* **Style**
  * Updated loading screen hero text display to show on two separate lines.
  * Reduced progress bar height for a more compact appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->