### PR TITLE
Global: enforce desktop v4 tokens and shell guardrails

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -87,6 +87,18 @@ describe('App shell', () => {
     })
   })
 
+  it('navbar does not force a narrow page shell', () => {
+    render(<App />)
+    const nav = document.querySelector('nav')
+    expect(nav).toBeInTheDocument()
+    const innerDiv = nav?.querySelector('div')
+    expect(innerDiv).not.toBeNull()
+    expect(innerDiv!.className).not.toContain('max-w-7xl')
+    expect(innerDiv!.className).not.toContain('mx-auto')
+    expect(innerDiv!.className).toContain('w-full')
+    expect(innerDiv!.className).toContain('px-8')
+  })
+
   it('initializes one RAF-batched parallax scroll listener and cleans it up', () => {
     let nextFrameId = 1
     const frameCallbacks = new Map<number, FrameRequestCallback>()

--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -171,13 +171,14 @@ describe('Navbar', () => {
       expect(logo.className).toContain('text-xl')
     })
 
-    it('nav inner content is wrapped in max-w-7xl mx-auto px-8 container', () => {
+    it('nav inner content spans full width without narrow shell constraint', () => {
       render(<Navbar />)
       const nav = screen.getByRole('navigation')
-      const innerContainer = nav.querySelector('div.max-w-7xl')
+      const innerContainer = nav.querySelector('div')
       expect(innerContainer).not.toBeNull()
-      expect(innerContainer!.className).toContain('max-w-7xl')
-      expect(innerContainer!.className).toContain('mx-auto')
+      expect(innerContainer!.className).not.toContain('max-w-7xl')
+      expect(innerContainer!.className).not.toContain('mx-auto')
+      expect(innerContainer!.className).toContain('w-full')
       expect(innerContainer!.className).toContain('px-8')
     })
   })

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -35,7 +35,7 @@ export default function Navbar() {
   return (
     <>
       <nav className="fixed top-0 z-40 w-full py-4 bg-graphite/90 backdrop-blur-md border-b border-graphite-light/30">
-        <div className="max-w-7xl mx-auto w-full flex items-center justify-between px-8">
+        <div className="w-full flex items-center justify-between px-8">
           <a href="#" className="font-display text-platinum text-xl no-underline">
             FM_
           </a>

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -13,7 +13,7 @@ const TAG_COLORS = [
   { bg: '#E0007F', fg: '#EFF1F3' },
   { bg: '#5200E0', fg: '#EFF1F3' },
   { bg: '#FF8547', fg: '#050609' },
-  { bg: '#FFCE47', fg: '#050609' },
+  { bg: '#FFC857', fg: '#050609' },
 ]
 
 const NOTCH = 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)'

--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -284,6 +284,16 @@ describe('SkillsSection', () => {
     expect(grid.parentElement!.classList).toContain('w-full')
   })
 
+  it('skill tiles use sharp edges (no rounded corners)', () => {
+    render(<SkillsSection />)
+    const grid = screen.getByTestId('skills-grid')
+    const tiles = Array.from(grid.children)
+
+    for (const tile of tiles) {
+      expect(tile.className).not.toMatch(/rounded/)
+    }
+  })
+
   it('no accent tile renders at bottom of grid', () => {
     render(<SkillsSection />)
 

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -72,19 +72,19 @@ const tiles: SkillTile[] = [
   { category: 'LANGUAGE',  name: 'C / C++',      colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
   { category: 'LANGUAGE',  name: 'JavaScript',   colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
   { category: 'FRAMEWORK', name: 'FastAPI',      colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'ML / DL',   name: 'PyTorch',      colSpan: 'col-span-2 md:col-span-3',          rowSpan: 'row-span-1 md:row-span-2', bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'PyTorch',      colSpan: 'col-span-2 md:col-span-3',          rowSpan: 'row-span-1 md:row-span-2', bg: '#FFC857', fg: '#050609' },
   { category: 'DATA',      name: 'NumPy',        colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
   { category: 'DATA',      name: 'Pandas',       colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
   { category: 'TOOL',      name: 'Ansible',      colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Hugging Face', colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Scikit-learn', colSpan: 'col-span-1 md:col-span-3',          rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Hugging Face', colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Scikit-learn', colSpan: 'col-span-1 md:col-span-3',          rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
   { category: 'TOOL',      name: 'Linux',        colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
   { category: 'TOOL',      name: 'Git',          colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
   { category: 'LANGUAGE',  name: 'SQL',          colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'ML / DL',   name: 'Transformers', colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Attention Mechanisms', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Gradient Optimization', colSpan: 'col-span-1 md:col-span-2', rowSpan: 'row-span-1',               bg: '#FFCE47', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Model Training / Fine-tuning', colSpan: 'col-span-1 md:col-span-3', rowSpan: 'row-span-1',        bg: '#FFCE47', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Transformers', colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Attention Mechanisms', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Gradient Optimization', colSpan: 'col-span-1 md:col-span-2', rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
+  { category: 'ML / DL',   name: 'Model Training / Fine-tuning', colSpan: 'col-span-1 md:col-span-3', rowSpan: 'row-span-1',        bg: '#FFC857', fg: '#050609' },
   { category: 'DATA',      name: 'Matplotlib',   colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
   { category: 'DATA',      name: 'Mixed-Precision Training', colSpan: 'col-span-1 md:col-span-2', rowSpan: 'row-span-1',            bg: '#E0007F', fg: '#EFF1F3' },
   { category: 'TOOL',      name: 'Jupyter',      colSpan: 'col-span-2',                        rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
@@ -116,7 +116,7 @@ function SkillTileCard({ tile }: { tile: SkillTile }) {
       variants={tileVariants}
       custom={revealOrder}
       whileHover="hover"
-      className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-5 rounded-lg flex flex-col justify-between cursor-default`}
+      className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-5 flex flex-col justify-between cursor-default`}
       style={{ backgroundColor: tile.bg, color: tile.fg }}
     >
       <span className="text-xs uppercase tracking-widest font-body">

--- a/src/index-css.test.ts
+++ b/src/index-css.test.ts
@@ -17,7 +17,13 @@ function blockFor(selector: string) {
 describe('global CSS brand chrome', () => {
   it('keeps canonical color tokens available', () => {
     expect(blockFor('@theme')).toContain('--color-graphite: #2A2B2A;')
+    expect(blockFor('@theme')).toContain('--color-graphite-light: #323332;')
     expect(blockFor('@theme')).toContain('--color-atomic-tangerine: #FF8547;')
+    expect(blockFor('@theme')).toContain('--color-ultrasonic-blue: #5200E0;')
+    expect(blockFor('@theme')).toContain('--color-fuchsia-flame: #E0007F;')
+    expect(blockFor('@theme')).toContain('--color-golden-pollen: #FFC857;')
+    expect(blockFor('@theme')).toContain('--color-platinum: #EFF1F3;')
+    expect(blockFor('@theme')).toContain('--color-periwinkle: #B2B6D2;')
     expect(css).toContain('--graphite: var(--color-graphite);')
     expect(css).toContain('--orange: var(--color-atomic-tangerine);')
   })
@@ -28,5 +34,10 @@ describe('global CSS brand chrome', () => {
     expect(blockFor('::-webkit-scrollbar-thumb')).toContain('background: var(--orange);')
     expect(blockFor('::selection')).toContain('background-color: var(--orange);')
     expect(blockFor('::selection')).toContain('color: var(--graphite);')
+  })
+
+  it('uses Press Start 2P for display and Space Mono for body text', () => {
+    expect(blockFor('@theme')).toContain("--font-display: 'Press Start 2P', monospace;")
+    expect(blockFor('@theme')).toContain("--font-body: 'Space Mono', monospace;")
   })
 })

--- a/src/index.css
+++ b/src/index.css
@@ -6,7 +6,7 @@
   --color-atomic-tangerine: #FF8547;
   --color-ultrasonic-blue: #5200E0;
   --color-fuchsia-flame: #E0007F;
-  --color-golden-pollen: #FFCE47;
+  --color-golden-pollen: #FFC857;
   --color-platinum: #EFF1F3;
   --color-periwinkle: #B2B6D2;
 


### PR DESCRIPTION
**Purpose** — Align the desktop implementation with the v4 HTML reference by correcting color tokens, removing the narrow page shell constraint, and enforcing sharp edges on section surfaces.

**What it does** — Fixes the golden-pollen yellow token to match the canonical value (#FFC857), removes the max-w-7xl mx-auto constraint from the navbar so content spans full browser width, removes rounded corners from skill tiles, and adds test coverage for all 8 canonical color tokens, font assignments, shell constraints, and sharp edges.

**Changes made** —
- Corrected `--color-golden-pollen` from `#FFCE47` to `#FFC857` in `src/index.css`
- Removed `max-w-7xl mx-auto` from navbar inner container in `src/components/Navbar.tsx`
- Removed `rounded-lg` from skill tiles in `src/components/SkillsSection.tsx`
- Propagated corrected yellow value through ProjectsSection tag colors and SkillsSection tile backgrounds
- Added comprehensive token assertions for all 8 canonical colors in `src/index-css.test.ts`
- Added font assignment test (Press Start 2P / Space Mono) in `src/index-css.test.ts`
- Added navbar shell constraint test in `src/App.test.tsx`
- Updated navbar test to assert absence of narrow shell constraint in `src/components/Navbar.test.tsx`
- Added sharp edges test for skill tiles in `src/components/SkillsSection.test.tsx`

**Additional notes** — All 206 tests pass. Typecheck passes. No section redesigns were made; this issue only enforces global guardrails.

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navbar now spans full width instead of being center-constrained
  * Skill tiles now display with sharp edges instead of rounded corners

* **Style**
  * Updated golden color palette values throughout the application

* **Tests**
  * Added test coverage for navbar full-width layout behavior
  * Added test verification for skill tile edge styling
  * Enhanced CSS theme variable validation tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->