### PR TITLE
Timeline: enforce desktop sticky panel scroll contract

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -13,6 +13,7 @@ const sectionIds = [
   'contact',
   'footer',
 ] as const
+const timelinePanelIds = ['timeline', 'timeline-a3f9d2b', 'timeline-b7c3e1a']
 const shellConstraintClasses = ['container', 'max-w-7xl', 'mx-auto'] as const
 
 function expectNoShellConstraint(element: Element) {
@@ -225,5 +226,76 @@ describe('App shell', () => {
       missingFactorLayer.remove()
       invalidFactorLayer.remove()
     }
+  })
+
+  describe('issue #157 - Timeline sticky panel scroll contract', () => {
+    it('timeline panels are part of the global sticky section stack', () => {
+      render(<App />)
+
+      const allStickySections = document.querySelectorAll('[data-sticky-section="true"]')
+      const timelinePanels = Array.from(allStickySections).filter((s) =>
+        timelinePanelIds.includes(s.id)
+      )
+
+      expect(timelinePanels.length).toBe(3)
+    })
+
+    it('timeline panels have z-index below navbar', () => {
+      render(<App />)
+
+      const timelinePanels = document.querySelectorAll('[data-sticky-section="true"]')
+      const filtered = Array.from(timelinePanels).filter((s) =>
+        timelinePanelIds.includes(s.id)
+      )
+
+      filtered.forEach((panel) => {
+        const zIndex = Number((panel as HTMLElement).style.zIndex)
+        expect(zIndex).toBeLessThan(40)
+        expect(zIndex).toBeGreaterThan(0)
+      })
+    })
+
+    it('timeline panels do not use horizontal scroll behavior', () => {
+      render(<App />)
+
+      const timelinePanels = document.querySelectorAll('[data-sticky-section="true"]')
+      const filtered = Array.from(timelinePanels).filter((s) =>
+        timelinePanelIds.includes(s.id)
+      )
+
+      filtered.forEach((panel) => {
+        const style = (panel as HTMLElement).style
+        expect(style.transform).not.toContain('translateX')
+      })
+    })
+
+    it('timeline panels render in newest-first order in the global stack', () => {
+      render(<App />)
+
+      const allStickySections = document.querySelectorAll('[data-sticky-section="true"][id]')
+      const ids = Array.from(allStickySections).map((s) => s.id)
+
+      const timelineIndex = ids.indexOf('timeline')
+      const msIndex = ids.indexOf('timeline-a3f9d2b')
+      const bsIndex = ids.indexOf('timeline-b7c3e1a')
+
+      expect(timelineIndex).toBeLessThan(msIndex)
+      expect(msIndex).toBeLessThan(bsIndex)
+    })
+
+    it('each timeline panel occupies full viewport height in the stack', () => {
+      render(<App />)
+
+      const allStickySections = document.querySelectorAll('[data-sticky-section="true"]')
+      const timelinePanels = Array.from(allStickySections).filter((s) =>
+        timelinePanelIds.includes(s.id)
+      )
+
+      timelinePanels.forEach((panel) => {
+        expect(panel).toHaveClass('min-h-screen')
+        expect(panel).toHaveClass('sticky')
+        expect(panel).toHaveClass('top-0')
+      })
+    })
   })
 })

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -277,4 +277,86 @@ describe('TimelineSection', () => {
       expect(texts).toContain(longestBullet)
     })
   })
+
+  describe('issue #157 - desktop sticky panel scroll contract', () => {
+    it('timeline panels do not use horizontal scroll or translateX', () => {
+      render(<TimelineSection />)
+
+      const stickyPanels = document.querySelectorAll('[data-sticky-section="true"]')
+      stickyPanels.forEach((panel) => {
+        const style = (panel as HTMLElement).style
+        expect(style.transform).not.toContain('translateX')
+        expect(style.transform).not.toContain('translate3d')
+      })
+    })
+
+    it('timeline panels do not have a horizontal track element', () => {
+      render(<TimelineSection />)
+
+      const stickyPanels = document.querySelectorAll('[data-sticky-section="true"]')
+      stickyPanels.forEach((panel) => {
+        const children = panel.querySelectorAll('[data-testid]')
+        const hasTrack = Array.from(children).some(
+          (child) =>
+            child.getAttribute('data-testid')?.includes('track') ||
+            child.getAttribute('data-testid')?.includes('carousel')
+        )
+        expect(hasTrack).toBe(false)
+      })
+    })
+
+    it('each timeline panel participates in card-deck stack with z-index', () => {
+      render(<TimelineSection />)
+
+      const stickyPanels = document.querySelectorAll('[data-sticky-section="true"]')
+      expect(stickyPanels.length).toBe(3)
+
+      stickyPanels.forEach((panel) => {
+        const zIndex = (panel as HTMLElement).style.zIndex
+        expect(zIndex).toBeTruthy()
+        expect(Number(zIndex)).toBeGreaterThan(0)
+      })
+    })
+
+    it('each timeline panel occupies a full desktop viewport beat (min-h-screen)', () => {
+      render(<TimelineSection />)
+
+      const stickyPanels = document.querySelectorAll('[data-sticky-section="true"]')
+      stickyPanels.forEach((panel) => {
+        expect(panel).toHaveClass('min-h-screen')
+        expect(panel).toHaveClass('sticky')
+        expect(panel).toHaveClass('top-0')
+      })
+    })
+
+    it('timeline panels are in DOM order matching newest-first scroll progression', () => {
+      render(<TimelineSection />)
+
+      const stickyPanels = document.querySelectorAll('[data-sticky-section="true"][id]')
+      const ids = Array.from(stickyPanels).map((p) => p.id)
+
+      expect(ids[0]).toBe('timeline')
+      expect(ids[1]).toBe('timeline-a3f9d2b')
+      expect(ids[2]).toBe('timeline-b7c3e1a')
+    })
+
+    it('timeline panels have origin-center and transform-gpu for card-deck animations', () => {
+      render(<TimelineSection />)
+
+      const stickyPanels = document.querySelectorAll('[data-sticky-section="true"]')
+      stickyPanels.forEach((panel) => {
+        expect(panel).toHaveClass('origin-center')
+        expect(panel).toHaveClass('transform-gpu')
+      })
+    })
+
+    it('timeline panels have willChange set for GPU compositing', () => {
+      render(<TimelineSection />)
+
+      const stickyPanels = document.querySelectorAll('[data-sticky-section="true"]')
+      stickyPanels.forEach((panel) => {
+        expect((panel as HTMLElement).style.willChange).toBe('transform, opacity')
+      })
+    })
+  })
 })


### PR DESCRIPTION
**Purpose** — Enforce the desktop Timeline scroll contract with tests guaranteeing each timeline entry behaves as a full-screen sticky panel in the global card-deck stack.

**What it does** — Adds 12 unit and integration tests that verify Timeline panels participate correctly in the card-deck stacking behavior, have no horizontal scroll mechanics, and render in newest-first order.

**Changes made** —
- Added 7 unit tests in `TimelineSection.test.tsx` covering: no horizontal scroll/translateX, no horizontal track element, z-index assignment, full viewport occupation (min-h-screen/sticky/top-0), newest-first DOM order, origin-center/transform-gpu for card-deck animations, willChange for GPU compositing
- Added 5 integration tests in `App.test.tsx` covering: timeline panels in global sticky stack, z-index below navbar, no horizontal scroll behavior, newest-first order in global stack, full viewport height in stack

**Additional notes** —
- Implementation already satisfied all acceptance criteria; this issue adds test coverage to enforce the contract going forward
- npm run typecheck and npm run test pass (218 tests)
- No changes to component implementation needed

Closes #157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites validating timeline panel sticky positioning and animation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->