### PR TITLE
Projects: implement desktop dead-zone progress mapping

### DIFF
--- a/src/hooks/useHorizontalScroll.test.tsx
+++ b/src/hooks/useHorizontalScroll.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { useRef } from 'react'
-import { useHorizontalScroll } from './useHorizontalScroll'
+import { useHorizontalScroll, applyDeadZones, clamp01 } from './useHorizontalScroll'
 
 function setViewport(width: number, height: number) {
   Object.defineProperty(window, 'innerWidth', {
@@ -189,5 +189,65 @@ describe('useHorizontalScroll', () => {
     act(() => window.dispatchEvent(new Event('resize')))
 
     expect(result.current).toEqual({ progress: 0.5, tx: -700 })
+  })
+})
+
+describe('applyDeadZones', () => {
+  it('returns 0 when raw progress is before start', () => {
+    expect(applyDeadZones(0, 0.125)).toBe(0)
+  })
+
+  it('returns 0 within the first dead zone', () => {
+    expect(applyDeadZones(0.06, 0.125)).toBe(0)
+    expect(applyDeadZones(0.125, 0.125)).toBe(0)
+  })
+
+  it('maps the midpoint linearly between dead zones', () => {
+    const result = applyDeadZones(0.5, 0.125)
+    expect(result).toBeCloseTo(0.5, 4)
+  })
+
+  it('returns 1 within the final dead zone', () => {
+    expect(applyDeadZones(0.875, 0.125)).toBe(1)
+    expect(applyDeadZones(0.94, 0.125)).toBe(1)
+  })
+
+  it('returns 1 after end', () => {
+    expect(applyDeadZones(1, 0.125)).toBe(1)
+    expect(applyDeadZones(1.2, 0.125)).toBe(1)
+  })
+
+  it('maps linearly between the leading and trailing dead zones', () => {
+    const deadZone = 0.125
+    const result = applyDeadZones(0.3, deadZone)
+    const expected = (0.3 - deadZone) / (1 - deadZone * 2)
+    expect(result).toBeCloseTo(expected, 4)
+  })
+
+  it('returns raw progress when dead zone is zero', () => {
+    expect(applyDeadZones(0.25, 0)).toBe(0.25)
+    expect(applyDeadZones(0.75, 0)).toBe(0.75)
+  })
+
+  it('returns 0 for negative raw progress (falls within leading dead zone)', () => {
+    expect(applyDeadZones(-0.1, 0.125)).toBe(0)
+  })
+})
+
+describe('clamp01', () => {
+  it('returns 0 for negative values', () => {
+    expect(clamp01(-0.5)).toBe(0)
+    expect(clamp01(-10)).toBe(0)
+  })
+
+  it('returns 1 for values above 1', () => {
+    expect(clamp01(1.5)).toBe(1)
+    expect(clamp01(10)).toBe(1)
+  })
+
+  it('passes through values between 0 and 1', () => {
+    expect(clamp01(0)).toBe(0)
+    expect(clamp01(0.5)).toBe(0.5)
+    expect(clamp01(1)).toBe(1)
   })
 })

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -7,11 +7,11 @@ interface HorizontalScrollState {
 
 const DEAD_ZONE_VIEWPORT_RATIO = 0.25
 
-function clamp01(value: number) {
+export function clamp01(value: number) {
   return Math.min(Math.max(value, 0), 1)
 }
 
-function applyDeadZones(rawProgress: number, deadZoneProgress: number) {
+export function applyDeadZones(rawProgress: number, deadZoneProgress: number) {
   if (deadZoneProgress <= 0) {
     return rawProgress
   }


### PR DESCRIPTION
**Purpose** — Separate raw scroll progress from dead-zone-adjusted progress so the mapping logic is directly testable and the first/last cards hold before horizontal movement.

**What it does** — Exports the `applyDeadZones` and `clamp01` functions from `useHorizontalScroll` and adds dedicated unit tests covering all dead-zone edge cases (before start, first dead zone, midpoint, final dead zone, after end, zero dead zone, and clamp boundaries).

**Changes made** —
- Exported `applyDeadZones` and `clamp01` in `src/hooks/useHorizontalScroll.ts`
- Added direct unit tests for `applyDeadZones` covering before start, first dead zone, linear midpoint mapping, final dead zone, after end, zero dead zone passthrough, and negative input handling
- Added direct unit tests for `clamp01` covering negative, above-1, and in-range values

**Additional notes** —
- npm run typecheck and npm run test pass (217 tests)
- No visual or behavioral changes to the carousel; existing hook tests continue to pass
- First 25vh of scroll maps to adjusted progress 0, final 25vh maps to 1, middle band maps linearly

Closes #151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Exported helper utilities `clamp01` and `applyDeadZones` from horizontal scroll functionality for broader accessibility.

* **Tests**
  * Added comprehensive unit tests for exported helper functions, covering edge cases and boundary conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->