### PR TITLE
Projects: enforce desktop active card and neighbor model

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -4,6 +4,9 @@ import userEvent from '@testing-library/user-event'
 import ProjectsSection from './ProjectsSection'
 import { getScrollRangeVh } from './projectsGeometry'
 
+const CARD_WIDTH = 480
+const CARD_GAP = 24
+
 const mockProjects = [
   {
     id: '1',
@@ -446,6 +449,165 @@ describe('ProjectsSection', () => {
     progressPoints.forEach((progress, i) => {
       const activeIndex = Math.round(progress * (threeProjects.length - 1))
       expect(activeIndex).toBe(expectedIndices[i])
+    })
+  })
+
+  describe('desktop active card and neighbor model', () => {
+    const threeProjects = [
+      ...mockProjects,
+      {
+        id: '3',
+        title: 'Project Three',
+        description: 'Description for project three',
+        tags: ['Vue', 'Python'],
+        links: [{ label: 'Site', url: 'https://project3.com' }]
+      }
+    ]
+
+    it('active card renders at full scale (1.0) and full opacity (1.0)', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      expect(cards).toHaveLength(3)
+
+      // At progress 0, card 0 is active
+      const activeCard = cards[0]
+      const style = (activeCard as HTMLElement).style
+      expect(style.transform).toContain('scale(1)')
+      expect(style.opacity).toBe('1')
+    })
+
+    it('active card remains unfilled by default (no orange fill when not hovered)', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      const activeCard = cards[0]
+      const fill = activeCard.querySelector('[data-testid="project-card-fill"]')
+
+      expect(fill).toHaveAttribute('data-active', 'false')
+    })
+
+    it('immediate left and right neighbor cards remain partially visible', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+
+      // At progress 0, card 0 is active, card 1 is right neighbor
+      const rightNeighbor = cards[1]
+      const neighborStyle = (rightNeighbor as HTMLElement).style
+      expect(neighborStyle.opacity).not.toBe('')
+      expect(parseFloat(neighborStyle.opacity)).toBeGreaterThan(0)
+      expect(parseFloat(neighborStyle.opacity)).toBeLessThan(1)
+    })
+
+    it('neighbor cards use reduced opacity relative to the active card', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      const activeCard = cards[0] as HTMLElement
+      const neighborCard = cards[1] as HTMLElement
+
+      const activeOpacity = parseFloat(activeCard.style.opacity) || 1
+      const neighborOpacity = parseFloat(neighborCard.style.opacity)
+
+      expect(neighborOpacity).toBeLessThan(activeOpacity)
+    })
+
+    it('neighbor cards use reduced scale relative to the active card', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      const activeCard = cards[0] as HTMLElement
+      const neighborCard = cards[1] as HTMLElement
+
+      const activeTransform = activeCard.style.transform
+      const neighborTransform = neighborCard.style.transform
+
+      const activeScaleMatch = activeTransform.match(/scale\(([\d.]+)\)/)
+      const neighborScaleMatch = neighborTransform.match(/scale\(([\d.]+)\)/)
+
+      if (activeScaleMatch && neighborScaleMatch) {
+        expect(parseFloat(neighborScaleMatch[1])).toBeLessThan(parseFloat(activeScaleMatch[1]))
+      }
+    })
+
+    it('far cards are visually suppressed with low opacity and scale', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+
+      // At progress 0, card 0 is active, card 1 is neighbor, card 2 is far
+      const farCard = cards[2] as HTMLElement
+      const activeCard = cards[0] as HTMLElement
+
+      const farOpacity = parseFloat(farCard.style.opacity)
+      const activeOpacity = parseFloat(activeCard.style.opacity) || 1
+
+      expect(farOpacity).toBeLessThan(activeOpacity)
+
+      const farTransform = farCard.style.transform
+      const activeTransform = activeCard.style.transform
+
+      const farScaleMatch = farTransform.match(/scale\(([\d.]+)\)/)
+      const activeScaleMatch = activeTransform.match(/scale\(([\d.]+)\)/)
+
+      if (farScaleMatch && activeScaleMatch) {
+        expect(parseFloat(farScaleMatch[1])).toBeLessThan(parseFloat(activeScaleMatch[1]))
+      }
+    })
+
+    it('no layout jump occurs when active index changes (smooth transition)', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+
+      // All cards should have transition properties for smooth scale/opacity changes
+      cards.forEach((card) => {
+        const style = (card as HTMLElement).style
+        expect(style.transition).toBeDefined()
+      })
+    })
+
+    it('outer container does not introduce horizontal page overflow from neighbor cards', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const projectsSection = document.getElementById('projects')
+      expect(projectsSection).toHaveStyle({ overflowX: 'hidden' })
+    })
+
+    it('active card updates correctly at end of scroll range', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const projectsSection = document.getElementById('projects') as HTMLElement
+      const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+
+      // Simulate scrolled to end position
+      const sectionHeight = getScrollRangeVh(threeProjects.length) * 900
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-(sectionHeight - 900), sectionHeight))
+      Object.defineProperty(carouselTrack, 'scrollWidth', {
+        configurable: true,
+        value: 3 * (CARD_WIDTH + CARD_GAP),
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      const lastIndex = threeProjects.length - 1
+
+      // At progress 1, last card should be active
+      const lastCard = cards[lastIndex] as HTMLElement
+      const style = lastCard.style
+      expect(style.transform).toContain('scale(1)')
+      expect(style.opacity).toBe('1')
     })
   })
 })

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -32,13 +32,19 @@ function getTagStyle(tagIndex: number) {
 }
 
 const CARD_WIDTH = 480
+const NEIGHBOR_SCALE = 0.92
+const NEIGHBOR_OPACITY = 0.6
+const FAR_SCALE = 0.85
+const FAR_OPACITY = 0.25
 
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
   const outerRef = useRef<HTMLElement>(null)
   const innerRef = useRef<HTMLDivElement>(null)
-  const { tx } = useHorizontalScroll(outerRef as React.RefObject<HTMLElement>, innerRef as React.RefObject<HTMLElement>, { cardWidth: CARD_WIDTH })
+  const { tx, progress } = useHorizontalScroll(outerRef as React.RefObject<HTMLElement>, innerRef as React.RefObject<HTMLElement>, { cardWidth: CARD_WIDTH })
   const scrollRangeVh = getScrollRangeVh(projects.length)
   useCardDeckDepth(outerRef as React.RefObject<HTMLElement>)
+
+  const activeIndex = projects.length > 1 ? Math.round(progress * (projects.length - 1)) : 0
 
   return (
     <section
@@ -58,8 +64,8 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
 
           <div ref={innerRef as React.RefObject<HTMLDivElement>} data-carousel-track="true" className="relative" style={{ transform: `translateX(${tx}px)` }}>
             <div className="flex gap-6 pb-4">
-              {projects.map((project) => (
-                <ProjectCard key={project.id} project={project} />
+              {projects.map((project, index) => (
+                <ProjectCard key={project.id} project={project} index={index} activeIndex={activeIndex} />
               ))}
             </div>
           </div>
@@ -69,10 +75,17 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
   )
 }
 
-const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
+const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: number }> = ({ project, index, activeIndex }) => {
   const [isHovered, setIsHovered] = useState(false)
   const [hasFocus, setHasFocus] = useState(false)
   const isFillActive = isHovered || hasFocus
+
+  const distance = Math.abs(index - activeIndex)
+  const isActive = distance === 0
+  const isNeighbor = distance === 1
+
+  const scale = isActive ? 1 : isNeighbor ? NEIGHBOR_SCALE : FAR_SCALE
+  const opacity = isActive ? 1 : isNeighbor ? NEIGHBOR_OPACITY : FAR_OPACITY
 
   return (
     <motion.div
@@ -88,7 +101,15 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
       transition={{ duration: 0.2, ease: 'easeOut' }}
       data-testid="project-card"
       className="relative shrink-0 bg-platinum"
-      style={{ clipPath: NOTCH, maxWidth: '480px', width: '480px' }}
+      style={{
+        clipPath: NOTCH,
+        maxWidth: '480px',
+        width: '480px',
+        transform: `scale(${scale})`,
+        opacity,
+        transition: 'transform 0.3s ease-out, opacity 0.3s ease-out',
+        transformOrigin: 'center center',
+      }}
     >
       <motion.div
         data-testid="project-card-fill"


### PR DESCRIPTION
**Purpose** — Implement the desktop carousel visibility model with one centered active card, visible subordinate neighbors, and suppressed far cards.

**What it does** — Computes the active card index from scroll progress and applies scale/opacity transforms to each card based on its distance from the active card, creating a clear visual hierarchy in the carousel.

**Changes made**
- Added active index computation from scroll progress using `Math.round(progress * (projects.length - 1))`
- Applied scale and opacity transforms: active card at scale(1)/opacity 1, neighbors at scale(0.92)/opacity 0.6, far cards at scale(0.85)/opacity 0.25
- Added CSS transitions for smooth scale/opacity changes on card state transitions
- Active card remains unfilled by default (separate from hover/focus fill state)
- Added 9 new tests covering active card rendering, neighbor visibility, opacity/scale differentiation, far card suppression, and end-of-range behavior

**Additional notes**
- Neighbor cards clip naturally at viewport edges via existing `overflowX: hidden` on the outer section
- No layout jump occurs when active index changes due to CSS transitions
- npm run typecheck and npm run test pass (248 tests)

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive desktop carousel behavior validation testing for active card scaling, neighbor visibility, smooth transitions, and correct active-card selection at scroll endpoints.

* **New Features**
  * Enhanced carousel cards now display dynamic visual states (active, neighbor, far) based on scroll progress with smooth opacity and scale transitions for improved desktop experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->