### PR TITLE
Timeline: enforce deterministic active panel detection

### DIFF
--- a/src/hooks/useActivePanel.test.ts
+++ b/src/hooks/useActivePanel.test.ts
@@ -1,0 +1,365 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { useActivePanel } from './useActivePanel'
+
+function setViewport(width: number, height: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value: height,
+  })
+}
+
+function createRect(top: number, height: number): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: window.innerWidth,
+    width: window.innerWidth,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
+describe('useActivePanel', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('issue #158 - deterministic active panel detection', () => {
+    it('returns exactly one active panel at a time', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(0, 800)
+          )
+          elements.push(el)
+        }
+
+        const { active, setRef } = useActivePanel(3)
+        elements.forEach((el, i) => setRef(i)(el))
+
+        return active
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      const active = result.current
+      const trueCount = active.filter(Boolean).length
+      expect(trueCount).toBe(1)
+    })
+
+    it('first panel is active when at top of timeline (all panels below viewport)', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        // Panel 0 at viewport top, panels 1 and 2 below
+        const rects = [
+          { top: 0, height: 800 },
+          { top: 800, height: 800 },
+          { top: 1600, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const { active, setRef } = useActivePanel(3)
+        elements.forEach((el, i) => setRef(i)(el))
+
+        return active
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current).toEqual([true, false, false])
+    })
+
+    it('second panel becomes active when it reaches sticky position', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        // Panel 0 scrolled past, panel 1 at sticky top, panel 2 below
+        const rects = [
+          { top: -800, height: 800 },
+          { top: 0, height: 800 },
+          { top: 800, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const { active, setRef } = useActivePanel(3)
+        elements.forEach((el, i) => setRef(i)(el))
+
+        return active
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current).toEqual([false, true, false])
+    })
+
+    it('third panel becomes active when it reaches sticky position', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        // Panels 0 and 1 scrolled past, panel 2 at sticky top
+        const rects = [
+          { top: -1600, height: 800 },
+          { top: -800, height: 800 },
+          { top: 0, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const { active, setRef } = useActivePanel(3)
+        elements.forEach((el, i) => setRef(i)(el))
+
+        return active
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current).toEqual([false, false, true])
+    })
+
+    it('active index changes in newest-first order while scrolling down', () => {
+      setViewport(1000, 800)
+
+      // Simulate scroll progression: top -> middle -> bottom
+      const scenarios = [
+        // At top: panel 0 active
+        { rects: [{ top: 0, height: 800 }, { top: 800, height: 800 }, { top: 1600, height: 800 }], expected: [true, false, false] },
+        // Scrolled a bit: panel 0 still active (panel 1 entering)
+        { rects: [{ top: -200, height: 800 }, { top: 600, height: 800 }, { top: 1400, height: 800 }], expected: [true, false, false] },
+        // Panel 1 reached sticky: panel 1 active
+        { rects: [{ top: -800, height: 800 }, { top: 0, height: 800 }, { top: 800, height: 800 }], expected: [false, true, false] },
+        // Panel 2 reached sticky: panel 2 active
+        { rects: [{ top: -1600, height: 800 }, { top: -800, height: 800 }, { top: 0, height: 800 }], expected: [false, false, true] },
+      ]
+
+      for (const scenario of scenarios) {
+        const { result, unmount } = renderHook(() => {
+          const elements: HTMLElement[] = []
+          for (let i = 0; i < 3; i++) {
+            const el = document.createElement('div')
+            el.getBoundingClientRect = vi.fn(() =>
+              createRect(scenario.rects[i].top, scenario.rects[i].height)
+            )
+            elements.push(el)
+          }
+
+          const { active, setRef } = useActivePanel(3)
+          elements.forEach((el, i) => setRef(i)(el))
+
+          return active
+        })
+
+        act(() => window.dispatchEvent(new Event('scroll')))
+
+        expect(result.current).toEqual(scenario.expected)
+        unmount()
+      }
+    })
+
+    it('does not flicker when two sticky panels intersect (tie-breaking by DOM order)', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        // Both panels at same top position (both sticky at top: 0)
+        // Higher DOM index (panel 1) should win
+        const rects = [
+          { top: 0, height: 800 },
+          { top: 0, height: 800 },
+          { top: 800, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const { active, setRef } = useActivePanel(3)
+        elements.forEach((el, i) => setRef(i)(el))
+
+        return active
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      // Panel 1 (higher DOM index) wins the tie
+      expect(result.current).toEqual([false, true, false])
+    })
+
+    it('last panel stays active when all panels have scrolled past', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        // All panels scrolled past viewport
+        const rects = [
+          { top: -2400, height: 800 },
+          { top: -1600, height: 800 },
+          { top: -800, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const { active, setRef } = useActivePanel(3)
+        elements.forEach((el, i) => setRef(i)(el))
+
+        return active
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      // Last panel remains active
+      expect(result.current).toEqual([false, false, true])
+    })
+
+    it('returns deterministic result across multiple scroll events at same position', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        const rects = [
+          { top: -800, height: 800 },
+          { top: 0, height: 800 },
+          { top: 800, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const { active, setRef } = useActivePanel(3)
+        elements.forEach((el, i) => setRef(i)(el))
+
+        return active
+      })
+
+      // Fire multiple scroll events
+      for (let i = 0; i < 10; i++) {
+        act(() => window.dispatchEvent(new Event('scroll')))
+        expect(result.current).toEqual([false, true, false])
+      }
+    })
+
+    it('recalculates active panel on resize', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        const rects = [
+          { top: -800, height: 800 },
+          { top: 0, height: 800 },
+          { top: 800, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const { active, setRef } = useActivePanel(3)
+        elements.forEach((el, i) => setRef(i)(el))
+
+        return active
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+      expect(result.current).toEqual([false, true, false])
+
+      // Resize shouldn't change the result since panel positions are relative
+      act(() => window.dispatchEvent(new Event('resize')))
+      expect(result.current).toEqual([false, true, false])
+    })
+
+    it('handles single panel correctly', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const el = document.createElement('div')
+        el.getBoundingClientRect = vi.fn(() => createRect(0, 800))
+
+        const { active, setRef } = useActivePanel(1)
+        setRef(0)(el)
+
+        return active
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current).toEqual([true])
+    })
+
+    it('handles two panels correctly', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        const rects = [
+          { top: -800, height: 800 },
+          { top: 0, height: 800 },
+        ]
+        for (let i = 0; i < 2; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const { active, setRef } = useActivePanel(2)
+        elements.forEach((el, i) => setRef(i)(el))
+
+        return active
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current).toEqual([false, true])
+    })
+  })
+})

--- a/src/hooks/useActivePanel.ts
+++ b/src/hooks/useActivePanel.ts
@@ -1,5 +1,26 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
+function computeActiveIndex(panelRefs: (HTMLElement | null)[]): number {
+  const count = panelRefs.length
+  if (count === 0) return 0
+  if (count === 1) return 0
+
+  let activeIndex = 0
+
+  for (let i = count - 1; i >= 0; i--) {
+    const ref = panelRefs[i]
+    if (!ref) continue
+
+    const rect = ref.getBoundingClientRect()
+    if (rect.top <= 0) {
+      activeIndex = i
+      break
+    }
+  }
+
+  return activeIndex
+}
+
 export function useActivePanel(panelCount: number): {
   active: boolean[]
   setRef: (index: number) => (el: HTMLElement | null) => void
@@ -7,35 +28,24 @@ export function useActivePanel(panelCount: number): {
   const [activeIndex, setActiveIndex] = useState(0)
   const panelRefs = useRef<(HTMLElement | null)[]>([])
 
+  const updateActiveIndex = useCallback(() => {
+    const next = computeActiveIndex(panelRefs.current)
+    setActiveIndex(next)
+  }, [])
+
   useEffect(() => {
     panelRefs.current = panelRefs.current.slice(0, panelCount)
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const visiblePanels = entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top)
+    updateActiveIndex()
 
-        if (visiblePanels.length === 0) {
-          return
-        }
+    window.addEventListener('scroll', updateActiveIndex, { passive: true })
+    window.addEventListener('resize', updateActiveIndex)
 
-        const topmostIndex = panelRefs.current.indexOf(visiblePanels[0].target as HTMLElement)
-        if (topmostIndex !== -1) {
-          setActiveIndex(topmostIndex)
-        }
-      },
-      { threshold: [0, 0.1, 0.5, 1] },
-    )
-
-    panelRefs.current.forEach((ref) => {
-      if (ref) {
-        observer.observe(ref)
-      }
-    })
-
-    return () => observer.disconnect()
-  }, [panelCount])
+    return () => {
+      window.removeEventListener('scroll', updateActiveIndex)
+      window.removeEventListener('resize', updateActiveIndex)
+    }
+  }, [panelCount, updateActiveIndex])
 
   const setRef = useCallback((index: number) => (el: HTMLElement | null) => {
     panelRefs.current[index] = el


### PR DESCRIPTION
**Purpose** — Replace non-deterministic IntersectionObserver-based active panel detection with a scroll-position-based approach that produces consistent results.

**What it does** — Computes the active timeline panel deterministically by reading each panel's `getBoundingClientRect()` on scroll/resize events and selecting the highest-index panel that has reached the sticky position (`top <= 0`).

**Changes made**
- Rewrote `useActivePanel` hook to use scroll/resize event listeners instead of IntersectionObserver
- Extracted `computeActiveIndex` as a pure function for testability
- Tie-breaking when multiple panels share `top <= 0` resolved by DOM order (highest index wins, matching the visual stacking behavior)
- Added 11 unit tests covering: single/multi-panel scenarios, scroll progression, intersecting panels, all-scrolled-past state, and deterministic repeatability

**Additional notes**
- Matches the deterministic pattern used by `useHorizontalScroll` for ProjectsSection
- No styling or content changes — active panel detection logic only
- All 259 tests pass, typecheck passes

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for active panel state detection, covering various viewport and scroll scenarios.

* **Refactor**
  * Refactored internal panel tracking mechanism while maintaining existing functionality and API compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->