### PR TITLE
Follow-up: consolidate Projects card motion state

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -473,9 +473,9 @@ describe('ProjectsSection', () => {
 
       // At progress 0, card 0 is active
       const activeCard = cards[0]
-      const style = (activeCard as HTMLElement).style
-      expect(style.transform).toContain('scale(1)')
-      expect(style.opacity).toBe('1')
+      expect(activeCard).toHaveAttribute('data-card-state', 'active')
+      expect(activeCard).toHaveAttribute('data-card-scale', '1')
+      expect(activeCard).toHaveAttribute('data-card-opacity', '1')
     })
 
     it('active card remains unfilled by default (no orange fill when not hovered)', () => {
@@ -497,10 +497,9 @@ describe('ProjectsSection', () => {
 
       // At progress 0, card 0 is active, card 1 is right neighbor
       const rightNeighbor = cards[1]
-      const neighborStyle = (rightNeighbor as HTMLElement).style
-      expect(neighborStyle.opacity).not.toBe('')
-      expect(parseFloat(neighborStyle.opacity)).toBeGreaterThan(0)
-      expect(parseFloat(neighborStyle.opacity)).toBeLessThan(1)
+      const neighborOpacity = Number(rightNeighbor.getAttribute('data-card-opacity'))
+      expect(neighborOpacity).toBeGreaterThan(0)
+      expect(neighborOpacity).toBeLessThan(1)
     })
 
     it('neighbor cards use reduced opacity relative to the active card', () => {
@@ -508,11 +507,11 @@ describe('ProjectsSection', () => {
       render(<ProjectsSection projects={threeProjects} />)
 
       const cards = document.querySelectorAll('[data-testid="project-card"]')
-      const activeCard = cards[0] as HTMLElement
-      const neighborCard = cards[1] as HTMLElement
+      const activeCard = cards[0]
+      const neighborCard = cards[1]
 
-      const activeOpacity = parseFloat(activeCard.style.opacity) || 1
-      const neighborOpacity = parseFloat(neighborCard.style.opacity)
+      const activeOpacity = Number(activeCard.getAttribute('data-card-opacity'))
+      const neighborOpacity = Number(neighborCard.getAttribute('data-card-opacity'))
 
       expect(neighborOpacity).toBeLessThan(activeOpacity)
     })
@@ -522,18 +521,13 @@ describe('ProjectsSection', () => {
       render(<ProjectsSection projects={threeProjects} />)
 
       const cards = document.querySelectorAll('[data-testid="project-card"]')
-      const activeCard = cards[0] as HTMLElement
-      const neighborCard = cards[1] as HTMLElement
+      const activeCard = cards[0]
+      const neighborCard = cards[1]
 
-      const activeTransform = activeCard.style.transform
-      const neighborTransform = neighborCard.style.transform
+      const activeScale = Number(activeCard.getAttribute('data-card-scale'))
+      const neighborScale = Number(neighborCard.getAttribute('data-card-scale'))
 
-      const activeScaleMatch = activeTransform.match(/scale\(([\d.]+)\)/)
-      const neighborScaleMatch = neighborTransform.match(/scale\(([\d.]+)\)/)
-
-      if (activeScaleMatch && neighborScaleMatch) {
-        expect(parseFloat(neighborScaleMatch[1])).toBeLessThan(parseFloat(activeScaleMatch[1]))
-      }
+      expect(neighborScale).toBeLessThan(activeScale)
     })
 
     it('far cards are visually suppressed with low opacity and scale', () => {
@@ -543,23 +537,18 @@ describe('ProjectsSection', () => {
       const cards = document.querySelectorAll('[data-testid="project-card"]')
 
       // At progress 0, card 0 is active, card 1 is neighbor, card 2 is far
-      const farCard = cards[2] as HTMLElement
-      const activeCard = cards[0] as HTMLElement
+      const farCard = cards[2]
+      const activeCard = cards[0]
 
-      const farOpacity = parseFloat(farCard.style.opacity)
-      const activeOpacity = parseFloat(activeCard.style.opacity) || 1
+      const farOpacity = Number(farCard.getAttribute('data-card-opacity'))
+      const activeOpacity = Number(activeCard.getAttribute('data-card-opacity'))
 
       expect(farOpacity).toBeLessThan(activeOpacity)
 
-      const farTransform = farCard.style.transform
-      const activeTransform = activeCard.style.transform
+      const farScale = Number(farCard.getAttribute('data-card-scale'))
+      const activeScale = Number(activeCard.getAttribute('data-card-scale'))
 
-      const farScaleMatch = farTransform.match(/scale\(([\d.]+)\)/)
-      const activeScaleMatch = activeTransform.match(/scale\(([\d.]+)\)/)
-
-      if (farScaleMatch && activeScaleMatch) {
-        expect(parseFloat(farScaleMatch[1])).toBeLessThan(parseFloat(activeScaleMatch[1]))
-      }
+      expect(farScale).toBeLessThan(activeScale)
     })
 
     it('no layout jump occurs when active index changes (smooth transition)', () => {
@@ -604,10 +593,10 @@ describe('ProjectsSection', () => {
       const lastIndex = threeProjects.length - 1
 
       // At progress 1, last card should be active
-      const lastCard = cards[lastIndex] as HTMLElement
-      const style = lastCard.style
-      expect(style.transform).toContain('scale(1)')
-      expect(style.opacity).toBe('1')
+      const lastCard = cards[lastIndex]
+      expect(lastCard).toHaveAttribute('data-card-state', 'active')
+      expect(lastCard).toHaveAttribute('data-card-scale', '1')
+      expect(lastCard).toHaveAttribute('data-card-opacity', '1')
     })
   })
 })

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -36,6 +36,15 @@ const NEIGHBOR_SCALE = 0.92
 const NEIGHBOR_OPACITY = 0.6
 const FAR_SCALE = 0.85
 const FAR_OPACITY = 0.25
+const CARD_STATE_TRANSITION = {
+  y: { duration: 0.2, ease: 'easeOut' },
+  scale: { duration: 0.3, ease: 'easeOut' },
+  opacity: { duration: 0.3, ease: 'easeOut' },
+} as const
+
+function clampIndex(index: number, projectCount: number) {
+  return Math.max(0, Math.min(projectCount - 1, index))
+}
 
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
   const outerRef = useRef<HTMLElement>(null)
@@ -44,7 +53,9 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
   const scrollRangeVh = getScrollRangeVh(projects.length)
   useCardDeckDepth(outerRef as React.RefObject<HTMLElement>)
 
-  const activeIndex = projects.length > 1 ? Math.round(progress * (projects.length - 1)) : 0
+  const activeIndex = projects.length > 1
+    ? clampIndex(Math.round(progress * (projects.length - 1)), projects.length)
+    : 0
 
   return (
     <section
@@ -83,6 +94,7 @@ const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: numb
   const distance = Math.abs(index - activeIndex)
   const isActive = distance === 0
   const isNeighbor = distance === 1
+  const cardState = isActive ? 'active' : isNeighbor ? 'neighbor' : 'far'
 
   const scale = isActive ? 1 : isNeighbor ? NEIGHBOR_SCALE : FAR_SCALE
   const opacity = isActive ? 1 : isNeighbor ? NEIGHBOR_OPACITY : FAR_OPACITY
@@ -97,17 +109,17 @@ const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: numb
           setHasFocus(false)
         }
       }}
-      animate={{ y: isFillActive ? -4 : 0 }}
-      transition={{ duration: 0.2, ease: 'easeOut' }}
+      animate={{ y: isFillActive ? -4 : 0, scale, opacity }}
+      transition={CARD_STATE_TRANSITION}
       data-testid="project-card"
+      data-card-state={cardState}
+      data-card-scale={scale}
+      data-card-opacity={opacity}
       className="relative shrink-0 bg-platinum"
       style={{
         clipPath: NOTCH,
         maxWidth: '480px',
         width: '480px',
-        transform: `scale(${scale})`,
-        opacity,
-        transition: 'transform 0.3s ease-out, opacity 0.3s ease-out',
         transformOrigin: 'center center',
       }}
     >


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #171 / issue #153.
- Moves Projects card scale and opacity into the same Framer Motion animate prop as hover/focus y movement so CSS transform ownership is not split.
- Clamps the computed active project index defensively.
- Updates tests to assert the active/neighbor/far card state contract directly instead of relying on inline transform strings.

## Why
PR #171 left a real animation risk: the card used Framer Motion for y translation while inline CSS also wrote transform: scale(...). Those can overwrite each other because they both own the CSS transform property.

## Validation
- npm run typecheck
- npm run test (256 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced card animation state handling to improve layout consistency and prevent edge cases in card positioning.

* **Tests**
  * Updated test assertions to validate card animation states using dedicated test attributes, improving test reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->