### PR TITLE
Projects: add pinned desktop progress indicator and scroll hint

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -452,6 +452,98 @@ describe('ProjectsSection', () => {
     })
   })
 
+  describe('progress indicator', () => {
+    it('renders zero-padded current index and total count in the header', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+      // 2 projects, progress=0 → activeIndex=0 → "01 / 02"
+      expect(screen.getByTestId('progress-count')).toHaveTextContent('01 / 02')
+    })
+
+    it('progress indicator is inside the header row, not inside the carousel track', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+      const progressIndicator = screen.getByTestId('progress-indicator')
+      expect(progressIndicator.closest('[data-carousel-track="true"]')).toBeNull()
+    })
+
+    it('progress fill starts at 0% width before any scroll', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+      const fill = screen.getByTestId('progress-fill')
+      expect(fill).toHaveStyle({ width: '0%' })
+    })
+
+    it('progress fill width reflects carousel progress on scroll', () => {
+      setViewport(1000, 800)
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const projectsSection = document.getElementById('projects') as HTMLElement
+      const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-800, 2400))
+      Object.defineProperty(carouselTrack, 'scrollWidth', {
+        configurable: true,
+        value: 1800,
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      const fill = screen.getByTestId('progress-fill')
+      const width = parseFloat(fill.style.width)
+      expect(width).toBeGreaterThan(0)
+      expect(width).toBeLessThanOrEqual(100)
+    })
+
+    it('progress indicator is inside the sticky viewport', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+      const progressIndicator = screen.getByTestId('progress-indicator')
+      expect(progressIndicator.closest('[data-sticky-viewport="true"]')).toBeInTheDocument()
+    })
+  })
+
+  describe('scroll hint', () => {
+    it('renders scroll hint element inside the sticky viewport', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+      const hint = screen.getByTestId('scroll-hint')
+      expect(hint).toBeInTheDocument()
+      expect(hint.closest('[data-sticky-viewport="true"]')).toBeInTheDocument()
+    })
+
+    it('scroll hint is visible when progress is 0', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+      const hint = screen.getByTestId('scroll-hint')
+      expect(hint).toHaveAttribute('data-visible', 'true')
+    })
+
+    it('scroll hint is not visible when progress advances beyond 0', () => {
+      setViewport(1000, 800)
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const projectsSection = document.getElementById('projects') as HTMLElement
+      const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-800, 2400))
+      Object.defineProperty(carouselTrack, 'scrollWidth', {
+        configurable: true,
+        value: 1800,
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      const hint = screen.getByTestId('scroll-hint')
+      expect(hint).toHaveAttribute('data-visible', 'false')
+    })
+
+    it('scroll hint is visually secondary (aria-hidden)', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+      expect(screen.getByTestId('scroll-hint')).toHaveAttribute('aria-hidden', 'true')
+    })
+
+    it('scroll hint is not inside the carousel track', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+      const hint = screen.getByTestId('scroll-hint')
+      expect(hint.closest('[data-carousel-track="true"]')).toBeNull()
+    })
+  })
+
   describe('desktop active card and neighbor model', () => {
     const threeProjects = [
       ...mockProjects,

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -455,7 +455,6 @@ describe('ProjectsSection', () => {
   describe('progress indicator', () => {
     it('renders zero-padded current index and total count in the header', () => {
       render(<ProjectsSection projects={mockProjects} />)
-      // 2 projects, progress=0 → activeIndex=0 → "01 / 02"
       expect(screen.getByTestId('progress-count')).toHaveTextContent('01 / 02')
     })
 
@@ -496,6 +495,54 @@ describe('ProjectsSection', () => {
       render(<ProjectsSection projects={mockProjects} />)
       const progressIndicator = screen.getByTestId('progress-indicator')
       expect(progressIndicator.closest('[data-sticky-viewport="true"]')).toBeInTheDocument()
+    })
+
+    it('progress count shows 01 / 01 for a single-project list', () => {
+      render(<ProjectsSection projects={[mockProjects[0]]} />)
+      expect(screen.getByTestId('progress-count')).toHaveTextContent('01 / 01')
+    })
+
+    it('progress count advances to last card index at full scroll', () => {
+      setViewport(1000, 800)
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const projectsSection = document.getElementById('projects') as HTMLElement
+      const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+
+      const sectionHeight = getScrollRangeVh(mockProjects.length) * 800
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(
+        createRect(-(sectionHeight - 800), sectionHeight),
+      )
+      Object.defineProperty(carouselTrack, 'scrollWidth', {
+        configurable: true,
+        value: 2 * (CARD_WIDTH + CARD_GAP),
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(screen.getByTestId('progress-count')).toHaveTextContent('02 / 02')
+    })
+
+    it('progress fill reaches 100% width at full scroll', () => {
+      setViewport(1000, 800)
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const projectsSection = document.getElementById('projects') as HTMLElement
+      const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+
+      const sectionHeight = getScrollRangeVh(mockProjects.length) * 800
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(
+        createRect(-(sectionHeight - 800), sectionHeight),
+      )
+      Object.defineProperty(carouselTrack, 'scrollWidth', {
+        configurable: true,
+        value: 2 * (CARD_WIDTH + CARD_GAP),
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      const fill = screen.getByTestId('progress-fill')
+      expect(parseFloat(fill.style.width)).toBe(100)
     })
   })
 

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -65,12 +65,31 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
       className="relative min-h-screen px-8 bg-graphite-light origin-center transform-gpu"
       style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'hidden', willChange: 'transform, opacity' }}
     >
-      <div data-sticky-viewport="true" className="flex flex-col justify-center py-14" style={{ position: 'sticky', top: 0, height: '100vh' }}>
+      <div data-sticky-viewport="true" className="relative flex flex-col justify-center py-14" style={{ position: 'sticky', top: 0, height: '100vh' }}>
         <div className="w-full">
           <div className="flex items-center gap-3 mb-8">
             <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 01</span>
             <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">PROJECTS</span>
             <hr className="flex-1 border-periwinkle/20" />
+            <div
+              data-testid="progress-indicator"
+              className="flex items-center gap-[10px] font-body text-periwinkle shrink-0"
+              style={{ fontSize: '9px', letterSpacing: '2px' }}
+            >
+              <span data-testid="progress-count">
+                {String(activeIndex + 1).padStart(2, '0')} / {String(projects.length).padStart(2, '0')}
+              </span>
+              <div
+                className="relative"
+                style={{ width: '80px', height: '1px', backgroundColor: 'rgba(178,182,210,0.2)' }}
+              >
+                <div
+                  data-testid="progress-fill"
+                  className="absolute left-0 top-0 h-full bg-atomic-tangerine"
+                  style={{ width: `${progress * 100}%`, transition: 'width 0.1s linear' }}
+                />
+              </div>
+            </div>
           </div>
 
           <div ref={innerRef as React.RefObject<HTMLDivElement>} data-carousel-track="true" className="relative" style={{ transform: `translateX(${tx}px)` }}>
@@ -81,6 +100,29 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
             </div>
           </div>
         </div>
+
+        <motion.div
+          data-testid="scroll-hint"
+          data-visible={progress === 0}
+          aria-hidden="true"
+          animate={{ opacity: progress === 0 ? 0.85 : 0 }}
+          transition={{ duration: 0.3 }}
+          className="absolute font-body text-periwinkle flex items-center gap-3 pointer-events-none"
+          style={{ fontSize: '14px', letterSpacing: '3px', left: '50%', bottom: '28px', transform: 'translateX(-50%)' }}
+        >
+          SCROLL{' '}
+          <motion.span
+            animate={progress === 0 ? { x: [0, 6, 0] } : { x: 0 }}
+            transition={
+              progress === 0
+                ? { duration: 1.6, repeat: Infinity, ease: 'easeInOut' }
+                : { duration: 0 }
+            }
+            style={{ display: 'inline-block' }}
+          >
+            →
+          </motion.span>
+        </motion.div>
       </div>
     </section>
   )


### PR DESCRIPTION
## Purpose

Add the pinned progress indicator and scroll hint to the Projects section so the carousel has consistent navigation feedback and an entry cue aligned with the v4 reference design.

## What it does

- Inserts a zero-padded `01 / 06`-style counter and a thin orange progress fill bar into the section header (right of the horizontal rule), driven by the adjusted carousel progress and active card index.
- Adds a `SCROLL →` hint anchored to the bottom-center of the sticky viewport; it is visible at progress `0` and fades out once the carousel begins advancing, using framer-motion for the opacity transition and the nudge loop on the arrow.

## Changes made

- **`src/components/ProjectsSection.tsx`** — added progress indicator (`data-testid="progress-indicator"`, `progress-count`, `progress-fill`) to the header row; added scroll hint (`data-testid="scroll-hint"`) as an absolute-positioned child of the sticky viewport; added `relative` class to sticky viewport so the hint anchors correctly within the `100vh` panel.
- **`src/components/ProjectsSection.test.tsx`** — 10 new tests in `progress indicator` and `scroll hint` describe blocks covering zero-padded count format, header placement, fill width at rest and on scroll, scroll hint visibility at `progress === 0` and hidden once `progress > 0`, `aria-hidden`, and carousel-track isolation.

## Additional notes

- Active index is derived from `Math.round(progress * (projects.length - 1))`, consistent with issue #153 — not from a raw scroll value.
- Scroll hint stays visible through the dead-zone at the start of the scroll range (progress remains `0` during the dead zone), which is correct UX.
- The sticky viewport received `relative` as an extra Tailwind class (not a style override) to serve as the containing block for the absolute scroll hint; existing `position: sticky` behavior is unaffected.
- Browser QA: compare placement against `ideas/proj.png` and `ideas/Portfolio.html` — progress indicator lives right of the PROJECTS header rule; scroll hint is centered 28 px from the section bottom.
- 277 tests pass; `npm run typecheck` clean.

Closes #154

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated progress indicator in the projects section showing zero-padded counts (e.g., "01 / 02") and a filling progress bar that updates to 100% as you scroll; remains visible in the sticky viewport.
  * Visual scroll hint that appears initially, uses a subtle wiggle, and fades/ hides as you begin scrolling.

* **Tests**
  * Added UI tests covering the progress indicator behavior and scroll-hint visibility during scroll.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->