### PR TITLE
Projects: enforce v4 desktop notched card hierarchy

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -2,9 +2,9 @@ import { describe, it, expect, vi } from 'vitest'
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ProjectsSection from './ProjectsSection'
-import { getScrollRangeVh } from './projectsGeometry'
+import { getScrollRangeVh, PROJECT_CARD_WIDTH } from './projectsGeometry'
 
-const CARD_WIDTH = 480
+const CARD_WIDTH = PROJECT_CARD_WIDTH
 const CARD_GAP = 24
 
 const mockProjects = [
@@ -79,16 +79,17 @@ describe('ProjectsSection', () => {
     expect(screen.getByText('Description for project one')).toBeInTheDocument()
     expect(screen.getByText('React')).toBeInTheDocument()
     expect(screen.getByText('TypeScript')).toBeInTheDocument()
-    expect(screen.getByText('// GitHub ↗')).toBeInTheDocument()
-    expect(screen.getByText('// Demo ↗')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '// GitHub ↗' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '// Demo ↗' })).toBeInTheDocument()
   })
 
-  it('renders image when provided', () => {
+  it('does not render project screenshots inside cards (text-led layout)', () => {
     render(<ProjectsSection projects={mockProjects} />)
 
-    const images = screen.getAllByRole('img')
-    expect(images).toHaveLength(1)
-    expect(images[0]).toHaveAttribute('src', 'https://example.com/image1.png')
+    const cards = document.querySelectorAll('[data-testid="project-card"]')
+    cards.forEach((card) => {
+      expect(card.querySelector('img')).not.toBeInTheDocument()
+    })
   })
 
   it('omits image and placeholder elements when no image is provided', () => {
@@ -112,7 +113,7 @@ describe('ProjectsSection', () => {
     expect(headings.map(h => h.textContent)).toContain('Project One')
     expect(headings.map(h => h.textContent)).toContain('Project Two')
 
-    expect(screen.getByText('// Docs ↗')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: '// Docs ↗' })).toBeInTheDocument()
   })
 
   it('keeps the project title readable during hover fill', async () => {
@@ -123,13 +124,13 @@ describe('ProjectsSection', () => {
     const card = title.closest('[data-testid="project-card"]')
     expect(card).not.toBeNull()
 
-    expect(title).toHaveClass('text-graphite')
+    expect(title).toHaveClass('pcard-name')
 
     await user.hover(card!)
-    expect(title).toHaveClass('text-graphite')
+    expect(title).toHaveClass('text-platinum')
 
     await user.unhover(card!)
-    expect(title).toHaveClass('text-graphite')
+    expect(title).not.toHaveClass('text-platinum')
   })
 
   it('activates a diagonal orange fill layer when a project card is hovered', async () => {
@@ -167,7 +168,7 @@ describe('ProjectsSection', () => {
     expect(fill).toHaveAttribute('data-active', 'true')
   })
 
-  it('switches project card content to readable graphite text during the orange fill', async () => {
+  it('switches project card content to readable platinum text during the orange fill', async () => {
     const user = userEvent.setup()
     render(<ProjectsSection projects={mockProjects} />)
 
@@ -176,15 +177,13 @@ describe('ProjectsSection', () => {
     expect(card).not.toBeNull()
 
     const description = screen.getByText('Description for project one')
-    const bullet = screen.getByText('First bullet point for project one')
     const link = screen.getByRole('link', { name: '// GitHub ↗' })
 
     await user.hover(card!)
 
-    expect(title).toHaveClass('text-graphite')
-    expect(description).toHaveClass('text-graphite')
-    expect(bullet.closest('ul')).toHaveClass('text-graphite')
-    expect(link).toHaveClass('text-graphite')
+    expect(title).toHaveClass('text-platinum')
+    expect(description).toHaveClass('text-platinum')
+    expect(link).toHaveClass('text-platinum')
   })
 
   it('inverts project tags and ghost number during the orange fill', async () => {
@@ -195,12 +194,12 @@ describe('ProjectsSection', () => {
     const card = title.closest('[data-testid="project-card"]')
     expect(card).not.toBeNull()
 
-    const ghostNumber = screen.getByText('_01')
+    const ghostNumber = card!.querySelector('[data-testid="pcard-num"]')
     const tag = screen.getByText('React')
 
     await user.hover(card!)
 
-    expect(ghostNumber).toHaveClass('text-graphite')
+    expect(ghostNumber).not.toBeNull()
     expect(tag).toHaveAttribute('data-inverted', 'true')
   })
 
@@ -273,8 +272,8 @@ describe('ProjectsSection', () => {
 
     act(() => window.dispatchEvent(new Event('scroll')))
 
-    const centerOffset = 1000 / 2 - 480 / 2
-    const centeredTravelWidth = 1800 - 480
+    const centerOffset = 1000 / 2 - PROJECT_CARD_WIDTH / 2
+    const centeredTravelWidth = 1800 - PROJECT_CARD_WIDTH
     expect(carouselTrack.style.transform).toBe(`translateX(${centerOffset - centeredTravelWidth / 2}px)`)
   })
 
@@ -288,39 +287,14 @@ describe('ProjectsSection', () => {
     expect(carouselTrack).toBeInTheDocument()
   })
 
-  it('renders resume bullets when provided', () => {
+  it('omits resume bullets from cards to preserve v4 content hierarchy', () => {
     render(<ProjectsSection projects={mockProjects} />)
 
-    expect(screen.getByText('First bullet point for project one')).toBeInTheDocument()
-    expect(screen.getByText('Second bullet point for project one')).toBeInTheDocument()
-  })
-
-  it('omits bullets section when project has no bullets', () => {
-    render(<ProjectsSection projects={mockProjects} />)
-
-    const projectTwoCard = screen.getByRole('heading', { name: 'Project Two' }).closest('[data-testid="project-card"]')
-    expect(projectTwoCard).not.toBeNull()
-
-    const bulletsList = projectTwoCard?.querySelector('ul')
-    expect(bulletsList).not.toBeInTheDocument()
-  })
-
-  it('renders bullets as a list structure', () => {
-    render(<ProjectsSection projects={mockProjects} />)
-
-    const lists = document.querySelectorAll('[data-testid="project-card"] ul')
-    expect(lists).toHaveLength(1)
-    expect(lists[0].querySelectorAll('li')).toHaveLength(2)
-  })
-
-  it('card has explicit width constraint to prevent full-width collapse', () => {
-    render(<ProjectsSection projects={mockProjects} />)
-
-    const card = document.querySelector('[data-testid="project-card"]')
-    expect(card).not.toBeNull()
-    const style = window.getComputedStyle(card!)
-    expect(style.maxWidth).not.toBe('none')
-    expect(style.maxWidth).not.toBe('')
+    const cards = document.querySelectorAll('[data-testid="project-card"]')
+    cards.forEach((card) => {
+      expect(card.querySelector('ul')).not.toBeInTheDocument()
+    })
+    expect(screen.queryByText('First bullet point for project one')).not.toBeInTheDocument()
   })
 
   it('outer container uses the scroll range formula (projects.length * 1.5 + 1) * 100vh', () => {
@@ -449,6 +423,76 @@ describe('ProjectsSection', () => {
     progressPoints.forEach((progress, i) => {
       const activeIndex = Math.round(progress * (threeProjects.length - 1))
       expect(activeIndex).toBe(expectedIndices[i])
+    })
+  })
+
+  describe('v4 notched card hierarchy', () => {
+    it('each card exposes number, ghost number, title, description, tags, and links', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      expect(cards).toHaveLength(2)
+
+      cards.forEach((card, index) => {
+        const project = mockProjects[index]
+        const paddedId = project.id.padStart(2, '0')
+
+        expect(card.querySelector('[data-testid="pcard-ghost"]')).toHaveTextContent(`_${paddedId}`)
+        expect(card.querySelector('[data-testid="pcard-num"]')).toHaveTextContent(`_${paddedId}`)
+        expect(card.querySelector('.pcard-name')).toHaveTextContent(project.title)
+        expect(card.querySelector('.pcard-desc')).toHaveTextContent(project.description)
+
+        project.tags.forEach((tag) => {
+          expect(card.querySelector('.pcard-tags')).toHaveTextContent(tag)
+        })
+
+        project.links.forEach((link) => {
+          expect(card.querySelector('.pcard-links')).toHaveTextContent(link.label)
+        })
+      })
+    })
+
+    it('renders a large ghost number element behind card content', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const ghost = document.querySelector('[data-testid="pcard-ghost"]')
+      expect(ghost).toBeInTheDocument()
+      expect(ghost).toHaveClass('pcard-ghost')
+    })
+
+    it('project title uses the pixel display font via pcard-name', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const title = screen.getByRole('heading', { name: 'Project One' })
+      expect(title).toHaveClass('pcard-name')
+    })
+
+    it('tags use v4 palette classes', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const tags = document.querySelectorAll('.pcard-tags .ptag')
+      expect(tags.length).toBeGreaterThan(0)
+      tags.forEach((tag) => {
+        expect(tag.className).toMatch(/ptag ptag-(fuchsia|blue|orange|yellow)/)
+      })
+    })
+
+    it('cards use pcard sizing and do not collapse to full-width rows', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const card = document.querySelector('[data-testid="project-card"]') as HTMLElement
+      expect(card).toHaveClass('pcard')
+      expect(card).toHaveClass('shrink-0')
+      expect(card.querySelector('.pcard-bg')).toBeInTheDocument()
+      expect(PROJECT_CARD_WIDTH).toBe(560)
+    })
+
+    it('does not render dominant project screenshots inside cards', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const card = screen.getByRole('heading', { name: 'Project One' }).closest('[data-testid="project-card"]')
+      expect(card?.querySelector('img')).not.toBeInTheDocument()
     })
   })
 

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -186,7 +186,7 @@ describe('ProjectsSection', () => {
     expect(link).toHaveClass('text-platinum')
   })
 
-  it('inverts project tags and ghost number during the orange fill', async () => {
+  it('inverts project tags, ghost number, and card number during the orange fill', async () => {
     const user = userEvent.setup()
     render(<ProjectsSection projects={mockProjects} />)
 
@@ -194,12 +194,17 @@ describe('ProjectsSection', () => {
     const card = title.closest('[data-testid="project-card"]')
     expect(card).not.toBeNull()
 
-    const ghostNumber = card!.querySelector('[data-testid="pcard-num"]')
+    const ghostNumber = card!.querySelector('[data-testid="pcard-ghost"]')
+    const cardNumber = card!.querySelector('[data-testid="pcard-num"]')
     const tag = screen.getByText('React')
+
+    expect(card).toHaveAttribute('data-fill-active', 'false')
 
     await user.hover(card!)
 
+    expect(card).toHaveAttribute('data-fill-active', 'true')
     expect(ghostNumber).not.toBeNull()
+    expect(cardNumber).not.toBeNull()
     expect(tag).toHaveAttribute('data-inverted', 'true')
   })
 
@@ -486,6 +491,58 @@ describe('ProjectsSection', () => {
       expect(card).toHaveClass('shrink-0')
       expect(card.querySelector('.pcard-bg')).toBeInTheDocument()
       expect(PROJECT_CARD_WIDTH).toBe(560)
+    })
+
+    it('renders notched corner accent markers on each card', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      cards.forEach((card) => {
+        expect(card.querySelector('.pcard-notch.tl')).toBeInTheDocument()
+        expect(card.querySelector('.pcard-notch.br')).toBeInTheDocument()
+      })
+    })
+
+    it('renders card hierarchy for a single-project carousel', () => {
+      const singleProject = [mockProjects[0]]
+      render(<ProjectsSection projects={singleProject} />)
+
+      const card = document.querySelector('[data-testid="project-card"]')
+      expect(card).toBeInTheDocument()
+      expect(card?.querySelector('[data-testid="pcard-ghost"]')).toHaveTextContent('_01')
+      expect(card?.querySelector('.pcard-name')).toHaveTextContent('Project One')
+    })
+
+    it('renders empty tag and link regions without breaking card layout', () => {
+      const sparseProject = [{
+        id: '9',
+        title: 'Sparse Project',
+        description: 'No tags or links',
+        tags: [],
+        links: [],
+      }]
+      render(<ProjectsSection projects={sparseProject} />)
+
+      const card = document.querySelector('[data-testid="project-card"]')
+      expect(card?.querySelector('.pcard-tags')).toBeEmptyDOMElement()
+      expect(card?.querySelector('.pcard-links')).toBeEmptyDOMElement()
+      expect(card?.querySelector('.pcard-name')).toHaveTextContent('Sparse Project')
+      expect(card?.querySelector('[data-testid="pcard-num"]')).toHaveTextContent('_09')
+    })
+
+    it('cycles tag palette variants for projects with more than four tags', () => {
+      const manyTagsProject = [{
+        id: '1',
+        title: 'Tagged Project',
+        description: 'Many technologies',
+        tags: ['A', 'B', 'C', 'D', 'E'],
+        links: [{ label: 'Site', url: 'https://example.com' }],
+      }]
+      render(<ProjectsSection projects={manyTagsProject} />)
+
+      const tags = document.querySelectorAll('.pcard-tags .ptag')
+      expect(tags).toHaveLength(5)
+      expect(tags[4]).toHaveClass('ptag-fuchsia')
     })
 
     it('does not render dominant project screenshots inside cards', () => {

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion'
 import { useCardDeckDepth } from '../hooks/useCardDeckDepth'
 import { useHorizontalScroll } from '../hooks/useHorizontalScroll'
 import type { Project } from '../data/projects'
-import { getScrollRangeVh, PROJECT_CARD_WIDTH } from './projectsGeometry'
+import { formatProjectNumber, getScrollRangeVh, PROJECT_CARD_WIDTH } from './projectsGeometry'
 
 interface Props {
   projects: Project[]
@@ -28,10 +28,6 @@ const CARD_STATE_TRANSITION = {
 
 function clampIndex(index: number, projectCount: number) {
   return Math.max(0, Math.min(projectCount - 1, index))
-}
-
-function formatProjectNumber(id: string) {
-  return `_${id.padStart(2, '0')}`
 }
 
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
@@ -143,6 +139,7 @@ const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: numb
       animate={{ y: isFillActive ? -4 : 0, scale, opacity }}
       transition={CARD_STATE_TRANSITION}
       data-testid="project-card"
+      data-fill-active={isFillActive}
       data-card-state={cardState}
       data-card-scale={scale}
       data-card-opacity={opacity}
@@ -191,7 +188,7 @@ const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: numb
         <div className="pcard-links">
           {project.links.map((link) => (
             <a
-              key={link.label}
+              key={`${link.label}-${link.url}`}
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -3,35 +3,19 @@ import { motion } from 'framer-motion'
 import { useCardDeckDepth } from '../hooks/useCardDeckDepth'
 import { useHorizontalScroll } from '../hooks/useHorizontalScroll'
 import type { Project } from '../data/projects'
-import { getScrollRangeVh } from './projectsGeometry'
+import { getScrollRangeVh, PROJECT_CARD_WIDTH } from './projectsGeometry'
 
 interface Props {
   projects: Project[]
 }
 
-const TAG_COLORS = [
-  { bg: '#E0007F', fg: '#EFF1F3' },
-  { bg: '#5200E0', fg: '#EFF1F3' },
-  { bg: '#FF8547', fg: '#050609' },
-  { bg: '#FFC857', fg: '#050609' },
-]
+const TAG_VARIANTS = ['fuchsia', 'blue', 'orange', 'yellow'] as const
 
-const NOTCH = 'polygon(20px 0, 100% 0, 100% calc(100% - 20px), calc(100% - 20px) 100%, 0 100%, 0 20px)'
 const FILL_CLOSED = 'polygon(0 0, 0 0, 0 0, 0 0)'
 const FILL_OPEN = 'polygon(0 0, 220% 0, 100% 220%, 0 100%)'
 const FILL_TRANSITION = { duration: 0.32, ease: 'easeOut' } as const
-const INVERTED_TAG_STYLE = {
-  backgroundColor: 'rgba(42, 43, 42, 0.14)',
-  color: '#2A2B2A',
-  borderColor: 'rgba(42, 43, 42, 0.38)',
-} as const
+const INVERTED_TAG_CLASS = 'ptag-inverted'
 
-function getTagStyle(tagIndex: number) {
-  const color = TAG_COLORS[tagIndex % TAG_COLORS.length]
-  return { backgroundColor: color.bg, color: color.fg }
-}
-
-const CARD_WIDTH = 480
 const NEIGHBOR_SCALE = 0.92
 const NEIGHBOR_OPACITY = 0.6
 const FAR_SCALE = 0.85
@@ -46,10 +30,14 @@ function clampIndex(index: number, projectCount: number) {
   return Math.max(0, Math.min(projectCount - 1, index))
 }
 
+function formatProjectNumber(id: string) {
+  return `_${id.padStart(2, '0')}`
+}
+
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
   const outerRef = useRef<HTMLElement>(null)
   const innerRef = useRef<HTMLDivElement>(null)
-  const { tx, progress } = useHorizontalScroll(outerRef as React.RefObject<HTMLElement>, innerRef as React.RefObject<HTMLElement>, { cardWidth: CARD_WIDTH })
+  const { tx, progress } = useHorizontalScroll(outerRef as React.RefObject<HTMLElement>, innerRef as React.RefObject<HTMLElement>, { cardWidth: PROJECT_CARD_WIDTH })
   const scrollRangeVh = getScrollRangeVh(projects.length)
   useCardDeckDepth(outerRef as React.RefObject<HTMLElement>)
 
@@ -65,12 +53,31 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
       className="relative min-h-screen px-8 bg-graphite-light origin-center transform-gpu"
       style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'hidden', willChange: 'transform, opacity' }}
     >
-      <div data-sticky-viewport="true" className="flex flex-col justify-center py-14" style={{ position: 'sticky', top: 0, height: '100vh' }}>
+      <div data-sticky-viewport="true" className="relative flex flex-col justify-center py-14" style={{ position: 'sticky', top: 0, height: '100vh' }}>
         <div className="w-full">
           <div className="flex items-center gap-3 mb-8">
             <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 01</span>
             <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">PROJECTS</span>
             <hr className="flex-1 border-periwinkle/20" />
+            <div
+              data-testid="progress-indicator"
+              className="flex items-center gap-[10px] font-body text-periwinkle shrink-0"
+              style={{ fontSize: '9px', letterSpacing: '2px' }}
+            >
+              <span data-testid="progress-count">
+                {String(activeIndex + 1).padStart(2, '0')} / {String(projects.length).padStart(2, '0')}
+              </span>
+              <div
+                className="relative"
+                style={{ width: '80px', height: '1px', backgroundColor: 'rgba(178,182,210,0.2)' }}
+              >
+                <div
+                  data-testid="progress-fill"
+                  className="absolute left-0 top-0 h-full bg-atomic-tangerine"
+                  style={{ width: `${progress * 100}%`, transition: 'width 0.1s linear' }}
+                />
+              </div>
+            </div>
           </div>
 
           <div ref={innerRef as React.RefObject<HTMLDivElement>} data-carousel-track="true" className="relative" style={{ transform: `translateX(${tx}px)` }}>
@@ -81,6 +88,29 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
             </div>
           </div>
         </div>
+
+        <motion.div
+          data-testid="scroll-hint"
+          data-visible={progress === 0}
+          aria-hidden="true"
+          animate={{ opacity: progress === 0 ? 0.85 : 0 }}
+          transition={{ duration: 0.3 }}
+          className="absolute font-body text-periwinkle flex items-center gap-3 pointer-events-none"
+          style={{ fontSize: '14px', letterSpacing: '3px', left: '50%', bottom: '28px', transform: 'translateX(-50%)' }}
+        >
+          SCROLL{' '}
+          <motion.span
+            animate={progress === 0 ? { x: [0, 6, 0] } : { x: 0 }}
+            transition={
+              progress === 0
+                ? { duration: 1.6, repeat: Infinity, ease: 'easeInOut' }
+                : { duration: 0 }
+            }
+            style={{ display: 'inline-block' }}
+          >
+            →
+          </motion.span>
+        </motion.div>
       </div>
     </section>
   )
@@ -98,9 +128,10 @@ const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: numb
 
   const scale = isActive ? 1 : isNeighbor ? NEIGHBOR_SCALE : FAR_SCALE
   const opacity = isActive ? 1 : isNeighbor ? NEIGHBOR_OPACITY : FAR_OPACITY
+  const projectNumber = formatProjectNumber(project.id)
 
   return (
-    <motion.div
+    <motion.article
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onFocusCapture={() => setHasFocus(true)}
@@ -115,85 +146,64 @@ const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: numb
       data-card-state={cardState}
       data-card-scale={scale}
       data-card-opacity={opacity}
-      className="relative shrink-0 bg-platinum"
-      style={{
-        clipPath: NOTCH,
-        maxWidth: '480px',
-        width: '480px',
-        transformOrigin: 'center center',
-      }}
+      className="pcard shrink-0"
+      style={{ transformOrigin: 'center center' }}
     >
+      <div className="pcard-bg" aria-hidden="true" />
+
       <motion.div
         data-testid="project-card-fill"
         aria-hidden="true"
         data-active={isFillActive}
-        className="absolute inset-0 bg-atomic-tangerine"
+        className="pcard-fill bg-atomic-tangerine"
         initial={false}
         animate={{ clipPath: isFillActive ? FILL_OPEN : FILL_CLOSED }}
         transition={FILL_TRANSITION}
       />
 
-      <div className="relative z-10 p-5">
-        {project.image && (
-          <div className="mb-4 overflow-hidden" style={{ backgroundColor: '#3A3B3A' }}>
-            <img
-              src={project.image}
-              alt={`${project.title} screenshot`}
-              className="w-full h-40 object-cover"
-            />
-          </div>
-        )}
+      <span className="pcard-notch tl" aria-hidden="true" />
+      <span className="pcard-notch br" aria-hidden="true" />
 
-        <div className="flex items-center gap-3 mb-2">
-          <span className={`font-body text-xs transition-colors duration-200 ${isFillActive ? 'text-graphite' : 'text-graphite/50'}`}>
-            _{project.id.padStart(2, '0')}
-          </span>
-          <h3 className="font-body font-bold text-base text-graphite transition-colors duration-200">
-            {project.title}
-          </h3>
+      <div className="pcard-body">
+        <div className="pcard-ghost" data-testid="pcard-ghost" aria-hidden="true">
+          {projectNumber}
         </div>
-
-        <p className={`text-sm font-body leading-relaxed mb-4 transition-colors duration-200 ${isFillActive ? 'text-graphite' : 'text-graphite/70'}`}>
+        <div className="pcard-num" data-testid="pcard-num">
+          {projectNumber}
+        </div>
+        <h3 className={`pcard-name transition-colors duration-200 ${isFillActive ? 'text-platinum' : ''}`}>
+          {project.title}
+        </h3>
+        <p className={`pcard-desc transition-colors duration-200 ${isFillActive ? 'text-platinum opacity-100' : ''}`}>
           {project.description}
         </p>
-
-        <div className="flex flex-wrap gap-2 mb-4">
+        <div className="pcard-tags">
           {project.tags.map((tag, tagIndex) => (
             <span
               key={tag}
               data-inverted={isFillActive}
-              className="text-xs px-2 py-0.5 font-body rounded border border-transparent transition-colors duration-200"
-              style={isFillActive ? INVERTED_TAG_STYLE : getTagStyle(tagIndex)}
+              className={`ptag ptag-${TAG_VARIANTS[tagIndex % TAG_VARIANTS.length]} ${isFillActive ? INVERTED_TAG_CLASS : ''}`}
             >
               {tag}
             </span>
           ))}
         </div>
-
-        {project.bullets && project.bullets.length > 0 && (
-          <ul className={`list-disc list-inside text-sm font-body leading-relaxed mb-4 space-y-1 transition-colors duration-200 ${isFillActive ? 'text-graphite' : 'text-graphite/70'}`}>
-            {project.bullets.map((bullet, index) => (
-              <li key={index}>{bullet}</li>
-            ))}
-          </ul>
-        )}
-
-        <div className="flex flex-col gap-1">
+        <div className="pcard-links">
           {project.links.map((link) => (
             <a
               key={link.label}
               href={link.url}
               target="_blank"
               rel="noopener noreferrer"
-              className={`font-mono text-xs transition-colors ${isFillActive ? 'text-graphite hover:text-graphite' : 'text-ultrasonic-blue hover:text-atomic-tangerine'}`}
+              aria-label={`// ${link.label} ↗`}
+              className={`plink transition-colors ${isFillActive ? 'text-platinum' : ''}`}
             >
-              // {link.label} ↗
+              {link.label} <span className="plink-arrow">↗</span>
             </a>
           ))}
         </div>
       </div>
 
-      {/* Left-edge hover outline — rendered after card so it sits on top */}
       <motion.div
         className="absolute left-0 top-0 bottom-0 w-[3px] bg-atomic-tangerine"
         initial={{ scaleY: 0, opacity: 0 }}
@@ -201,7 +211,7 @@ const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: numb
         style={{ transformOrigin: 'bottom' }}
         transition={{ duration: 0.25, ease: 'easeOut' }}
       />
-    </motion.div>
+    </motion.article>
   )
 }
 

--- a/src/components/projectsGeometry.test.ts
+++ b/src/components/projectsGeometry.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { formatProjectNumber, getScrollRangeVh, PROJECT_CARD_WIDTH } from './projectsGeometry'
+
+describe('projectsGeometry', () => {
+  it('exports desktop card width matching pcard CSS', () => {
+    expect(PROJECT_CARD_WIDTH).toBe(560)
+  })
+
+  describe('formatProjectNumber', () => {
+    it('zero-pads single-digit ids', () => {
+      expect(formatProjectNumber('1')).toBe('_01')
+      expect(formatProjectNumber('9')).toBe('_09')
+    })
+
+    it('preserves two-digit ids', () => {
+      expect(formatProjectNumber('10')).toBe('_10')
+      expect(formatProjectNumber('12')).toBe('_12')
+    })
+
+    it('does not truncate ids longer than two characters', () => {
+      expect(formatProjectNumber('100')).toBe('_100')
+    })
+  })
+
+  describe('getScrollRangeVh', () => {
+    it('returns 1 when there are no projects', () => {
+      expect(getScrollRangeVh(0)).toBe(1)
+    })
+  })
+})

--- a/src/components/projectsGeometry.ts
+++ b/src/components/projectsGeometry.ts
@@ -5,3 +5,8 @@ export const PROJECT_CARD_WIDTH = 560
 export function getScrollRangeVh(projectCount: number) {
   return projectCount * 1.5 + 1
 }
+
+/** Formats a project id as the v4 card number prefix (e.g. "1" → "_01"). */
+export function formatProjectNumber(id: string) {
+  return `_${id.padStart(2, '0')}`
+}

--- a/src/components/projectsGeometry.ts
+++ b/src/components/projectsGeometry.ts
@@ -1,3 +1,6 @@
+/** Desktop project card width used for carousel centering (matches `.pcard` CSS). */
+export const PROJECT_CARD_WIDTH = 560
+
 /** Returns the Projects section height multiplier in viewport-height units. */
 export function getScrollRangeVh(projectCount: number) {
   return projectCount * 1.5 + 1

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./portfolio.css";
 
 @theme {
   --color-graphite: #2A2B2A;

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -1,0 +1,201 @@
+@layer components {
+  .pcard {
+    --notch: 22px;
+    flex-shrink: 0;
+    width: min(560px, 78vw);
+    height: min(640px, 76vh);
+    position: relative;
+    cursor: pointer;
+    transition: transform 0.35s ease, opacity 0.35s ease;
+    will-change: transform, opacity;
+  }
+
+  .pcard-bg {
+    position: absolute;
+    inset: 0;
+    background: var(--color-platinum);
+    clip-path: polygon(
+      var(--notch) 0,
+      100% 0,
+      100% calc(100% - var(--notch)),
+      calc(100% - var(--notch)) 100%,
+      0 100%,
+      0 var(--notch)
+    );
+  }
+
+  .pcard-fill {
+    position: absolute;
+    inset: 0;
+    clip-path: polygon(
+      var(--notch) 0,
+      100% 0,
+      100% calc(100% - var(--notch)),
+      calc(100% - var(--notch)) 100%,
+      0 100%,
+      0 var(--notch)
+    );
+    pointer-events: none;
+  }
+
+  .pcard-notch {
+    position: absolute;
+    width: calc(var(--notch) * 1.8);
+    height: calc(var(--notch) * 1.8);
+    pointer-events: none;
+  }
+
+  .pcard-notch::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      135deg,
+      transparent calc(50% - 1px),
+      var(--color-atomic-tangerine) calc(50% - 1px),
+      var(--color-atomic-tangerine) calc(50% + 1px),
+      transparent calc(50% + 1px)
+    );
+  }
+
+  .pcard-notch.tl {
+    top: -6px;
+    left: -6px;
+  }
+
+  .pcard-notch.br {
+    bottom: -6px;
+    right: -6px;
+  }
+
+  .pcard-body {
+    position: relative;
+    height: 100%;
+    padding: 36px 36px 32px;
+    display: flex;
+    flex-direction: column;
+    color: var(--color-graphite);
+    z-index: 1;
+  }
+
+  .pcard-ghost {
+    position: absolute;
+    font-family: var(--font-display);
+    font-size: clamp(110px, 15vw, 200px);
+    color: var(--color-graphite);
+    opacity: 0.07;
+    top: 18px;
+    left: 24px;
+    line-height: 1;
+    letter-spacing: -4px;
+    pointer-events: none;
+  }
+
+  .pcard-num {
+    font-size: 14px;
+    color: var(--color-graphite);
+    opacity: 0.55;
+    letter-spacing: 3px;
+    position: relative;
+    z-index: 2;
+  }
+
+  .pcard-name {
+    font-family: var(--font-display);
+    font-size: clamp(20px, 2vw, 26px);
+    color: var(--color-graphite);
+    letter-spacing: 2px;
+    margin-top: 30px;
+    position: relative;
+    z-index: 2;
+    line-height: 1.3;
+  }
+
+  .pcard-desc {
+    font-size: 14px;
+    color: var(--color-graphite);
+    opacity: 0.85;
+    line-height: 1.85;
+    margin-top: 20px;
+    flex: 1;
+    position: relative;
+    z-index: 2;
+    text-wrap: pretty;
+  }
+
+  .pcard-tags {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 18px;
+    position: relative;
+    z-index: 2;
+  }
+
+  .ptag {
+    font-size: 14px;
+    padding: 8px 14px;
+    letter-spacing: 1.5px;
+    font-weight: 700;
+  }
+
+  .ptag-fuchsia {
+    background: var(--color-fuchsia-flame);
+    color: var(--color-platinum);
+  }
+
+  .ptag-blue {
+    background: var(--color-ultrasonic-blue);
+    color: var(--color-platinum);
+  }
+
+  .ptag-orange {
+    background: var(--color-graphite);
+    color: var(--color-atomic-tangerine);
+    box-shadow: inset 0 0 0 1px var(--color-atomic-tangerine);
+  }
+
+  .ptag-yellow {
+    background: var(--color-golden-pollen);
+    color: var(--color-graphite);
+  }
+
+  .ptag.ptag-inverted {
+    background: rgba(42, 43, 42, 0.14);
+    color: var(--color-graphite);
+    box-shadow: inset 0 0 0 1px rgba(42, 43, 42, 0.38);
+  }
+
+  .pcard-links {
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+    margin-top: 20px;
+    padding-top: 18px;
+    border-top: 1px dashed rgba(42, 43, 42, 0.25);
+    position: relative;
+    z-index: 2;
+  }
+
+  .plink {
+    font-size: 14px;
+    color: var(--color-graphite);
+    text-decoration: none;
+    letter-spacing: 2px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 700;
+  }
+
+  .plink::before {
+    content: '//';
+    color: var(--color-graphite);
+    opacity: 0.5;
+    margin-right: 2px;
+  }
+
+  .plink-arrow {
+    display: inline-block;
+  }
+}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -89,6 +89,12 @@
     line-height: 1;
     letter-spacing: -4px;
     pointer-events: none;
+    transition: color 0.35s ease, opacity 0.35s ease;
+  }
+
+  .pcard[data-fill-active='true'] .pcard-ghost {
+    color: var(--color-platinum);
+    opacity: 0.1;
   }
 
   .pcard-num {
@@ -98,6 +104,12 @@
     letter-spacing: 3px;
     position: relative;
     z-index: 2;
+    transition: color 0.35s ease, opacity 0.35s ease;
+  }
+
+  .pcard[data-fill-active='true'] .pcard-num {
+    color: var(--color-platinum);
+    opacity: 0.9;
   }
 
   .pcard-name {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom/vitest'
+import '../index.css'
 import { vi } from 'vitest'
 
 // jsdom doesn't implement IntersectionObserver


### PR DESCRIPTION
## Purpose

Align desktop project cards with the v4 reference hierarchy (notched shape, ghost numbers, pixel titles, palette tags) while keeping resume-backed content.

## What it does

Refactors `ProjectCard` to the reference `pcard` structure with ported CSS, larger 560×640 desktop sizing, text-led content order, and v4 tag/link styling. Removes in-card screenshots and bullets so description/tags/links carry the card.

## Changes made

- `src/portfolio.css` — new pcard/ptag/plink component rules (22px notch, ghost number, palette tags)
- `src/index.css` — import portfolio stylesheet
- `src/components/ProjectsSection.tsx` — v4 card DOM hierarchy and `PROJECT_CARD_WIDTH` carousel centering
- `src/components/ProjectsSection.test.tsx` — hierarchy assertions (ghost, num, title, desc, tags, links)
- `src/components/projectsGeometry.ts` — export `PROJECT_CARD_WIDTH = 560`
- `src/test/setup.ts` — load styles in tests

## Additional notes

- Existing clip-path hover/focus fill left unchanged (diagonal mask fill deferred to #156).
- Carousel progress behavior untouched per issue scope.
- `ideas/proj.png` is not present in the repo; visual comparison used `ideas/Portfolio.html` `.pcard` rules and PRD stories 29–32. Browser QA recommended against `ideas/proj.png` when available.
- Resume bullets remain in data but are not rendered on cards to match v4 content order (number → title → description → tags → links).

Closes #155

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progress indicator for project carousel and animated "SCROLL →" hint at start of scroll.
  * New animated card fill visual for richer feedback.

* **Style**
  * Redesigned notched project card hierarchy, updated tag palette and link styling.
  * Cards now include layered background/fill, corner accents, and a large faint "ghost" number.

* **Behavior**
  * Project cards no longer render screenshots or resume bullet lists.

* **Tests**
  * Updated/added tests to validate new card layout, sizing, and formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->