### PR TITLE
Timeline: preserve per-panel typewriter progress

### DIFF
--- a/src/animations/Typewriter.test.tsx
+++ b/src/animations/Typewriter.test.tsx
@@ -171,6 +171,20 @@ describe('Typewriter', () => {
     expect(screen.getByText('World')).toBeInTheDocument()
   })
 
+  it('does not restart when lines array reference changes with same content', () => {
+    const lines1 = ['Hello']
+    const { rerender } = render(<Typewriter active={true} lines={lines1} />)
+
+    act(() => { vi.advanceTimersByTime(30) })
+    expect(screen.getByText('H')).toBeInTheDocument()
+
+    const lines2 = ['Hello']
+    rerender(<Typewriter active={true} lines={lines2} />)
+
+    act(() => { vi.advanceTimersByTime(30) })
+    expect(screen.getByText('He')).toBeInTheDocument()
+  })
+
   it('clears old displayed lines when lines prop changes', () => {
     const { rerender } = render(<Typewriter active={true} lines={['Old Line 1', 'Old Line 2']} />)
 

--- a/src/animations/Typewriter.tsx
+++ b/src/animations/Typewriter.tsx
@@ -13,17 +13,21 @@ export function Typewriter({ active, lines, speed = 25, onDone }: TypewriterProp
   const timerRef = useRef<number | null>(null)
   const onDoneRef = useRef(onDone)
   const prevActiveRef = useRef(active)
-  const prevLinesRef = useRef(lines)
+  const linesRef = useRef(lines)
+  const linesKey = JSON.stringify(lines)
+  const prevLinesKeyRef = useRef(linesKey)
+
+  linesRef.current = lines
 
   useEffect(() => {
     onDoneRef.current = onDone
   }, [onDone])
 
   useEffect(() => {
-    const linesChanged = JSON.stringify(prevLinesRef.current) !== JSON.stringify(lines)
+    const linesChanged = linesKey !== prevLinesKeyRef.current
 
     if (linesChanged) {
-      prevLinesRef.current = lines
+      prevLinesKeyRef.current = linesKey
       stateRef.current = { lineIndex: 0, charIndex: 0, done: false }
       setDisplayedLines([])
     }
@@ -37,7 +41,9 @@ export function Typewriter({ active, lines, speed = 25, onDone }: TypewriterProp
       return
     }
 
-    if (lines.length === 0) {
+    const currentLines = linesRef.current
+
+    if (currentLines.length === 0) {
       if (!stateRef.current.done) {
         stateRef.current.done = true
         onDoneRef.current?.()
@@ -50,6 +56,7 @@ export function Typewriter({ active, lines, speed = 25, onDone }: TypewriterProp
 
     const typeNextChar = () => {
       const { lineIndex, charIndex } = stateRef.current
+      const lines = linesRef.current
 
       if (lineIndex >= lines.length) {
         stateRef.current.done = true
@@ -73,7 +80,7 @@ export function Typewriter({ active, lines, speed = 25, onDone }: TypewriterProp
         stateRef.current.lineIndex = lineIndex + 1
         stateRef.current.charIndex = 0
 
-        if (stateRef.current.lineIndex < lines.length) {
+        if (stateRef.current.lineIndex < linesRef.current.length) {
           setDisplayedLines(prev => {
             const newLines = [...prev]
             newLines[stateRef.current.lineIndex] = ''
@@ -97,7 +104,7 @@ export function Typewriter({ active, lines, speed = 25, onDone }: TypewriterProp
         timerRef.current = null
       }
     }
-  }, [active, lines, speed])
+  }, [active, linesKey, speed])
 
   useEffect(() => {
     return () => {

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -278,6 +278,113 @@ describe('TimelineSection', () => {
     })
   })
 
+  describe('issue #159 - preserve per-panel typewriter progress', () => {
+    it('next panel activation does not clear previous panel partial text', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      const { rerender } = render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const panel1Partial = commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+      expect(panel1Partial.length).toBeGreaterThan(0)
+
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [false, true, false],
+        setRef: () => () => {},
+      })
+      rerender(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      const panel1Held = commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+      expect(panel1Held).toBe(panel1Partial)
+
+      const panel2Lines = commitEntries[1].querySelectorAll('[data-typewriter-line]')
+      expect(panel2Lines.length).toBeGreaterThan(0)
+    })
+
+    it('reactivate does not blank partial text before resuming', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      const { rerender } = render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const partialText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
+      expect(partialText.length).toBeGreaterThan(0)
+
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [false, false, false],
+        setRef: () => () => {},
+      })
+      rerender(<TimelineSection />)
+
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      rerender(<TimelineSection />)
+
+      const immediateText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
+      expect(immediateText).toBe(partialText)
+    })
+
+    it('completed panel text remains when next panel activates', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      const { rerender } = render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const panel1Texts = Array.from(
+        commitEntries[0].querySelectorAll('[data-typewriter-line]')
+      ).map((el) => el.textContent)
+
+      expect(panel1Texts).toContain('commit d4e8f2c')
+      expect(panel1Texts).toContain('NETAPP INC.')
+
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [false, true, false],
+        setRef: () => () => {},
+      })
+      rerender(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      const panel1TextsAfter = Array.from(
+        commitEntries[0].querySelectorAll('[data-typewriter-line]')
+      ).map((el) => el.textContent)
+
+      expect(panel1TextsAfter).toContain('commit d4e8f2c')
+      expect(panel1TextsAfter).toContain('NETAPP INC.')
+    })
+  })
+
   describe('issue #157 - desktop sticky panel scroll contract', () => {
     it('timeline panels do not use horizontal scroll or translateX', () => {
       render(<TimelineSection />)

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -345,6 +345,57 @@ describe('TimelineSection', () => {
       expect(immediateText).toBe(partialText)
     })
 
+    it('each panel retains independent partial progress when switching panels', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      const { rerender } = render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const panel1Partial =
+        commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+      expect(panel1Partial.length).toBeGreaterThan(0)
+
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [false, true, false],
+        setRef: () => () => {},
+      })
+      rerender(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const panel1Held =
+        commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+      const panel2Partial =
+        commitEntries[1].querySelector('[data-typewriter-line]')?.textContent ?? ''
+
+      expect(panel1Held).toBe(panel1Partial)
+      expect(panel2Partial.length).toBeGreaterThan(0)
+
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      rerender(<TimelineSection />)
+
+      const panel1Immediate =
+        commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+      const panel2Held =
+        commitEntries[1].querySelector('[data-typewriter-line]')?.textContent ?? ''
+
+      expect(panel1Immediate).toBe(panel1Partial)
+      expect(panel2Held).toBe(panel2Partial)
+    })
+
     it('completed panel text remains when next panel activates', () => {
       vi.mocked(useActivePanel).mockReturnValue({
         active: [true, false, false],

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Typewriter } from '../animations/Typewriter'
 import { useActivePanel } from '../hooks/useActivePanel'
 import { StickySection } from './StickySection'
@@ -47,14 +48,17 @@ const timelineEntries: TimelineEntry[] = [
 ]
 
 function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean }) {
-  const lines = [
-    `commit ${entry.hash}`,
-    'Author: Farhan Mohammed',
-    `Date:   ${entry.dateRange}`,
-    entry.institution,
-    entry.role,
-    ...entry.bullets,
-  ]
+  const lines = useMemo(
+    () => [
+      `commit ${entry.hash}`,
+      'Author: Farhan Mohammed',
+      `Date:   ${entry.dateRange}`,
+      entry.institution,
+      entry.role,
+      ...entry.bullets,
+    ],
+    [entry]
+  )
 
   return (
     <div className="min-h-screen py-6 font-mono" data-testid="commit-entry">


### PR DESCRIPTION
## Purpose

Ensure timeline typewriter behavior is tied to active sticky panels and preserves typed progress when panels deactivate, matching the HTML reference behavior where panels keep their text once typed.

## What it does

- Typewriter starts only when its panel becomes active
- Scrolling away mid-type pauses and holds the currently visible text
- Returning to a partially typed panel resumes without blanking already typed content
- Activating the next panel does not restart or clear previous panel text
- Bullet lines continue typing at speed=16ms so dense timeline content does not feel blocked

## Changes made

- **Typewriter**: key effect deps by serialized line content (`linesKey`) and read lines from a ref so parent rerenders do not restart typing or clear held progress
- **TimelineSection**: memoize per-entry line arrays so panel rerenders do not thrash Typewriter effects
- **Tests**: add issue #159 integration tests for next-panel activation, reactivate-without-blank, and completed-panel preservation; add Typewriter unit test for stable progress across lines array reference changes

## Additional notes

- Builds on #158 deterministic active panel detection (`useActivePanel`)
- Explicit non-goals respected: no timeline visual layout changes, no card-deck stacking changes
- Reference: `ideas/Portfolio.html` Typewriter comment — "panels keep their text once typed"
- `npm run typecheck` and `npm run test` pass

Closes #159

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed typewriter progress being lost when switching between timeline panels (resolves issue `#159`)
  * Prevented typewriter from restarting when content is re-provided with equivalent text

* **Performance Improvements**
  * Optimized panel rendering to avoid unnecessary recomputation of display lines

* **Tests**
  * Added tests verifying per-panel typewriter progress is preserved across switches and content updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->