### PR TITLE
Browser chrome: on-brand scrollbar thumb and text selection

### DIFF
--- a/src/index-css.test.ts
+++ b/src/index-css.test.ts
@@ -32,6 +32,7 @@ describe('global CSS brand chrome', () => {
     expect(blockFor('::-webkit-scrollbar')).toContain('width: 8px;')
     expect(blockFor('::-webkit-scrollbar-track')).toContain('background: var(--graphite);')
     expect(blockFor('::-webkit-scrollbar-thumb')).toContain('background: var(--orange);')
+    expect(blockFor('::-webkit-scrollbar-thumb')).not.toContain('border-radius')
     expect(blockFor('::selection')).toContain('background-color: var(--orange);')
     expect(blockFor('::selection')).toContain('color: var(--graphite);')
   })

--- a/src/index.css
+++ b/src/index.css
@@ -34,7 +34,6 @@ html {
 
 ::-webkit-scrollbar-thumb {
   background: var(--orange);
-  border-radius: 4px;
 }
 
 ::selection {


### PR DESCRIPTION
## Purpose
Align browser chrome (scrollbar and text selection) with the on-brand reference design from issue #177.

## What it does
- Scrollbar thumb is orange on a graphite track with sharp square edges (no border-radius)
- Text selection uses orange background with graphite text

## Changes made
- Removed `border-radius: 4px` from `::-webkit-scrollbar-thumb` in `src/index.css`
- Extended `src/index-css.test.ts` to assert the scrollbar thumb rule has no `border-radius`

## Additional notes
- `::selection` styling was already correct; only the scrollbar thumb needed adjustment
- Verified with RGR: failing test first, then CSS fix, all 318 tests pass

Closes #177

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated webkit scrollbar thumb styling to remove the border-radius property. The rule now exclusively applies background color styling.

* **Tests**
  * Added test assertion to verify that the global CSS webkit scrollbar thumb rule does not include a border-radius declaration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->