### PR TITLE
Timeline: render structured resume-backed panel content

### DIFF
--- a/src/animations/Typewriter.tsx
+++ b/src/animations/Typewriter.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useTypewriter } from './useTypewriter'
 
 interface TypewriterProps {
   active: boolean
@@ -8,111 +8,7 @@ interface TypewriterProps {
 }
 
 export function Typewriter({ active, lines, speed = 25, onDone }: TypewriterProps) {
-  const [displayedLines, setDisplayedLines] = useState<string[]>([])
-  const stateRef = useRef({ lineIndex: 0, charIndex: 0, done: false })
-  const timerRef = useRef<number | null>(null)
-  const onDoneRef = useRef(onDone)
-  const prevActiveRef = useRef(active)
-  const linesRef = useRef(lines)
-  const linesKey = JSON.stringify(lines)
-  const prevLinesKeyRef = useRef(linesKey)
-
-  linesRef.current = lines
-
-  useEffect(() => {
-    onDoneRef.current = onDone
-  }, [onDone])
-
-  useEffect(() => {
-    const linesChanged = linesKey !== prevLinesKeyRef.current
-
-    if (linesChanged) {
-      prevLinesKeyRef.current = linesKey
-      stateRef.current = { lineIndex: 0, charIndex: 0, done: false }
-      setDisplayedLines([])
-    }
-
-    if (!active) {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-        timerRef.current = null
-      }
-      prevActiveRef.current = active
-      return
-    }
-
-    const currentLines = linesRef.current
-
-    if (currentLines.length === 0) {
-      if (!stateRef.current.done) {
-        stateRef.current.done = true
-        onDoneRef.current?.()
-      }
-      prevActiveRef.current = active
-      return
-    }
-
-    if (stateRef.current.done) return
-
-    const typeNextChar = () => {
-      const { lineIndex, charIndex } = stateRef.current
-      const lines = linesRef.current
-
-      if (lineIndex >= lines.length) {
-        stateRef.current.done = true
-        onDoneRef.current?.()
-        return
-      }
-
-      const currentLine = lines[lineIndex]
-
-      if (charIndex < currentLine.length) {
-        setDisplayedLines(prev => {
-          const newLines = [...prev]
-          if (!newLines[lineIndex]) newLines[lineIndex] = ''
-          newLines[lineIndex] = currentLine.slice(0, charIndex + 1)
-          return newLines
-        })
-
-        stateRef.current.charIndex = charIndex + 1
-        timerRef.current = window.setTimeout(typeNextChar, speed)
-      } else {
-        stateRef.current.lineIndex = lineIndex + 1
-        stateRef.current.charIndex = 0
-
-        if (stateRef.current.lineIndex < linesRef.current.length) {
-          setDisplayedLines(prev => {
-            const newLines = [...prev]
-            newLines[stateRef.current.lineIndex] = ''
-            return newLines
-          })
-          timerRef.current = window.setTimeout(typeNextChar, speed)
-        } else {
-          stateRef.current.done = true
-          onDoneRef.current?.()
-        }
-      }
-    }
-
-    timerRef.current = window.setTimeout(typeNextChar, speed)
-
-    prevActiveRef.current = active
-
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-        timerRef.current = null
-      }
-    }
-  }, [active, linesKey, speed])
-
-  useEffect(() => {
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current)
-      }
-    }
-  }, [])
+  const displayedLines = useTypewriter(active, lines, speed, onDone)
 
   return (
     <div>

--- a/src/animations/useTypewriter.ts
+++ b/src/animations/useTypewriter.ts
@@ -1,0 +1,111 @@
+import { useState, useEffect, useRef } from 'react'
+
+export function useTypewriter(
+  active: boolean,
+  lines: string[],
+  speed = 25,
+  onDone?: () => void
+) {
+  const [displayedLines, setDisplayedLines] = useState<string[]>([])
+  const stateRef = useRef({ lineIndex: 0, charIndex: 0, done: false })
+  const timerRef = useRef<number | null>(null)
+  const onDoneRef = useRef(onDone)
+  const linesRef = useRef(lines)
+  const linesKey = JSON.stringify(lines)
+  const prevLinesKeyRef = useRef(linesKey)
+
+  linesRef.current = lines
+
+  useEffect(() => {
+    onDoneRef.current = onDone
+  }, [onDone])
+
+  useEffect(() => {
+    const linesChanged = linesKey !== prevLinesKeyRef.current
+
+    if (linesChanged) {
+      prevLinesKeyRef.current = linesKey
+      stateRef.current = { lineIndex: 0, charIndex: 0, done: false }
+      setDisplayedLines([])
+    }
+
+    if (!active) {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      return
+    }
+
+    const currentLines = linesRef.current
+
+    if (currentLines.length === 0) {
+      if (!stateRef.current.done) {
+        stateRef.current.done = true
+        onDoneRef.current?.()
+      }
+      return
+    }
+
+    if (stateRef.current.done) return
+
+    const typeNextChar = () => {
+      const { lineIndex, charIndex } = stateRef.current
+      const lines = linesRef.current
+
+      if (lineIndex >= lines.length) {
+        stateRef.current.done = true
+        onDoneRef.current?.()
+        return
+      }
+
+      const currentLine = lines[lineIndex]
+
+      if (charIndex < currentLine.length) {
+        setDisplayedLines(prev => {
+          const newLines = [...prev]
+          if (!newLines[lineIndex]) newLines[lineIndex] = ''
+          newLines[lineIndex] = currentLine.slice(0, charIndex + 1)
+          return newLines
+        })
+
+        stateRef.current.charIndex = charIndex + 1
+        timerRef.current = window.setTimeout(typeNextChar, speed)
+      } else {
+        stateRef.current.lineIndex = lineIndex + 1
+        stateRef.current.charIndex = 0
+
+        if (stateRef.current.lineIndex < linesRef.current.length) {
+          setDisplayedLines(prev => {
+            const newLines = [...prev]
+            newLines[stateRef.current.lineIndex] = ''
+            return newLines
+          })
+          timerRef.current = window.setTimeout(typeNextChar, speed)
+        } else {
+          stateRef.current.done = true
+          onDoneRef.current?.()
+        }
+      }
+    }
+
+    timerRef.current = window.setTimeout(typeNextChar, speed)
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [active, linesKey, speed])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+      }
+    }
+  }, [])
+
+  return displayedLines
+}

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -541,6 +541,62 @@ describe('TimelineSection', () => {
       expect(typedFields.length).toBeGreaterThan(0)
       expect(typedFields[0].closest('[data-testid="commit-metadata"]')).toBeTruthy()
     })
+
+    it('omits commit-details list when entry has no bullets', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [false, true, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const msPanel = commitEntries[1]
+      expect(msPanel.querySelector('[data-testid="commit-details"]')).not.toBeInTheDocument()
+      expect(msPanel.querySelector('[data-testid="commit-institution"]')?.textContent).toBe(
+        'WICHITA STATE UNIVERSITY'
+      )
+    })
+
+    it('holds partial metadata within structured fields when panel deactivates', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      const { rerender } = render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const partialHash =
+        commitEntries[0].querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+      expect(partialHash.length).toBeGreaterThan(0)
+
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [false, false, false],
+        setRef: () => () => {},
+      })
+      rerender(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      const heldEntries = screen.getAllByTestId('commit-entry')
+      const heldHash =
+        heldEntries[0].querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+      expect(heldHash).toBe(partialHash)
+      expect(heldEntries[0].querySelector('[data-testid="commit-institution"]')).toBeNull()
+    })
   })
 
   describe('issue #157 - desktop sticky panel scroll contract', () => {

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -436,6 +436,113 @@ describe('TimelineSection', () => {
     })
   })
 
+  describe('issue #160 - structured resume-backed panel content', () => {
+    it('renders commit metadata as distinct fields', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const metadata = commitEntries[0].querySelector('[data-testid="commit-metadata"]')
+      expect(metadata).toBeInTheDocument()
+      expect(metadata?.querySelector('[data-testid="commit-hash"]')?.textContent).toBe(
+        'commit d4e8f2c'
+      )
+      expect(metadata?.querySelector('[data-testid="commit-author"]')?.textContent).toBe(
+        'Author: Farhan Mohammed'
+      )
+      expect(metadata?.querySelector('[data-testid="commit-date"]')?.textContent).toBe(
+        'Date:   AUG 2024 – PRESENT'
+      )
+    })
+
+    it('renders institution as its own heading', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const institution = commitEntries[0].querySelector('[data-testid="commit-institution"]')
+      expect(institution?.tagName).toBe('H2')
+      expect(institution?.textContent).toBe('NETAPP INC.')
+    })
+
+    it('renders role as its own line', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const role = commitEntries[0].querySelector('[data-testid="commit-role"]')
+      expect(role?.textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+    })
+
+    it('renders bullets as semantic list items', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const details = commitEntries[0].querySelector('[data-testid="commit-details"]')
+      expect(details?.tagName).toBe('UL')
+
+      const items = details?.querySelectorAll('li') ?? []
+      expect(items.length).toBe(4)
+      expect(items[0].textContent).toContain('Built automated analysis pipeline')
+    })
+
+    it('preserves data-typewriter-line markers on typed fields', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const typedFields = commitEntries[0].querySelectorAll('[data-typewriter-line]')
+      expect(typedFields.length).toBeGreaterThan(0)
+      expect(typedFields[0].closest('[data-testid="commit-metadata"]')).toBeTruthy()
+    })
+  })
+
   describe('issue #157 - desktop sticky panel scroll contract', () => {
     it('timeline panels do not use horizontal scroll or translateX', () => {
       render(<TimelineSection />)

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,16 +1,7 @@
 import { useMemo } from 'react'
-import { Typewriter } from '../animations/Typewriter'
+import { useTypewriter } from '../animations/useTypewriter'
 import { useActivePanel } from '../hooks/useActivePanel'
 import { StickySection } from './StickySection'
-
-interface TimelineEntry {
-  hash: string
-  dateRange: string
-  institution: string
-  role: string
-  bullets: string[]
-  category: 'experience' | 'education'
-}
 
 const timelineEntries: TimelineEntry[] = [
   {
@@ -47,6 +38,8 @@ const timelineEntries: TimelineEntry[] = [
   },
 ]
 
+const METADATA_LINE_COUNT = 3
+
 function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean }) {
   const lines = useMemo(
     () => [
@@ -60,9 +53,56 @@ function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean 
     [entry]
   )
 
+  const displayedLines = useTypewriter(active, lines, 16)
+
+  const institutionLine = displayedLines[METADATA_LINE_COUNT]
+  const roleLine = displayedLines[METADATA_LINE_COUNT + 1]
+  const bulletLines = entry.bullets
+    .map((_, index) => displayedLines[METADATA_LINE_COUNT + 2 + index])
+    .filter((line): line is string => line !== undefined && line !== '')
+
   return (
     <div className="min-h-screen py-6 font-mono" data-testid="commit-entry">
-      <Typewriter active={active} lines={lines} speed={16} />
+      <div data-testid="commit-metadata">
+        {displayedLines[0] !== undefined && (
+          <div data-testid="commit-hash" data-typewriter-line>
+            {displayedLines[0]}
+          </div>
+        )}
+        {displayedLines[1] !== undefined && (
+          <div data-testid="commit-author" data-typewriter-line>
+            {displayedLines[1]}
+          </div>
+        )}
+        {displayedLines[2] !== undefined && (
+          <div data-testid="commit-date" data-typewriter-line>
+            {displayedLines[2]}
+          </div>
+        )}
+      </div>
+      {institutionLine !== undefined && (
+        <h2 data-testid="commit-institution" data-typewriter-line>
+          {institutionLine}
+        </h2>
+      )}
+      {roleLine !== undefined && (
+        <p data-testid="commit-role" data-typewriter-line>
+          {roleLine}
+        </p>
+      )}
+      {bulletLines.length > 0 && (
+        <ul data-testid="commit-details">
+          {entry.bullets.map((_, index) => {
+            const line = displayedLines[METADATA_LINE_COUNT + 2 + index]
+            if (line === undefined) return null
+            return (
+              <li key={index} data-typewriter-line>
+                {line}
+              </li>
+            )
+          })}
+        </ul>
+      )}
     </div>
   )
 }
@@ -112,3 +152,14 @@ const TimelineSection: React.FC = () => {
 }
 
 export default TimelineSection
+
+export interface TimelineEntry {
+  hash: string
+  dateRange: string
+  institution: string
+  role: string
+  bullets: string[]
+  category: 'experience' | 'education'
+}
+
+export { timelineEntries }

--- a/src/data/resume-audit.test.ts
+++ b/src/data/resume-audit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { projects } from './projects'
 import { FIRST_NAME, LAST_NAME } from '../components/HeroSection.constants'
+import { timelineEntries } from '../components/TimelineSection'
 
 // Resume source-of-truth constants (from public/resume.pdf)
 const RESUME_FULL_NAME = 'Farhan Mohammed'
@@ -58,6 +59,46 @@ describe('resume source-of-truth audit', () => {
       expect(mlaImpl?.bullets).toHaveLength(2)
       expect(mlaImpl?.bullets?.[0]).toContain('DeepSeek-V2')
       expect(mlaImpl?.bullets?.[1]).toContain('PyPI')
+    })
+  })
+
+  describe('timeline', () => {
+    it('entry count matches resume (1 experience + 2 education)', () => {
+      expect(timelineEntries).toHaveLength(3)
+      expect(timelineEntries.filter((e) => e.category === 'experience')).toHaveLength(1)
+      expect(timelineEntries.filter((e) => e.category === 'education')).toHaveLength(2)
+    })
+
+    it('NetApp date range matches resume', () => {
+      const netapp = timelineEntries.find((e) => e.hash === 'd4e8f2c')
+      expect(netapp?.dateRange).toBe('AUG 2024 – PRESENT')
+    })
+
+    it('NetApp bullets match resume content', () => {
+      const netapp = timelineEntries.find((e) => e.hash === 'd4e8f2c')
+      expect(netapp?.bullets).toHaveLength(4)
+      expect(netapp?.bullets?.[0]).toContain('automated analysis pipeline')
+      expect(netapp?.bullets?.[1]).toContain('30%')
+    })
+
+    it('B.S. education bullets match resume', () => {
+      const bs = timelineEntries.find((e) => e.hash === 'b7c3e1a')
+      expect(bs?.bullets?.[0]).toContain("Dean's List")
+      expect(bs?.bullets?.[1]).toContain('Relevant Coursework')
+    })
+
+    it('documents resume formatting differences for role titles', () => {
+      const netapp = timelineEntries.find((e) => e.hash === 'd4e8f2c')
+      // Resume uses title case; timeline uses stylized uppercase with underscores.
+      expect(netapp?.role).toBe('SOFTWARE_ENGINEER_IN_TEST')
+      expect(netapp?.role).not.toBe('Software Engineer in Test')
+    })
+
+    it('documents resume content gap for B.S. GPA honors line', () => {
+      const bs = timelineEntries.find((e) => e.hash === 'b7c3e1a')
+      // Resume includes "GPA: 3.66/4.0, Magna Cum Laude" in the degree line.
+      expect(bs?.role).toBe('B.S._COMPUTER_SCIENCE')
+      expect(bs?.role).not.toContain('GPA')
     })
   })
 })


### PR DESCRIPTION
## Purpose

Fix #160 by rendering each timeline panel as structured resume-backed content instead of one flat typewriter text block.

## What it does

Each timeline commit panel now exposes semantic HTML for git-style metadata, institution heading, role line, and bullet details while keeping the existing per-panel typewriter hold/resume behavior from #159.

## Changes made

- Extract `useTypewriter` hook from `Typewriter` for reuse
- Render timeline panels with distinct metadata fields (`commit`, `Author`, `Date`), an `<h2>` institution heading, a role line, and a `<ul>` of bullet `<li>` items
- Preserve `data-typewriter-line` markers on typed fields for existing animation/progress tests
- Add issue #160 tests for metadata presence and semantic list structure
- Extend resume audit tests for timeline content and documented formatting gaps

## Additional notes

Resume vs app data mismatches (intentional stylization, not silently invented):

- Role titles use uppercase underscore styling (e.g. `SOFTWARE_ENGINEER_IN_TEST`) instead of resume title case (`Software Engineer in Test`)
- Institution names use uppercase stylization (`NETAPP INC.`) instead of resume title case (`NetApp Inc.`)
- B.S. role line omits resume GPA/honors text (`GPA: 3.66/4.0, Magna Cum Laude`)

Closes #160

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved animation and rendering so the typewriter behavior is more consistent; structured timeline content (hash, author/date, institution, role, bullets) now renders reliably and preserves partially-typed metadata during panel deactivation.

* **Tests**
  * Expanded test coverage validating structured resume/timeline rendering, entry counts, field formatting, and typewriter markers for typed fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->