### PR TITLE
Loading Screen: implement v4 full-screen boot sequence

### DIFF
--- a/src/components/LoadingScreen.constants.ts
+++ b/src/components/LoadingScreen.constants.ts
@@ -1,8 +1,16 @@
 export const STATUS_MESSAGES = [
-  'ESTABLISHING_SIGNAL',
-  'COMPILING_MODULES',
   'LOADING_ASSETS',
+  'COMPILING_MODULES',
+  'ESTABLISHING_SIGNAL',
+  'DECRYPTING_DATA',
   'SYSTEM_READY',
 ] as const
 
-export const MESSAGE_DURATION = 700
+/** Reference: ideas/Portfolio.html — message rotation interval (ms) */
+export const MESSAGE_INTERVAL = 560
+
+/** Reference: ideas/Portfolio.html — total boot duration before fade-out (ms) */
+export const BOOT_DURATION = 2800
+
+/** Reference: ideas/Portfolio.html — fade-out duration after `.out` class (ms) */
+export const FADE_OUT_DURATION = 600

--- a/src/components/LoadingScreen.test.tsx
+++ b/src/components/LoadingScreen.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, act } from '@testing-library/react'
 import LoadingScreen from './LoadingScreen'
-import { MESSAGE_DURATION, STATUS_MESSAGES } from './LoadingScreen.constants'
+import {
+  BOOT_DURATION,
+  FADE_OUT_DURATION,
+  MESSAGE_INTERVAL,
+  STATUS_MESSAGES,
+} from './LoadingScreen.constants'
 
 describe('LoadingScreen', () => {
   beforeEach(() => {
@@ -12,97 +17,94 @@ describe('LoadingScreen', () => {
     vi.useRealTimers()
   })
 
-  it('uses a 2.8 second total status message sequence', () => {
-    expect(MESSAGE_DURATION * STATUS_MESSAGES.length).toBe(2800)
+  it('uses the reference boot sequence timing (2.8s boot + 0.6s fade)', () => {
+    expect(BOOT_DURATION).toBe(2800)
+    expect(MESSAGE_INTERVAL).toBe(560)
+    expect(FADE_OUT_DURATION).toBe(600)
+    expect(BOOT_DURATION + FADE_OUT_DURATION).toBeGreaterThanOrEqual(2600)
+    expect(BOOT_DURATION + FADE_OUT_DURATION).toBeLessThanOrEqual(3400)
   })
 
-  it('shows ESTABLISHING_SIGNAL as the first status message', () => {
-    const { getByText } = render(<LoadingScreen onComplete={vi.fn()} />)
-    expect(getByText('ESTABLISHING_SIGNAL')).toBeInTheDocument()
+  it('renders #ls root with portfolio.css boot structure', () => {
+    const { container } = render(<LoadingScreen onComplete={vi.fn()} />)
+    const root = container.querySelector('#ls')
+
+    expect(root).toBeInTheDocument()
+    expect(root?.querySelector('.ls-inner')).toBeInTheDocument()
+    expect(root?.querySelector('.ls-sys')).toHaveTextContent('SYSTEM_INIT...')
+    expect(root?.querySelector('.ls-name')).toHaveTextContent('FARHAN')
+    expect(root?.querySelector('.ls-name')).toHaveTextContent('MOHAMMED')
+    expect(root?.querySelector('.ls-track .ls-fill')).toBeInTheDocument()
+    expect(root?.querySelector('.ls-msg')).toBeInTheDocument()
+  })
+
+  it('shows LOADING_ASSETS as the first status message', () => {
+    const { container } = render(<LoadingScreen onComplete={vi.fn()} />)
+    expect(container.querySelector('.ls-msg')).toHaveTextContent('LOADING_ASSETS')
   })
 
   it('cycles through all status messages in sequence', async () => {
-    const { getByText } = render(<LoadingScreen onComplete={vi.fn()} />)
+    const { container } = render(<LoadingScreen onComplete={vi.fn()} />)
+    const msg = () => container.querySelector('.ls-msg')
 
-    expect(getByText('ESTABLISHING_SIGNAL')).toBeInTheDocument()
+    expect(msg()).toHaveTextContent('LOADING_ASSETS')
 
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    expect(getByText('COMPILING_MODULES')).toBeInTheDocument()
+    await act(() => vi.advanceTimersByTime(MESSAGE_INTERVAL))
+    expect(msg()).toHaveTextContent('COMPILING_MODULES')
 
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    expect(getByText('LOADING_ASSETS')).toBeInTheDocument()
+    await act(() => vi.advanceTimersByTime(MESSAGE_INTERVAL))
+    expect(msg()).toHaveTextContent('ESTABLISHING_SIGNAL')
 
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    expect(getByText('SYSTEM_READY')).toBeInTheDocument()
+    await act(() => vi.advanceTimersByTime(MESSAGE_INTERVAL))
+    expect(msg()).toHaveTextContent('DECRYPTING_DATA')
+
+    await act(() => vi.advanceTimersByTime(MESSAGE_INTERVAL))
+    expect(msg()).toHaveTextContent('SYSTEM_READY')
   })
 
-  it('calls onComplete after the final message', async () => {
+  it('calls onComplete after boot sequence and fade-out', async () => {
     const onComplete = vi.fn()
     render(<LoadingScreen onComplete={onComplete} />)
 
-    // Each act() flushes React state so the next timer gets scheduled
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
+    await act(() => vi.advanceTimersByTime(BOOT_DURATION))
+    expect(onComplete).not.toHaveBeenCalled()
 
+    await act(() => vi.advanceTimersByTime(FADE_OUT_DURATION))
     expect(onComplete).toHaveBeenCalledOnce()
   })
 
-  it('does not call onComplete before the final message', async () => {
+  it('does not call onComplete before fade-out completes', async () => {
     const onComplete = vi.fn()
     render(<LoadingScreen onComplete={onComplete} />)
 
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
+    await act(() => vi.advanceTimersByTime(BOOT_DURATION - 1))
+    expect(onComplete).not.toHaveBeenCalled()
 
+    await act(() => vi.advanceTimersByTime(1))
+    expect(onComplete).not.toHaveBeenCalled()
+
+    await act(() => vi.advanceTimersByTime(FADE_OUT_DURATION - 1))
     expect(onComplete).not.toHaveBeenCalled()
   })
 
-  it('progress bar steps from 25% to 100% across all messages', async () => {
-    const { getByRole } = render(<LoadingScreen onComplete={vi.fn()} />)
-    const bar = getByRole('progressbar')
-
-    expect(bar).toHaveAttribute('aria-valuenow', '25')
-
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    expect(bar).toHaveAttribute('aria-valuenow', '50')
-
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    expect(bar).toHaveAttribute('aria-valuenow', '75')
-
-    await act(() => vi.advanceTimersByTime(MESSAGE_DURATION))
-    expect(bar).toHaveAttribute('aria-valuenow', '100')
-  })
-
-  it('renders FARHAN and MOHAMMED on separate display lines', () => {
-    const { getByText } = render(<LoadingScreen onComplete={vi.fn()} />)
-    expect(getByText('FARHAN')).toBeInTheDocument()
-    expect(getByText('MOHAMMED')).toBeInTheDocument()
-  })
-
-  it('uses graphite background covering the full viewport', () => {
+  it('adds the out class when the boot sequence finishes', async () => {
     const { container } = render(<LoadingScreen onComplete={vi.fn()} />)
-    const overlay = container.firstChild as HTMLElement
-    expect(overlay).toHaveClass('fixed')
-    expect(overlay).toHaveClass('inset-0')
-    expect(overlay).toHaveClass('bg-graphite')
+    const root = container.querySelector('#ls')
+
+    expect(root).not.toHaveClass('out')
+
+    await act(() => vi.advanceTimersByTime(BOOT_DURATION))
+    expect(root).toHaveClass('out')
   })
 
-  it('renders a thin orange progress bar', () => {
+  it('renders a thin orange progress bar fill element', () => {
     const { container } = render(<LoadingScreen onComplete={vi.fn()} />)
-    const track = container.querySelector('[role="progressbar"]')
-    expect(track).toHaveClass('h-0.5')
-    const fill = track?.querySelector('.bg-atomic-tangerine')
+    const fill = container.querySelector('.ls-fill')
     expect(fill).toBeInTheDocument()
+    expect(fill?.parentElement).toHaveClass('ls-track')
   })
 
-  it('uses display font for identity and mono font for status text', () => {
-    const { getByText } = render(<LoadingScreen onComplete={vi.fn()} />)
-    const firstName = getByText('FARHAN')
-    expect(firstName).toHaveClass('font-display')
-    const status = getByText('ESTABLISHING_SIGNAL')
-    expect(status).toHaveClass('font-body')
+  it('exposes at least three rotating terminal status messages', () => {
+    expect(STATUS_MESSAGES.length).toBeGreaterThanOrEqual(3)
   })
 })

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,6 +1,10 @@
-import { useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
-import { MESSAGE_DURATION, STATUS_MESSAGES } from './LoadingScreen.constants'
+import { useEffect, useState } from 'react'
+import {
+  BOOT_DURATION,
+  FADE_OUT_DURATION,
+  MESSAGE_INTERVAL,
+  STATUS_MESSAGES,
+} from './LoadingScreen.constants'
 
 interface LoadingScreenProps {
   onComplete: () => void
@@ -8,56 +12,47 @@ interface LoadingScreenProps {
 
 export default function LoadingScreen({ onComplete }: LoadingScreenProps) {
   const [messageIndex, setMessageIndex] = useState(0)
+  const [exiting, setExiting] = useState(false)
 
   useEffect(() => {
-    const isFinalMessage = messageIndex >= STATUS_MESSAGES.length - 1
-    const timer = setTimeout(
-      () => {
-        if (isFinalMessage) {
-          onComplete()
-        } else {
-          setMessageIndex((i) => i + 1)
-        }
-      },
-      MESSAGE_DURATION,
-    )
-    return () => clearTimeout(timer)
-  }, [messageIndex, onComplete])
+    const interval = setInterval(() => {
+      setMessageIndex((index) => Math.min(index + 1, STATUS_MESSAGES.length - 1))
+    }, MESSAGE_INTERVAL)
 
-  const progress = ((messageIndex + 1) / STATUS_MESSAGES.length) * 100
+    const bootTimer = setTimeout(() => {
+      clearInterval(interval)
+      setExiting(true)
+    }, BOOT_DURATION)
+
+    return () => {
+      clearInterval(interval)
+      clearTimeout(bootTimer)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!exiting) {
+      return
+    }
+
+    const fadeTimer = setTimeout(onComplete, FADE_OUT_DURATION)
+    return () => clearTimeout(fadeTimer)
+  }, [exiting, onComplete])
 
   return (
-    <motion.div
-      className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-graphite"
-      exit={{ opacity: 0 }}
-      transition={{ duration: 0.5 }}
-    >
-      <p className="mb-4 font-display text-xs text-atomic-tangerine">
-        SYSTEM_INIT...
-      </p>
-      <h1 className="mb-8 font-display text-2xl text-platinum">
-        FARHAN
-      </h1>
-      <h2 className="-mt-6 mb-8 font-display text-2xl text-platinum">
-        MOHAMMED
-      </h2>
-      <div
-        role="progressbar"
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={progress}
-        className="mb-4 h-0.5 w-64 overflow-hidden rounded-none bg-periwinkle/20"
-      >
-        <motion.div
-          className="h-full bg-atomic-tangerine"
-          initial={{ width: '0%' }}
-          animate={{ width: `${progress}%` }}
-          transition={{ duration: 0.3, ease: 'easeOut' }}
-        />
+    <div id="ls" className={exiting ? 'out' : undefined}>
+      <div className="ls-inner">
+        <div className="ls-sys">SYSTEM_INIT...</div>
+        <div className="ls-name">
+          FARHAN
+          <br />
+          MOHAMMED
+        </div>
+        <div className="ls-track">
+          <div className="ls-fill" role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-label="Loading progress" />
+        </div>
+        <div className="ls-msg">{STATUS_MESSAGES[messageIndex]}</div>
       </div>
-      <p className="font-body text-xs text-periwinkle">
-        {STATUS_MESSAGES[messageIndex]}
-      </p>
-    </motion.div>
+    </div>
   )
 }


### PR DESCRIPTION
## Purpose

Implement the v4 full-screen boot sequence so the loading screen matches the canonical reference design in `ideas/Portfolio.html` using the CSS anchor from #176.

## What it does

- Full-screen graphite overlay (`#ls`) with pixel-font `FARHAN / MOHAMMED` identity
- Thin orange progress bar (`.ls-fill`) driven by the reference CSS animation (2.4s fill + 0.3s delay)
- Five rotating terminal status messages cycling every 560ms over a 2.8s boot sequence
- Smooth fade-out via the `.out` class (0.6s) before unmounting into the hero

## Changes made

- Refactored `LoadingScreen` to use portfolio.css classes (`#ls`, `.ls-inner`, `.ls-sys`, `.ls-name`, `.ls-track`, `.ls-fill`, `.ls-msg`) instead of Tailwind approximations
- Updated constants to match reference timing (`BOOT_DURATION=2800`, `MESSAGE_INTERVAL=560`, `FADE_OUT_DURATION=600`)
- Aligned status message list with reference order (`LOADING_ASSETS` → `SYSTEM_READY`)
- Rewrote component tests (RGR) to assert DOM structure, message rotation, fade-out class, and completion timing

## Additional notes

- Removed framer-motion from LoadingScreen; fade is handled by the ported `#ls.out` CSS transition
- Progress bar fill is CSS-animated per reference; no JS width stepping needed
- All 317 tests pass; typecheck clean

Closes #178


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Loading screen boot sequence now uses consistent fixed-interval timing for status message transitions.
  * Simplified progress animations with improved performance during app startup.
  * Enhanced exit transition behavior with cleaner visual feedback.

* **Tests**
  * Updated test coverage for new loading screen timing and lifecycle behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->