### PR TITLE
Hero: name typography, typewriter sequence, and role label

### DIFF
--- a/src/animations/RotatingRole.tsx
+++ b/src/animations/RotatingRole.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from 'react'
 interface RotatingRoleProps {
   roles: string[]
   active: boolean
+  className?: string
   typeSpeed?: number
   eraseSpeed?: number
   holdMs?: number
@@ -15,6 +16,7 @@ type Phase = 'idle' | 'typing' | 'holding' | 'erasing'
 export function RotatingRole({
   roles,
   active,
+  className = '',
   typeSpeed = 40,
   eraseSpeed = 30,
   holdMs = 2000,
@@ -98,7 +100,7 @@ export function RotatingRole({
   }, [active, roles, typeSpeed, eraseSpeed, holdMs])
 
   return (
-    <div data-testid="rotating-role">
+    <div data-testid="rotating-role" className={className}>
       {displayed}
       <span style={{ opacity: showCursor ? 1 : 0 }}>▍</span>
     </div>

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -12,7 +12,7 @@ import {
 } from './HeroSection.constants'
 
 const FIRST_NAME_DURATION = FIRST_NAME.length * NAME_SPEED
-const LAST_NAME_DURATION = ` ${LAST_NAME}`.length * NAME_SPEED
+const LAST_NAME_DURATION = LAST_NAME.length * NAME_SPEED
 const ROLE_TYPE_SPEED = 40
 const ROLE_ERASE_SPEED = 30
 const ROLE_HOLD_MS = 2000
@@ -67,21 +67,35 @@ describe('HeroSection', () => {
     expect(screen.getByTestId('hero-name')).toBeInTheDocument()
   })
 
-  it('keeps the init label clear of the navbar and aligns its underline to the leading slashes', () => {
+  it('renders two stacked hero-name-line spans inside hero-name', () => {
+    render(<HeroSection />)
+
+    const heading = screen.getByTestId('hero-name')
+    const nameLines = heading.querySelectorAll('.hero-name-line')
+
+    expect(heading).toHaveClass('hero-name')
+    expect(nameLines).toHaveLength(2)
+    expect(nameLines[0]).toBeInTheDocument()
+    expect(nameLines[1]).toBeInTheDocument()
+  })
+
+  it('shows hero-init label and hero-bar aligned beneath it', () => {
+    render(<HeroSection />)
+
+    const label = screen.getByText('// PORTFOLIO_INIT')
+    const bar = document.querySelector('.hero-bar')
+
+    expect(label).toHaveClass('hero-init')
+    expect(bar).toBeInTheDocument()
+    expect(label.nextElementSibling).toBe(bar)
+  })
+
+  it('wraps hero content in hero-inner for horizontal padding', () => {
     render(<HeroSection />)
 
     const content = screen.getByTestId('hero-content')
-    const labelUnit = screen.getByTestId('hero-init-label-unit')
-    const label = screen.getByText('// PORTFOLIO_INIT')
-    const underline = screen.getByTestId('hero-init-label-underline')
-
+    expect(content).toHaveClass('hero-inner')
     expect(content).toHaveClass('pt-16')
-    expect(labelUnit).toHaveClass('w-fit')
-    expect(labelUnit).toContainElement(label)
-    expect(labelUnit).toContainElement(underline)
-    expect(label.textContent?.startsWith('//')).toBe(true)
-    expect(label.nextElementSibling).toBe(underline)
-    expect(underline).toHaveClass('ml-0')
   })
 
   it('marks the dot grid as a slow parallax layer', () => {
@@ -169,9 +183,44 @@ describe('HeroSection', () => {
 
     advanceToNameComplete()
 
-    const heading = screen.getByRole('heading')
-    expect(heading).toBeInTheDocument()
-    expect(screen.getByTestId('hero-name')).toBeInTheDocument()
+    const cursor = screen.getByTestId('hero-name-cursor')
+    const nameLines = screen.getByTestId('hero-name').querySelectorAll('.hero-name-line')
+
+    expect(cursor).toBeInTheDocument()
+    expect(nameLines[1]?.contains(cursor)).toBe(true)
+  })
+
+  it('types FARHAN completely before MOHAMMED begins', () => {
+    render(<HeroSection />)
+
+    act(() => {
+      vi.advanceTimersByTime(FIRST_NAME_DURATION - NAME_SPEED)
+    })
+
+    const nameLines = screen.getByTestId('hero-name').querySelectorAll('.hero-name-line')
+    expect(nameLines[0]?.textContent).toBe(FIRST_NAME.slice(0, -1))
+    expect(nameLines[1]?.textContent).toBe('')
+
+    act(() => {
+      vi.advanceTimersByTime(NAME_SPEED)
+    })
+
+    expect(nameLines[0]?.textContent).toBe(FIRST_NAME)
+    expect(nameLines[1]?.textContent).toBe('')
+  })
+
+  it('applies hero-role to the rotating role line', () => {
+    render(<HeroSection />)
+
+    advanceToNameComplete()
+
+    expect(screen.getByTestId('rotating-role')).toHaveClass('hero-role')
+  })
+
+  it('applies hero-tag to the value prop line', () => {
+    render(<HeroSection />)
+
+    expect(screen.getByTestId('value-prop')).toHaveClass('hero-tag')
   })
 
   it('uses a step-like one-second blink animation for the cursor', () => {

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -38,52 +38,53 @@ const HeroSection: React.FC = () => {
         ></div>
       </div>
 
-      <div data-testid="hero-content" className="relative z-10 px-8 pt-16 w-full space-y-6">
-        <div data-testid="hero-init-label-unit" className="space-y-2 w-fit">
-          <p className="font-body text-xs text-atomic-tangerine tracking-widest">
-            // PORTFOLIO_INIT
-          </p>
-          <div data-testid="hero-init-label-underline" className="ml-0 w-8 h-0.5 bg-atomic-tangerine" />
-        </div>
+      <div data-testid="hero-content" className="hero-inner pt-16 w-full">
+        <p className="hero-init">// PORTFOLIO_INIT</p>
+        <div className="hero-bar" />
 
-        <h1 data-testid="hero-name" className="font-display text-5xl text-platinum leading-tight">
-          <TypeIn
-            start={true}
-            text={FIRST_NAME}
-            speed={NAME_SPEED}
-            onDone={() => {
-              setFirstNameDone(true)
-            }}
-          />
-          <TypeIn
-            start={firstNameDone}
-            text={` ${LAST_NAME}`}
-            speed={NAME_SPEED}
-            onDone={() => {
-              setNameDone(true)
-              setShowNameCursor(true)
-            }}
-          />
-          {showNameCursor && (
-            <motion.span
-              data-testid="hero-name-cursor"
-              aria-hidden="true"
-              className="inline-block w-[3px] h-[1.2em] bg-atomic-tangerine align-middle ml-1"
-              variants={cursorVariants}
-              animate="blink"
+        <h1 data-testid="hero-name" className="hero-name">
+          <span className="hero-name-line">
+            <TypeIn
+              start={true}
+              text={FIRST_NAME}
+              speed={NAME_SPEED}
+              onDone={() => {
+                setFirstNameDone(true)
+              }}
             />
-          )}
+          </span>
+          <span className="hero-name-line">
+            <TypeIn
+              start={firstNameDone}
+              text={LAST_NAME}
+              speed={NAME_SPEED}
+              onDone={() => {
+                setNameDone(true)
+                setShowNameCursor(true)
+              }}
+            />
+            {showNameCursor && (
+              <motion.span
+                data-testid="hero-name-cursor"
+                aria-hidden="true"
+                className="inline-block w-[3px] h-[1.2em] bg-atomic-tangerine align-middle ml-1"
+                variants={cursorVariants}
+                animate="blink"
+              />
+            )}
+          </span>
         </h1>
 
         <RotatingRole
           roles={ROLES}
           active={nameDone}
+          className="hero-role"
           onFirstCycleComplete={() => {
             setStartValueProp(true)
           }}
         />
 
-        <p className="font-body text-lg text-periwinkle/80" data-testid="value-prop">
+        <p className="hero-tag" data-testid="value-prop">
           <TypeIn
             start={startValueProp}
             text={VALUE_PROP}

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -105,4 +105,8 @@ describe('portfolio.css CSS anchor', () => {
   it('does not duplicate hero-name-line selector', () => {
     expect(portfolioCss.match(/\.hero-name-line\{/g)).toHaveLength(1)
   })
+
+  it('anchors hero-inner horizontal padding from the reference', () => {
+    expect(portfolioCss).toMatch(/\.hero-inner\{[^}]*padding:0 5vw/)
+  })
 })

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -48,7 +48,7 @@
   /* ─── HERO ──── */
   #hero{width:100vw;min-height:100vh;display:flex;flex-direction:column;justify-content:center;padding:0 5vw;position:relative;overflow:hidden}
   .hero-grid{position:absolute;inset:0;background-image:linear-gradient(var(--color-graphite-light) 1px,transparent 1px),linear-gradient(90deg,var(--color-graphite-light) 1px,transparent 1px);background-size:80px 80px;opacity:.35;mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%);-webkit-mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%)}
-  .hero-inner{position:relative;z-index:1;width:100%}
+  .hero-inner{position:relative;z-index:1;width:100%;padding:0 5vw}
   .hero-init{font-size:11px;color:var(--color-atomic-tangerine);letter-spacing:4px;margin-bottom:18px}
   .hero-bar{width:48px;height:2px;background:var(--color-atomic-tangerine);margin-bottom:32px}
   .hero-name{font-family:var(--font-display);font-size:clamp(40px,12vw,180px);line-height:1.05;color:var(--color-platinum);letter-spacing:-2px;margin-bottom:36px}


### PR DESCRIPTION
## Purpose
Apply portfolio.css hero typography and typewriter sequencing to match the reference design for issue #180.

## What it does
- Splits the hero name into two stacked `hero-name-line` spans with sequential TypeIn (FARHAN completes before MOHAMMED starts)
- Applies `hero-init`, `hero-bar`, `hero-inner`, `hero-name`, `hero-role`, and `hero-tag` classes from the CSS anchor
- Shows a blinking orange cursor at the end of MOHAMMED after name typing completes

## Changes made
- Updated `HeroSection.tsx` to use portfolio CSS classes instead of Tailwind typography overrides
- Added optional `className` prop to `RotatingRole` for `hero-role` styling
- Extended `HeroSection.test.tsx` with assertions for two name lines, init label, bar alignment, sequential typing, cursor placement, and role/tag classes

## Additional notes
- CTA buttons and background line grid (#181) are intentionally out of scope
- `npm run typecheck` and `npm run test` pass (335 tests)

Closes #180

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated hero layout and spacing for improved horizontal padding and alignment
  * Rotating role element now accepts styling so it can be customized by themes/CSS

* **Tests**
  * Expanded tests to verify hero layout, typing/animation timing, class application, and CSS spacing consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->