### PR TITLE
Navbar: enforce v4 floating terminal bar visual spec

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -76,7 +76,7 @@ describe('App shell', () => {
     const nav = document.querySelector('nav')
     const stackSurfaces = document.querySelectorAll('[data-sticky-section="true"][id]')
 
-    expect(nav?.className).toContain('z-40')
+    expect(nav?.className).toContain('nav')
     stackSurfaces.forEach((surface) => {
       if (surface.id === 'projects') {
         expect(surface.className).toContain('relative')
@@ -84,7 +84,7 @@ describe('App shell', () => {
       } else {
         expect(surface.className).toContain('sticky')
       }
-      expect(Number((surface as HTMLElement).style.zIndex)).toBeLessThan(40)
+      expect(Number((surface as HTMLElement).style.zIndex)).toBeLessThan(100)
     })
   })
 
@@ -92,12 +92,10 @@ describe('App shell', () => {
     render(<App />)
     const nav = document.querySelector('nav')
     expect(nav).toBeInTheDocument()
-    const innerDiv = nav?.querySelector('div')
-    expect(innerDiv).not.toBeNull()
-    expect(innerDiv!.className).not.toContain('max-w-7xl')
-    expect(innerDiv!.className).not.toContain('mx-auto')
-    expect(innerDiv!.className).toContain('w-full')
-    expect(innerDiv!.className).toContain('px-8')
+    expect(nav!.className).toContain('nav')
+    expect(nav!.className).not.toContain('max-w-7xl')
+    expect(nav!.className).not.toContain('mx-auto')
+    expect(nav!.querySelector('.nav-logo')).toBeInTheDocument()
   })
 
   it('initializes one RAF-batched parallax scroll listener and cleans it up', () => {
@@ -250,7 +248,7 @@ describe('App shell', () => {
 
       filtered.forEach((panel) => {
         const zIndex = Number((panel as HTMLElement).style.zIndex)
-        expect(zIndex).toBeLessThan(40)
+        expect(zIndex).toBeLessThan(100)
         expect(zIndex).toBeGreaterThan(0)
       })
     })

--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -121,11 +121,10 @@ describe('Navbar', () => {
       expect(skillsLink).not.toBeNull()
       const skillsLabel = screen.getByText('SKILLS')
 
-      expect(skillsLink!.className).not.toContain('border-b-2')
-      expect(skillsLink!.className).not.toContain('border-atomic-tangerine')
-      expect(skillsLabel).toHaveClass('text-atomic-tangerine')
-      expect(skillsLabel).toHaveClass('border-b-2')
-      expect(skillsLabel).toHaveClass('border-atomic-tangerine')
+      expect(skillsLink).toHaveClass('nav-link', 'active')
+      expect(skillsLabel).toHaveClass('nav-label')
+      expect(skillsLabel.className).not.toContain('border-b-2')
+      expect(skillsLabel.className).not.toContain('border-atomic-tangerine')
       expect(skillsLink!.querySelector('[data-testid="nav-caret"]')).toBeNull()
     })
 
@@ -156,99 +155,127 @@ describe('Navbar', () => {
       const projectsLabel = screen.getByText('PROJECTS')
 
       expect(skillsLink!.querySelector('[data-testid="nav-caret"]')).not.toBeNull()
-      expect(skillsLabel).not.toHaveClass('text-atomic-tangerine')
-      expect(skillsLabel).not.toHaveClass('border-b-2')
+      expect(skillsLink).not.toHaveClass('active')
+      expect(skillsLabel).toHaveClass('nav-label')
+      expect(projectsLink).toHaveClass('nav-link', 'active')
       expect(projectsLink!.querySelector('[data-testid="nav-caret"]')).toBeNull()
-      expect(projectsLabel).toHaveClass('text-atomic-tangerine')
-      expect(projectsLabel).toHaveClass('border-b-2')
+      expect(projectsLabel).toHaveClass('nav-label')
     })
   })
 
   describe('issue #38 - logo size and container alignment', () => {
-    it('FM_ logo uses text-xl', () => {
+    it('FM_ logo uses nav-logo portfolio class', () => {
       render(<Navbar />)
       const logo = screen.getByText('FM_')
-      expect(logo.className).toContain('text-xl')
+      expect(logo).toHaveClass('nav-logo')
     })
 
-    it('nav inner content spans full width without narrow shell constraint', () => {
+    it('nav spans full width without narrow shell constraint', () => {
       render(<Navbar />)
       const nav = screen.getByRole('navigation')
-      const innerContainer = nav.querySelector('div')
-      expect(innerContainer).not.toBeNull()
-      expect(innerContainer!.className).not.toContain('max-w-7xl')
-      expect(innerContainer!.className).not.toContain('mx-auto')
-      expect(innerContainer!.className).toContain('w-full')
-      expect(innerContainer!.className).toContain('px-8')
+      expect(nav).toHaveClass('nav')
+      expect(nav.className).not.toContain('max-w-7xl')
+      expect(nav.className).not.toContain('mx-auto')
     })
   })
 
-  describe('issue #103 - fixed translucent v4 chrome', () => {
-    it('navbar uses fixed top chrome above page sections', () => {
+  describe('issue #179 - v4 floating terminal bar visual spec', () => {
+    it('navbar root uses portfolio.css nav anchor class', () => {
       render(<Navbar />)
-      const nav = screen.getByRole('navigation')
-      expect(nav.className).toContain('fixed')
-      expect(nav.className).toContain('top-0')
-      expect(nav.className).toContain('z-40')
-      expect(nav.className).toContain('w-full')
+      expect(screen.getByRole('navigation')).toHaveClass('nav')
     })
 
-    it('navbar has translucent graphite background, blur, and subtle border', () => {
+    it('FM_ logo uses nav-logo portfolio class', () => {
       render(<Navbar />)
-      const nav = screen.getByRole('navigation')
-      expect(nav.className).toContain('bg-graphite/90')
-      expect(nav.className).toContain('backdrop-blur-md')
-      expect(nav.className).toContain('border-b')
-      expect(nav.className).toContain('border-graphite-light/30')
+      expect(screen.getByText('FM_')).toHaveClass('nav-logo')
     })
 
-    it('desktop links use fast restrained color transitions', () => {
+    it('desktop nav list uses nav-list portfolio class', () => {
       render(<Navbar />)
-      const homeLink = screen.getByRole('link', { name: /home/i })
-      expect(homeLink.className).toContain('transition-colors')
-      expect(homeLink.className).toContain('duration-150')
+      const nav = screen.getByRole('navigation')
+      expect(nav.querySelector('.nav-list')).toBeInTheDocument()
+    })
+
+    it('each desktop link uses nav-link and nav-label structure', () => {
+      render(<Navbar />)
+      const links = screen.getByRole('navigation').querySelectorAll('.nav-link')
+      expect(links.length).toBe(5)
+      links.forEach((link) => {
+        expect(link.querySelector('.nav-label')).toBeInTheDocument()
+      })
+    })
+
+    it('navbar does not use Tailwind chrome utilities superseding portfolio.css', () => {
+      render(<Navbar />)
+      const nav = screen.getByRole('navigation')
+      expect(nav.className).not.toContain('bg-graphite')
+      expect(nav.className).not.toContain('backdrop-blur')
+      expect(nav.className).not.toContain('border-b')
+      expect(nav.className).not.toContain('fixed')
+    })
+
+    it('active link applies active class with nav-label underline via CSS not border utilities', () => {
+      const section = document.createElement('section')
+      section.id = 'skills'
+      document.body.appendChild(section)
+      let observerCallback!: IntersectionObserverCallback
+
+      vi.stubGlobal('IntersectionObserver', vi.fn(function (cb: IntersectionObserverCallback) {
+        observerCallback = cb
+        return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() }
+      }))
+
+      try {
+        render(<Navbar />)
+
+        act(() => {
+          observerCallback(
+            [{ target: section, isIntersecting: true } as unknown as IntersectionObserverEntry],
+            {} as IntersectionObserver,
+          )
+        })
+
+        const skillsLink = screen.getByText('SKILLS').closest('a')
+        const skillsLabel = screen.getByText('SKILLS')
+
+        expect(skillsLink).toHaveClass('nav-link', 'active')
+        expect(skillsLabel).toHaveClass('nav-label')
+        expect(skillsLabel.className).not.toContain('border-b-2')
+        expect(skillsLabel.className).not.toContain('border-atomic-tangerine')
+        expect(skillsLabel.className).not.toContain('text-atomic-tangerine')
+        expect(skillsLink!.querySelector('.nav-caret')).toBeNull()
+      } finally {
+        vi.unstubAllGlobals()
+        document.body.removeChild(section)
+      }
     })
   })
 
   describe('issue #42 - > prefix on hover', () => {
-    it('nav link shows > prefix on hover', async () => {
-      const user = userEvent.setup()
+    it('nav link includes nav-caret prefix styled by portfolio.css', () => {
       render(<Navbar />)
 
       const homeLink = screen.getByRole('link', { name: /home/i })
-      const prefixSpan = homeLink.querySelector('span')
-      expect(prefixSpan).not.toBeNull()
-      expect(prefixSpan!.textContent).toBe('> ')
-      expect(prefixSpan!.style.opacity).toBe('0')
-
-      await user.hover(homeLink)
-      expect(prefixSpan!.style.opacity).toBe('1')
-
-      await user.unhover(homeLink)
-      expect(prefixSpan!.style.opacity).toBe('0')
+      const caret = homeLink.querySelector('.nav-caret')
+      expect(caret).not.toBeNull()
+      expect(caret).toHaveTextContent('>')
+      expect(caret).toHaveAttribute('data-testid', 'nav-caret')
+      expect((caret as HTMLElement).style.opacity).toBe('')
     })
 
-    it('> prefix appears on hover for all nav links', async () => {
-      const user = userEvent.setup()
+    it('> prefix is present on all inactive nav links', () => {
       render(<Navbar />)
 
       const labels = ['HOME', 'PROJECTS', 'SKILLS', 'TIMELINE', 'CONTACT']
       for (const label of labels) {
         const link = screen.getByRole('link', { name: new RegExp(label, 'i') })
-        const prefixSpan = link.querySelector('span')
-        expect(prefixSpan).not.toBeNull()
-        expect(prefixSpan!.textContent).toBe('> ')
-        expect(prefixSpan!.style.opacity).toBe('0')
-
-        await user.hover(link)
-        expect(prefixSpan!.style.opacity).toBe('1')
-
-        await user.unhover(link)
-        expect(prefixSpan!.style.opacity).toBe('0')
+        const caret = link.querySelector('.nav-caret')
+        expect(caret).not.toBeNull()
+        expect(caret).toHaveTextContent('>')
       }
     })
 
-    it('active link keeps the > prefix hidden until hover', () => {
+    it('active link keeps the > prefix absent', () => {
       const section = document.createElement('section')
       section.id = 'skills'
       document.body.appendChild(section)
@@ -270,9 +297,9 @@ describe('Navbar', () => {
         })
 
         const skillsLink = screen.getByRole('link', { name: /skills/i })
-        const labelSpan = skillsLink.querySelector('span:last-child')
+        const labelSpan = skillsLink.querySelector('.nav-label')
         const caretSpan = skillsLink.querySelector('[data-testid="nav-caret"]')
-        expect(labelSpan?.className).toContain('border-b-2')
+        expect(labelSpan).toHaveClass('nav-label')
         expect(caretSpan).toBeNull()
       } finally {
         vi.unstubAllGlobals()

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,7 +14,6 @@ const NAV_LINKS = [
 export default function Navbar() {
   const [activeSection, setActiveSection] = useState<string>('')
   const [menuOpen, setMenuOpen] = useState(false)
-  const [hoveredLink, setHoveredLink] = useState<string | null>(null)
 
   useEffect(() => {
     const sections = document.querySelectorAll('section[id]')
@@ -34,60 +33,46 @@ export default function Navbar() {
 
   return (
     <>
-      <nav className="fixed top-0 z-40 w-full py-4 bg-graphite/90 backdrop-blur-md border-b border-graphite-light/30">
-        <div className="w-full flex items-center justify-between px-8">
-          <a href="#" className="font-display text-platinum text-xl no-underline">
-            FM_
-          </a>
+      <nav className="nav">
+        <a href="#" className="nav-logo">
+          FM_
+        </a>
 
-          <ul className="hidden md:flex gap-8 list-none m-0 p-0">
-            {NAV_LINKS.map(({ label, href }) => {
-              const isActive = activeSection === href.slice(1)
-              const isHovered = hoveredLink === label
-              return (
-                <li key={label}>
-                  <motion.a
-                    href={href}
-                    variants={hoverEase}
-                    initial="idle"
-                    whileHover="hover"
-                    onMouseEnter={() => setHoveredLink(label)}
-                    onMouseLeave={() => setHoveredLink(null)}
-                    className="group font-body text-sm no-underline pb-0.5 text-platinum transition-colors duration-150"
-                  >
-                    {!isActive && (
-                      <span
-                        data-testid="nav-caret"
-                        style={{ opacity: isHovered ? 1 : 0 }}
-                        className="transition-opacity duration-200"
-                      >
-                        &gt;{' '}
-                      </span>
-                    )}
-                    <span className={isActive ? 'text-atomic-tangerine border-b-2 border-atomic-tangerine' : undefined}>
-                      {label}
+        <ul className="nav-list hidden md:flex">
+          {NAV_LINKS.map(({ label, href }) => {
+            const isActive = activeSection === href.slice(1)
+            return (
+              <li key={label}>
+                <a
+                  href={href}
+                  className={`nav-link${isActive ? ' active' : ''}`}
+                >
+                  {!isActive && (
+                    <span className="nav-caret" data-testid="nav-caret">
+                      &gt;
                     </span>
-                  </motion.a>
-                </li>
-              )
-            })}
-          </ul>
+                  )}
+                  <span className="nav-label">{label}</span>
+                </a>
+              </li>
+            )
+          })}
+        </ul>
 
-          <motion.button
-            className="flex md:hidden text-periwinkle"
-            onClick={() => setMenuOpen(true)}
-            variants={hoverEase}
-            initial="idle"
-            whileHover="hover"
-            aria-label="Open menu"
-          >
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-              <line x1="3" y1="6" x2="21" y2="6" />
-              <line x1="3" y1="12" x2="21" y2="12" />
-              <line x1="3" y1="18" x2="21" y2="18" />
-            </svg>
-          </motion.button>
-        </div>
+        <motion.button
+          className="flex md:hidden text-periwinkle"
+          onClick={() => setMenuOpen(true)}
+          variants={hoverEase}
+          initial="idle"
+          whileHover="hover"
+          aria-label="Open menu"
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        </motion.button>
       </nav>
 
       <MobileMenu

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -89,6 +89,19 @@ describe('portfolio.css CSS anchor', () => {
     expect(portfolioCss).toContain('scroll-margin-top: 56px')
   })
 
+  it('anchors navbar floating terminal bar chrome from the reference', () => {
+    expect(portfolioCss).toMatch(/\.nav\{[^}]*position:fixed/)
+    expect(portfolioCss).toMatch(/\.nav\{[^}]*z-index:100/)
+    expect(portfolioCss).toMatch(/\.nav\{[^}]*backdrop-filter:blur\(12px\)/)
+    expect(portfolioCss).toContain('.nav-logo{font-family:var(--font-display)')
+    expect(portfolioCss).toContain('.nav-link{font-size:14px')
+    expect(portfolioCss).toContain('.nav-caret{display:inline-block')
+    expect(portfolioCss).toContain('.nav-caret{display:inline-block;color:var(--color-atomic-tangerine);opacity:0')
+    expect(portfolioCss).toContain('.nav-link:hover .nav-caret')
+    expect(portfolioCss).toContain('.nav-label::after{content')
+    expect(portfolioCss).toContain('.nav-link.active .nav-label{color:var(--color-atomic-tangerine)}')
+  })
+
   it('anchors timeline panel typography and terminal caret', () => {
     expect(portfolioCss).toContain('.tl-panel{flex-shrink:0;width:100vw')
     expect(portfolioCss).toContain('.tl-commit{font-size:14px;color:var(--color-atomic-tangerine)')


### PR DESCRIPTION
## Purpose
Enforce the v4 floating terminal bar navbar visual spec from `ideas/Portfolio.html` by wiring the React `Navbar` component to the existing `portfolio.css` anchor classes.

## What it does
- Replaces Tailwind chrome utilities on the navbar with `.nav`, `.nav-logo`, `.nav-list`, `.nav-link`, `.nav-caret`, and `.nav-label` classes
- Preserves hover-vs-active distinction: `>` caret on hover only (via CSS), orange label + `::after` underline on active (no caret, no border utilities)
- Keeps navbar `z-index: 100` from portfolio.css above all card-deck stack layers

## Changes made
- **`Navbar.tsx`**: Simplified structure to match reference markup; removed inline opacity hover state and Tailwind border/background classes
- **`Navbar.test.tsx`**: Added issue #179 acceptance tests; updated existing tests for portfolio.css class assertions
- **`App.test.tsx`**: Updated z-index expectations to match `.nav { z-index: 100 }`
- **`portfolio-css.test.ts`**: Added navbar chrome anchor tests (fixed position, blur, caret hover, active label)

## Additional notes
- Hover caret visibility is asserted structurally in component tests and via CSS rule presence in `portfolio-css.test.ts` (jsdom does not reliably compute `:hover` opacity)
- Mobile hamburger menu unchanged; uses structural Tailwind utilities only per portfolio-css rule

Closes #179

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined navbar styling with a simplified, class-based approach for active link highlighting
  * Removed hover-state animations from navigation links for streamlined interactions
  * Updated caret indicator to display only on inactive links
  * Improved navbar z-index layering for better visual hierarchy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->