### PR TITLE
Projects: carousel scroll pacing, dead zones, and edge spacing

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -2,10 +2,11 @@ import { describe, it, expect, vi } from 'vitest'
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import ProjectsSection from './ProjectsSection'
-import { getScrollRangeVh, PROJECT_CARD_WIDTH } from './projectsGeometry'
-
-const CARD_WIDTH = PROJECT_CARD_WIDTH
-const CARD_GAP = 24
+import {
+  getCarouselTrackWidth,
+  getScrollRangeVh,
+  PROJECT_CARD_WIDTH,
+} from './projectsGeometry'
 
 const mockProjects = [
   {
@@ -256,6 +257,15 @@ describe('ProjectsSection', () => {
     expect(fill).toHaveAttribute('data-active', 'false')
   })
 
+  it('renders proj-edge spacers before the first card and after the last card', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const edges = document.querySelectorAll('.proj-edge')
+    expect(edges).toHaveLength(2)
+    expect(edges[0]?.nextElementSibling).toHaveAttribute('data-testid', 'project-card')
+    expect(edges[1]?.previousElementSibling).toHaveAttribute('data-testid', 'project-card')
+  })
+
   it('renders cards in a horizontal track structure for carousel scrolling', () => {
     render(<ProjectsSection projects={mockProjects} />)
 
@@ -282,16 +292,15 @@ describe('ProjectsSection', () => {
     const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
 
     vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-800, 2400))
+    const trackWidth = getCarouselTrackWidth(mockProjects.length, 1000)
     Object.defineProperty(carouselTrack, 'scrollWidth', {
       configurable: true,
-      value: 1800,
+      value: trackWidth,
     })
 
     act(() => window.dispatchEvent(new Event('scroll')))
 
-    const centerOffset = 1000 / 2 - PROJECT_CARD_WIDTH / 2
-    const centeredTravelWidth = 1800 - PROJECT_CARD_WIDTH
-    expect(carouselTrack.style.transform).toBe(`translateX(${centerOffset - centeredTravelWidth / 2}px)`)
+    expect(carouselTrack.style.transform).toBe(`translateX(${-0.5 * (trackWidth - 1000)}px)`)
   })
 
   it('section header is separate from carousel track', () => {
@@ -471,7 +480,7 @@ describe('ProjectsSection', () => {
       vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-800, 2400))
       Object.defineProperty(carouselTrack, 'scrollWidth', {
         configurable: true,
-        value: 1800,
+        value: getCarouselTrackWidth(mockProjects.length, 1000),
       })
 
       act(() => window.dispatchEvent(new Event('scroll')))
@@ -506,7 +515,7 @@ describe('ProjectsSection', () => {
       )
       Object.defineProperty(carouselTrack, 'scrollWidth', {
         configurable: true,
-        value: 2 * (CARD_WIDTH + CARD_GAP),
+        value: getCarouselTrackWidth(mockProjects.length, 1000),
       })
 
       act(() => window.dispatchEvent(new Event('scroll')))
@@ -527,7 +536,7 @@ describe('ProjectsSection', () => {
       )
       Object.defineProperty(carouselTrack, 'scrollWidth', {
         configurable: true,
-        value: 2 * (CARD_WIDTH + CARD_GAP),
+        value: getCarouselTrackWidth(mockProjects.length, 1000),
       })
 
       act(() => window.dispatchEvent(new Event('scroll')))
@@ -561,7 +570,7 @@ describe('ProjectsSection', () => {
       vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-800, 2400))
       Object.defineProperty(carouselTrack, 'scrollWidth', {
         configurable: true,
-        value: 1800,
+        value: getCarouselTrackWidth(mockProjects.length, 1000),
       })
 
       act(() => window.dispatchEvent(new Event('scroll')))
@@ -836,7 +845,7 @@ describe('ProjectsSection', () => {
       vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-(sectionHeight - 900), sectionHeight))
       Object.defineProperty(carouselTrack, 'scrollWidth', {
         configurable: true,
-        value: 3 * (CARD_WIDTH + CARD_GAP),
+        value: getCarouselTrackWidth(threeProjects.length, 1440),
       })
 
       act(() => window.dispatchEvent(new Event('scroll')))

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion'
 import { useCardDeckDepth } from '../hooks/useCardDeckDepth'
 import { useHorizontalScroll } from '../hooks/useHorizontalScroll'
 import type { Project } from '../data/projects'
-import { formatProjectNumber, getScrollRangeVh, PROJECT_CARD_WIDTH } from './projectsGeometry'
+import { formatProjectNumber, getScrollRangeVh } from './projectsGeometry'
 
 interface Props {
   projects: Project[]
@@ -30,7 +30,7 @@ function clampIndex(index: number, projectCount: number) {
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
   const outerRef = useRef<HTMLElement>(null)
   const innerRef = useRef<HTMLDivElement>(null)
-  const { tx, progress } = useHorizontalScroll(outerRef as React.RefObject<HTMLElement>, innerRef as React.RefObject<HTMLElement>, { cardWidth: PROJECT_CARD_WIDTH })
+  const { tx, progress } = useHorizontalScroll(outerRef as React.RefObject<HTMLElement>, innerRef as React.RefObject<HTMLElement>)
   const scrollRangeVh = getScrollRangeVh(projects.length)
   useCardDeckDepth(outerRef as React.RefObject<HTMLElement>)
 
@@ -74,10 +74,12 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
           </div>
 
           <div ref={innerRef as React.RefObject<HTMLDivElement>} data-carousel-track="true" className="relative" style={{ transform: `translateX(${tx}px)` }}>
-            <div className="flex gap-6 pb-4">
+            <div className="flex proj-track pb-4">
+              <div className="proj-edge" aria-hidden="true" />
               {projects.map((project, index) => (
                 <ProjectCard key={project.id} project={project} index={index} activeIndex={activeIndex} />
               ))}
+              <div className="proj-edge" aria-hidden="true" />
             </div>
           </div>
         </div>

--- a/src/components/projectsGeometry.test.ts
+++ b/src/components/projectsGeometry.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { formatProjectNumber, getScrollRangeVh, PROJECT_CARD_WIDTH } from './projectsGeometry'
+import {
+  formatProjectNumber,
+  getEdgeSpacerWidth,
+  getScrollRangeVh,
+  PROJECT_CARD_GAP,
+  PROJECT_CARD_WIDTH,
+} from './projectsGeometry'
 
 describe('projectsGeometry', () => {
   it('exports desktop card width matching pcard CSS', () => {
@@ -25,6 +31,17 @@ describe('projectsGeometry', () => {
   describe('getScrollRangeVh', () => {
     it('returns 1 when there are no projects', () => {
       expect(getScrollRangeVh(0)).toBe(1)
+    })
+  })
+
+  it('exports the reference proj-track gap in pixels', () => {
+    expect(PROJECT_CARD_GAP).toBe(56)
+  })
+
+  describe('getEdgeSpacerWidth', () => {
+    it('matches calc(50vw - min(280px, 39vw)) for desktop card width', () => {
+      expect(getEdgeSpacerWidth(1440)).toBe(440)
+      expect(getEdgeSpacerWidth(1000)).toBe(220)
     })
   })
 })

--- a/src/components/projectsGeometry.ts
+++ b/src/components/projectsGeometry.ts
@@ -1,6 +1,33 @@
 /** Desktop project card width used for carousel centering (matches `.pcard` CSS). */
 export const PROJECT_CARD_WIDTH = 560
 
+/** Gap between project cards in the carousel track (matches `.proj-track` CSS). */
+export const PROJECT_CARD_GAP = 56
+
+/** Fraction of viewport height reserved as entry/exit dead zones in the Projects scroll range. */
+export const DEAD_ZONE_VIEWPORT_RATIO = 0.25
+
+/** Returns edge spacer width in px (matches `.proj-edge` calc for a fixed card width). */
+export function getEdgeSpacerWidth(viewportWidth: number, cardWidth = PROJECT_CARD_WIDTH) {
+  return viewportWidth / 2 - Math.min(cardWidth / 2, viewportWidth * 0.39)
+}
+
+/** Returns the total horizontal scroll width of a project carousel track. */
+export function getCarouselTrackWidth(
+  projectCount: number,
+  viewportWidth: number,
+  cardWidth = PROJECT_CARD_WIDTH,
+  cardGap = PROJECT_CARD_GAP,
+) {
+  if (projectCount === 0) {
+    return 0
+  }
+
+  const edgeWidth = getEdgeSpacerWidth(viewportWidth, cardWidth)
+  const cardsWidth = projectCount * cardWidth + Math.max(projectCount - 1, 0) * cardGap
+  return edgeWidth * 2 + cardsWidth
+}
+
 /** Returns the Projects section height multiplier in viewport-height units. */
 export function getScrollRangeVh(projectCount: number) {
   return projectCount * 1.5 + 1

--- a/src/hooks/useHorizontalScroll.test.tsx
+++ b/src/hooks/useHorizontalScroll.test.tsx
@@ -34,12 +34,10 @@ function renderHorizontalScrollHook({
   outerTop,
   outerHeight,
   innerScrollWidth,
-  cardWidth,
 }: {
   outerTop: number | (() => number)
   outerHeight: number
   innerScrollWidth: number
-  cardWidth?: number
 }) {
   const outer = document.createElement('section')
   const inner = document.createElement('div')
@@ -55,12 +53,18 @@ function renderHorizontalScrollHook({
     const outerRef = useRef<HTMLElement>(outer)
     const innerRef = useRef<HTMLElement>(inner)
 
-    return useHorizontalScroll(outerRef, innerRef, { cardWidth })
+    return useHorizontalScroll(outerRef, innerRef)
   })
 }
 
-function cardCenterX(tx: number, cardIndex: number, cardWidth: number, cardGap: number) {
-  return tx + cardIndex * (cardWidth + cardGap) + cardWidth / 2
+function cardCenterX(
+  tx: number,
+  cardIndex: number,
+  cardWidth: number,
+  cardGap: number,
+  edgeWidth: number,
+) {
+  return tx + edgeWidth + cardIndex * (cardWidth + cardGap) + cardWidth / 2
 }
 
 describe('useHorizontalScroll', () => {
@@ -197,102 +201,86 @@ describe('useHorizontalScroll', () => {
     expect(result.current).toEqual({ progress: 0.5, tx: -700 })
   })
 
-  it('centers the first card at progress 0 when cardWidth is provided', () => {
+  it('keeps the first card centered at progress 0 when proj-edge spacers are included in scroll width', () => {
     setViewport(1000, 800)
+
+    const cardWidth = 480
+    const cardGap = 56
+    const edgeWidth = 1000 / 2 - Math.min(cardWidth / 2, 1000 * 0.39)
+    const innerScrollWidth = edgeWidth * 2 + cardWidth * 2 + cardGap
 
     const { result } = renderHorizontalScrollHook({
       outerTop: 0,
       outerHeight: 2400,
-      innerScrollWidth: 984,
-      cardWidth: 480,
+      innerScrollWidth,
     })
 
     act(() => window.dispatchEvent(new Event('scroll')))
 
-    const centerOffset = 1000 / 2 - 480 / 2
     expect(result.current.progress).toBe(0)
-    expect(result.current.tx).toBe(centerOffset)
+    expect(result.current.tx).toBe(0)
+    expect(cardCenterX(result.current.tx, 0, cardWidth, cardGap, edgeWidth)).toBe(1000 / 2)
   })
 
-  it('centers the last card at progress 1 when cardWidth is provided', () => {
+  it('keeps the last card centered at progress 1 when proj-edge spacers are included in scroll width', () => {
     setViewport(1000, 800)
+
+    const cardWidth = 480
+    const cardGap = 56
+    const edgeWidth = 1000 / 2 - Math.min(cardWidth / 2, 1000 * 0.39)
+    const innerScrollWidth = edgeWidth * 2 + cardWidth * 2 + cardGap
 
     const { result } = renderHorizontalScrollHook({
       outerTop: -1600,
       outerHeight: 2400,
-      innerScrollWidth: 984,
-      cardWidth: 480,
+      innerScrollWidth,
     })
 
     act(() => window.dispatchEvent(new Event('scroll')))
 
     expect(result.current.progress).toBe(1)
-    expect(cardCenterX(result.current.tx, 1, 480, 24)).toBe(1000 / 2)
+    expect(cardCenterX(result.current.tx, 1, cardWidth, cardGap, edgeWidth)).toBe(1000 / 2)
   })
 
-  it('centers intermediate cards as progress advances', () => {
+  it('holds the first card centered through the leading dead zone', () => {
     setViewport(1000, 800)
 
-    const { result } = renderHorizontalScrollHook({
-      outerTop: -800,
-      outerHeight: 2400,
-      innerScrollWidth: 1992,
-      cardWidth: 480,
-    })
-
-    act(() => window.dispatchEvent(new Event('scroll')))
-
-    expect(result.current.progress).toBe(0.5)
-    expect(cardCenterX(result.current.tx, 1.5, 480, 24)).toBe(1000 / 2)
-  })
-
-  it('centers a middle active card when progress selects that card', () => {
-    setViewport(1000, 800)
-
-    const { result } = renderHorizontalScrollHook({
-      outerTop: -600,
-      outerHeight: 2400,
-      innerScrollWidth: 1992,
-      cardWidth: 480,
-    })
-
-    act(() => window.dispatchEvent(new Event('scroll')))
-
-    expect(result.current.progress).toBeCloseTo(1 / 3, 4)
-    expect(cardCenterX(result.current.tx, 1, 480, 24)).toBeCloseTo(1000 / 2, 2)
-  })
-
-  it('holds first card centered through the leading dead zone', () => {
-    setViewport(1000, 800)
+    const cardWidth = 480
+    const cardGap = 56
+    const edgeWidth = 1000 / 2 - Math.min(cardWidth / 2, 1000 * 0.39)
+    const innerScrollWidth = edgeWidth * 2 + cardWidth * 2 + cardGap
 
     const { result } = renderHorizontalScrollHook({
       outerTop: -160,
       outerHeight: 2400,
-      innerScrollWidth: 984,
-      cardWidth: 480,
+      innerScrollWidth,
     })
 
     act(() => window.dispatchEvent(new Event('scroll')))
 
-    const centerOffset = 1000 / 2 - 480 / 2
     expect(result.current.progress).toBe(0)
-    expect(result.current.tx).toBe(centerOffset)
+    expect(result.current.tx).toBe(0)
+    expect(cardCenterX(result.current.tx, 0, cardWidth, cardGap, edgeWidth)).toBe(1000 / 2)
   })
 
-  it('holds last card centered through the trailing dead zone', () => {
+  it('holds the last card centered through the trailing dead zone', () => {
     setViewport(1000, 800)
+
+    const cardWidth = 480
+    const cardGap = 56
+    const edgeWidth = 1000 / 2 - Math.min(cardWidth / 2, 1000 * 0.39)
+    const innerScrollWidth = edgeWidth * 2 + cardWidth * 2 + cardGap
 
     const { result } = renderHorizontalScrollHook({
       outerTop: -1440,
       outerHeight: 2400,
-      innerScrollWidth: 984,
-      cardWidth: 480,
+      innerScrollWidth,
     })
 
     act(() => window.dispatchEvent(new Event('scroll')))
 
     expect(result.current.progress).toBe(1)
-    expect(cardCenterX(result.current.tx, 1, 480, 24)).toBe(1000 / 2)
+    expect(cardCenterX(result.current.tx, 1, cardWidth, cardGap, edgeWidth)).toBe(1000 / 2)
   })
 })
 

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -1,15 +1,10 @@
 import { useEffect, useState, type RefObject } from 'react'
-
-interface HorizontalScrollOptions {
-  cardWidth?: number
-}
+import { DEAD_ZONE_VIEWPORT_RATIO } from '../components/projectsGeometry'
 
 interface HorizontalScrollState {
   tx: number
   progress: number
 }
-
-const DEAD_ZONE_VIEWPORT_RATIO = 0.25
 
 export function clamp01(value: number) {
   return Math.min(Math.max(value, 0), 1)
@@ -34,7 +29,6 @@ export function applyDeadZones(rawProgress: number, deadZoneProgress: number) {
 function getHorizontalScrollState(
   outer: HTMLElement | null,
   inner: HTMLElement | null,
-  options?: HorizontalScrollOptions
 ): HorizontalScrollState {
   if (!outer || !inner) {
     return { tx: 0, progress: 0 }
@@ -48,14 +42,7 @@ function getHorizontalScrollState(
   const deadZoneProgress = scrollRange === 0 ? 0 : (viewportHeight * DEAD_ZONE_VIEWPORT_RATIO) / scrollRange
   const progress = clamp01(applyDeadZones(rawProgress, deadZoneProgress))
   const trackWidth = Math.max(inner.scrollWidth - viewportWidth, 0)
-  const centeredTravelWidth = options?.cardWidth ? Math.max(inner.scrollWidth - options.cardWidth, 0) : trackWidth
-
-  let tx = progress === 0 || trackWidth === 0 ? 0 : -(progress * trackWidth)
-
-  if (options?.cardWidth) {
-    const centerOffset = viewportWidth / 2 - options.cardWidth / 2
-    tx = centerOffset - progress * centeredTravelWidth
-  }
+  const tx = progress === 0 || trackWidth === 0 ? 0 : -(progress * trackWidth)
 
   return {
     progress,
@@ -66,15 +53,12 @@ function getHorizontalScrollState(
 export function useHorizontalScroll(
   outerRef: RefObject<HTMLElement>,
   innerRef: RefObject<HTMLElement>,
-  options?: HorizontalScrollOptions
 ): HorizontalScrollState {
   const [state, setState] = useState<HorizontalScrollState>({ tx: 0, progress: 0 })
-  const cardWidth = options?.cardWidth
 
   useEffect(() => {
-    const opts = cardWidth !== undefined ? { cardWidth } : undefined
     const update = () => {
-      setState(getHorizontalScrollState(outerRef.current, innerRef.current, opts))
+      setState(getHorizontalScrollState(outerRef.current, innerRef.current))
     }
 
     update()
@@ -86,7 +70,7 @@ export function useHorizontalScroll(
       window.removeEventListener('scroll', update)
       window.removeEventListener('resize', update)
     }
-  }, [outerRef, innerRef, cardWidth])
+  }, [outerRef, innerRef])
 
   return state
 }


### PR DESCRIPTION
## Purpose

Align the Projects carousel scroll behavior with the reference design (`ideas/Portfolio.html`): paced vertical scroll range, entry/exit dead zones, and horizontal edge spacers so first and last cards can reach the centered position.

## What it does

- Renders `proj-edge` spacers before the first and after the last project card inside a `proj-track` row (56px gap per reference CSS).
- Keeps the outer section height at `(projectCount * 1.5 + 1) * 100vh` with 25vh dead zones at the start and end of the scroll range where carousel translate does not change.
- Centers cards by translating the track with `translateX(-progress * (scrollWidth - viewportWidth))`, relying on edge spacers instead of a separate `cardWidth` offset.
- Adds geometry helpers (`getEdgeSpacerWidth`, `getCarouselTrackWidth`, `PROJECT_CARD_GAP`, `DEAD_ZONE_VIEWPORT_RATIO`) shared by the hook and tests.

## Changes made

- `ProjectsSection.tsx`: `proj-edge` elements + `proj-track` class; hook no longer passes `cardWidth`.
- `projectsGeometry.ts`: edge spacer and track width helpers; exported dead-zone ratio and card gap.
- `useHorizontalScroll.ts`: edge-based translate; dead-zone ratio imported from geometry.
- Tests: assert two `.proj-edge` nodes; update scroll-width expectations for edge-inclusive tracks.

## Additional notes

- `proj-edge` / `proj-track` CSS was already present in `portfolio.css` from #176; this PR wires them into the React carousel.
- Closes #182


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refined carousel layout with improved edge spacing and geometry calculations.
  * Optimized horizontal scrolling behavior for enhanced consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->