### PR TITLE
Timeline: enforce v4 desktop panel visual hierarchy

### DIFF
--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -12,12 +12,12 @@ describe('TimelineSection', () => {
     vi.useRealTimers()
   })
 
-  it('each entry has min-h-screen', () => {
+  it('each entry uses tl-panel layout class', () => {
     render(<TimelineSection />)
     const commitEntries = screen.getAllByTestId('commit-entry')
     expect(commitEntries.length).toBe(3)
     commitEntries.forEach((entry) => {
-      expect(entry).toHaveClass('min-h-screen')
+      expect(entry).toHaveClass('tl-panel')
     })
   })
 
@@ -85,30 +85,33 @@ describe('TimelineSection', () => {
       expect(sectionLabels.length).toBe(3)
 
       const labelTexts = Array.from(sectionLabels).map((el) => el.textContent)
-      expect(labelTexts).toContain('// EXPERIENCE')
-      expect(labelTexts).toContain('// EDUCATION')
+      expect(labelTexts).toContain('//EXPERIENCE')
+      expect(labelTexts.filter((t) => t === '//EDUCATION').length).toBe(2)
     })
 
-    it('section labels use font-display (pixel font) in orange', () => {
+    it('section labels use tl-section-tag with portfolio typography classes', () => {
       render(<TimelineSection />)
 
       const sectionLabels = document.querySelectorAll('[data-testid="section-label"]')
       sectionLabels.forEach((label) => {
-        expect(label.className).toContain('font-display')
-        expect(label.className).toContain('text-atomic-tangerine')
-        expect(label.className).not.toContain('font-body')
+        expect(label.className).toContain('tl-section-tag')
+        expect(label.className).not.toContain('font-display')
+        expect(label.className).not.toContain('text-atomic-tangerine')
       })
     })
 
-    it('section label // is smaller than section word', () => {
+    it('section label // and word are separate tl-section-slash and tl-section-kind siblings', () => {
       render(<TimelineSection />)
 
       const sectionLabels = document.querySelectorAll('[data-testid="section-label"]')
       sectionLabels.forEach((label) => {
-        const slash = label.querySelector('span:first-child')
-        const word = label.querySelector('span:last-child')
-        expect(slash?.className).toContain('text-xs')
-        expect(word?.className).toContain('text-sm')
+        const slash = label.querySelector('.tl-section-slash')
+        const word = label.querySelector('.tl-section-kind')
+        expect(slash?.textContent).toBe('//')
+        expect(slash?.className).toContain('tl-section-slash')
+        expect(slash?.className).not.toContain('text-xs')
+        expect(word?.className).toContain('tl-section-kind')
+        expect(word?.className).not.toContain('text-sm')
       })
     })
 
@@ -596,6 +599,111 @@ describe('TimelineSection', () => {
         heldEntries[0].querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
       expect(heldHash).toBe(partialHash)
       expect(heldEntries[0].querySelector('[data-testid="commit-institution"]')).toBeNull()
+    })
+  })
+
+  describe('issue #161 - v4 desktop panel visual hierarchy', () => {
+    it('commit hash uses tl-commit, author and date use tl-meta', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const metadata = commitEntries[0].querySelector('[data-testid="commit-metadata"]')
+      expect(metadata?.querySelector('[data-testid="commit-hash"]')).toHaveClass('tl-commit')
+      expect(metadata?.querySelector('[data-testid="commit-author"]')).toHaveClass('tl-meta')
+      expect(metadata?.querySelector('[data-testid="commit-date"]')).toHaveClass('tl-meta')
+    })
+
+    it('institution heading uses tl-org portfolio class', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const institution = commitEntries[0].querySelector('[data-testid="commit-institution"]')
+      expect(institution).toHaveClass('tl-org')
+      expect(institution?.textContent).toBe('NETAPP INC.')
+    })
+
+    it('role uses tl-title portfolio class', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const role = commitEntries[0].querySelector('[data-testid="commit-role"]')
+      expect(role).toHaveClass('tl-title')
+      expect(role?.textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+    })
+
+    it('bullets use tl-bullets portfolio class', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const details = commitEntries[0].querySelector('[data-testid="commit-details"]')
+      expect(details).toHaveClass('tl-bullets')
+    })
+
+    it('section tag carries experience or education category class', () => {
+      render(<TimelineSection />)
+
+      const sectionLabels = document.querySelectorAll('[data-testid="section-label"]')
+      expect(sectionLabels[0].className).toContain('experience')
+      expect(sectionLabels[1].className).toContain('education')
+      expect(sectionLabels[2].className).toContain('education')
+    })
+
+    it('inserts tl-sep spacer before institution heading', () => {
+      vi.mocked(useActivePanel).mockReturnValue({
+        active: [true, false, false],
+        setRef: () => () => {},
+      })
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const commitEntries = screen.getAllByTestId('commit-entry')
+      const institution = commitEntries[0].querySelector('[data-testid="commit-institution"]')
+      expect(institution?.previousElementSibling).toHaveClass('tl-sep')
     })
   })
 

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -62,36 +62,39 @@ function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean 
     .filter((line): line is string => line !== undefined && line !== '')
 
   return (
-    <div className="min-h-screen py-6 font-mono" data-testid="commit-entry">
+    <div className="tl-panel" data-testid="commit-entry">
       <div data-testid="commit-metadata">
         {displayedLines[0] !== undefined && (
-          <div data-testid="commit-hash" data-typewriter-line>
+          <div className="tl-commit" data-testid="commit-hash" data-typewriter-line>
             {displayedLines[0]}
           </div>
         )}
         {displayedLines[1] !== undefined && (
-          <div data-testid="commit-author" data-typewriter-line>
+          <div className="tl-meta" data-testid="commit-author" data-typewriter-line>
             {displayedLines[1]}
           </div>
         )}
         {displayedLines[2] !== undefined && (
-          <div data-testid="commit-date" data-typewriter-line>
+          <div className="tl-meta" data-testid="commit-date" data-typewriter-line>
             {displayedLines[2]}
           </div>
         )}
       </div>
       {institutionLine !== undefined && (
-        <h2 data-testid="commit-institution" data-typewriter-line>
-          {institutionLine}
-        </h2>
+        <>
+          <div className="tl-sep" aria-hidden="true" />
+          <h2 className="tl-org" data-testid="commit-institution" data-typewriter-line>
+            {institutionLine}
+          </h2>
+        </>
       )}
       {roleLine !== undefined && (
-        <p data-testid="commit-role" data-typewriter-line>
+        <p className="tl-title" data-testid="commit-role" data-typewriter-line>
           {roleLine}
         </p>
       )}
       {bulletLines.length > 0 && (
-        <ul data-testid="commit-details">
+        <ul className="tl-bullets" data-testid="commit-details">
           {entry.bullets.map((_, index) => {
             const line = displayedLines[METADATA_LINE_COUNT + 2 + index]
             if (line === undefined) return null
@@ -120,10 +123,13 @@ function TimelinePanel({
 }) {
   return (
     <StickySection id={id} className="bg-graphite-light">
-      <div ref={panelRef} className="min-h-screen flex flex-col justify-center py-14 px-8">
-        <div data-testid="section-label" className="font-display text-atomic-tangerine mb-8">
-          <span className="text-xs">//</span>{' '}
-          <span className="text-sm">
+      <div ref={panelRef} className="relative min-h-screen">
+        <div
+          data-testid="section-label"
+          className={`tl-section-tag ${entry.category}`}
+        >
+          <span className="tl-section-slash">//</span>
+          <span className="tl-section-kind">
             {entry.category === 'experience' ? 'EXPERIENCE' : 'EDUCATION'}
           </span>
         </div>


### PR DESCRIPTION
## Purpose

Enforce the v4 Timeline desktop visual hierarchy on top of the structured sticky panels from #160, matching `ideas/Portfolio v4.html` and `ideas/timeline.png` typography and spacing.

## What it does

- Replaces Tailwind typography utilities with canonical `portfolio.css` timeline classes
- Applies the v4 section label, metadata, institution, role, and bullet hierarchy within each sticky panel
- Preserves typewriter activation and per-panel progress behavior (unchanged from #159/#160)

## Changes made

- **Section labels:** `tl-section-tag` with separate `tl-section-slash` (`//`, body font) and `tl-section-kind` (`EXPERIENCE`/`EDUCATION`, pixel display font), plus `experience`/`education` category class
- **Panel layout:** `tl-panel` for sparse full-screen rhythm with 8vw padding
- **Commit metadata:** `tl-commit` (orange mono) for hash; `tl-meta` (periwinkle mono) for author/date
- **Institution:** `tl-org` large pixel heading with `tl-sep` spacer above
- **Role:** `tl-title` below institution with clear hierarchy
- **Bullets:** `tl-bullets` list with orange `•` markers and periwinkle text
- **Tests:** Added issue #161 describe block; updated label/layout assertions to match portfolio classes

## Additional notes

**Reference comparison:**
- `ideas/timeline.png` / `ideas/timeline 2.png`: orange pixel `// EXPERIENCE`/`// EDUCATION` labels, large pixel institution heading, small orange/periwinkle metadata, role below institution, orange bullet markers with periwinkle body text, sparse full-viewport spacing — all mapped to existing `portfolio.css` rules
- `ideas/Portfolio v4.html`: class names and spacing rhythm preserved via `tl-section-tag`, `tl-panel`, `tl-sep`, `tl-org`, `tl-title`, `tl-bullets`
- Content remains resume-backed from `public/resume.pdf` (no placeholder copy from the HTML reference)

Closes #161

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined visual layout and styling structure for timeline section entries, improving the visual hierarchy and organization of metadata, roles, and section labels on desktop.

* **Tests**
  * Updated test suite to verify new UI class structure and hierarchy implementation for timeline components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->