### PR TITLE
Hero: CTA buttons and background line grid

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -118,7 +118,7 @@ describe('App shell', () => {
     const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener')
 
     const { unmount } = render(<App />)
-    const dotGrid = document.querySelector('[data-testid="hero-dot-grid"]') as HTMLElement
+    const lineGrid = document.querySelector('[data-testid="hero-grid"]') as HTMLElement
     const homeSection = document.getElementById('home') as HTMLElement
 
     vi.spyOn(homeSection, 'getBoundingClientRect').mockReturnValue(rectAtTop(-120))
@@ -128,7 +128,7 @@ describe('App shell', () => {
       frameCallbacks.delete(1)
     })
 
-    expect(dotGrid.style.transform).toBe('translate3d(0, 36px, 0)')
+    expect(lineGrid.style.transform).toBe('translate3d(0, 36px, 0)')
     expect(addEventListenerSpy).toHaveBeenCalledWith('scroll', expect.any(Function), { passive: true })
     expect(addEventListenerSpy).toHaveBeenCalledWith('resize', expect.any(Function), { passive: true })
 

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -98,12 +98,13 @@ describe('HeroSection', () => {
     expect(content).toHaveClass('pt-16')
   })
 
-  it('marks the dot grid as a slow parallax layer', () => {
+  it('marks the line grid as a slow parallax layer', () => {
     render(<HeroSection />)
-    const dotGrid = screen.getByTestId('hero-dot-grid')
+    const lineGrid = screen.getByTestId('hero-grid')
 
-    expect(dotGrid).toHaveAttribute('data-parallax')
-    expect(dotGrid).toHaveAttribute('data-parallax-factor', '0.3')
+    expect(lineGrid).toHaveClass('hero-grid')
+    expect(lineGrid).toHaveAttribute('data-parallax')
+    expect(lineGrid).toHaveAttribute('data-parallax-factor', '0.3')
   })
 
   it('value prop is empty initially', () => {
@@ -292,7 +293,7 @@ describe('HeroSection', () => {
     expect(viewResume).toHaveAttribute('rel', 'noopener noreferrer')
   })
 
-  it('VIEW_WORK uses filled tangerine style, VIEW_RESUME uses outlined style', () => {
+  it('VIEW_WORK uses btn btn-fill, VIEW_RESUME uses btn btn-outline', () => {
     render(<HeroSection />)
 
     advanceToValuePropComplete()
@@ -300,10 +301,21 @@ describe('HeroSection', () => {
     const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
     const viewResume = screen.getByRole('link', { name: /VIEW_RESUME →/i })
 
-    expect(viewWork).toHaveClass('bg-atomic-tangerine')
-    expect(viewWork).toHaveClass('text-graphite')
-    expect(viewResume).toHaveClass('border-atomic-tangerine')
-    expect(viewResume).toHaveClass('text-atomic-tangerine')
+    expect(viewWork).toHaveClass('btn')
+    expect(viewWork).toHaveClass('btn-fill')
+    expect(viewResume).toHaveClass('btn')
+    expect(viewResume).toHaveClass('btn-outline')
+  })
+
+  it('wraps CTAs in hero-cta after value prop completes', () => {
+    render(<HeroSection />)
+
+    advanceToValuePropComplete()
+
+    const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
+    const ctaRow = viewWork.parentElement
+
+    expect(ctaRow).toHaveClass('hero-cta')
   })
 
   it('rotating role stays stopped until both name lines finish typing', () => {

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -31,10 +31,10 @@ const HeroSection: React.FC = () => {
     <StickySection id="home" className="relative flex flex-col justify-center bg-graphite">
       <div className="absolute inset-0 pointer-events-none">
         <div
-          data-testid="hero-dot-grid"
+          data-testid="hero-grid"
           data-parallax
           data-parallax-factor="0.3"
-          className="absolute inset-0 bg-[radial-gradient(#3A3B3A_1px,transparent_1px)] bg-[size:20px_20px]"
+          className="hero-grid"
         ></div>
       </div>
 
@@ -111,21 +111,18 @@ const HeroSection: React.FC = () => {
             animate="visible"
             variants={ctaVariants}
             transition={{ duration: CTA_FADE_DURATION }}
-            className="flex gap-4"
+            className="hero-cta"
           >
-            <a
-              href="#projects"
-              className="inline-block px-6 py-2 bg-atomic-tangerine text-graphite text-sm font-body hover:bg-atomic-tangerine/90 transition-colors duration-200"
-            >
-              VIEW_WORK →
+            <a href="#projects" className="btn btn-fill">
+              VIEW_WORK <span>→</span>
             </a>
             <a
               href="/resume.pdf"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-block px-6 py-2 border border-atomic-tangerine text-atomic-tangerine text-sm font-body hover:bg-atomic-tangerine/10 transition-colors duration-200"
+              className="btn btn-outline"
             >
-              VIEW_RESUME →
+              VIEW_RESUME <span>→</span>
             </a>
           </motion.div>
         )}


### PR DESCRIPTION
## Purpose
Wire the hero section to the portfolio.css design tokens for the background grid and CTA buttons, matching the reference layout from `ideas/Portfolio.html`.

## What it does
- Replaces the Tailwind dot-grid background with the `hero-grid` line grid (radial mask fade from the left)
- Applies `btn btn-fill` and `btn btn-outline` to the VIEW_WORK and VIEW_RESUME CTAs
- Wraps the CTA row in `hero-cta`
- Keeps CTAs gated until the value-prop TypeIn finishes

## Changes made
- `HeroSection.tsx`: swap dot grid for `hero-grid`, use portfolio button classes and arrow `<span>` hover animation
- `HeroSection.test.tsx`: assert `hero-grid`, `hero-cta`, `btn-fill`, and `btn-outline` classes
- `App.test.tsx`: update parallax test to target `hero-grid`

## Additional notes
CSS rules (`hero-grid`, `hero-cta`, `btn`, `btn-fill`, `btn-outline`) were already present in `src/portfolio.css` from #180.

Closes #181

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated hero section grid visual element
  * Refined call-to-action button styles and structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->