### PR TITLE
Skills: bento grid layout and tile visual hierarchy

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -55,6 +55,7 @@ vi.mock('framer-motion', async () => {
           transition,
           variants,
           whileHover,
+          'data-testid': domProps['data-testid'],
         })
       }
 
@@ -71,19 +72,8 @@ vi.mock('framer-motion', async () => {
   }
 })
 
-function getExplicitGridRows() {
-  const grid = screen.getByTestId('skills-grid')
-  const rowsClass = Array.from(grid.classList).find(className => className.includes('grid-rows-['))
-  expect(rowsClass).toBeDefined()
-
-  const match = rowsClass!.match(/grid-rows-\[(.+)\]/)
-  expect(match).not.toBeNull()
-
-  return match![1].split('_')
-}
-
 function getSkillTile(name: string) {
-  const tile = screen.getByText(name).closest('div')
+  const tile = screen.getByText(name).closest('.bi')
   expect(tile).not.toBeNull()
   return tile!
 }
@@ -94,9 +84,9 @@ function getSkillAnimation(name: string) {
   return animation!
 }
 
-function getLatestGridAnimation() {
-  const gridAnimations = motionMock.divProps.filter(props => props.text === '')
-  const animation = gridAnimations[gridAnimations.length - 1]
+function getGridAnimation() {
+  const animations = motionMock.divProps.filter(props => props['data-testid'] === 'skills-grid')
+  const animation = animations[animations.length - 1]
   expect(animation).toBeDefined()
   return animation!
 }
@@ -104,7 +94,7 @@ function getLatestGridAnimation() {
 function getLatestTileRevealOrder() {
   return motionMock.divProps
     .filter(props => props.text !== undefined && props.text !== '')
-    .slice(-22)
+    .slice(-12)
     .map(props => [props.text, props.custom])
 }
 
@@ -122,17 +112,13 @@ describe('SkillsSection', () => {
     expect(section!.tagName.toLowerCase()).toBe('section')
   })
 
-  it('renders all required skill names', () => {
+  it('renders bento skill tiles from the reference layout', () => {
     render(<SkillsSection />)
     const required = [
-      'Python', 'TypeScript', 'JavaScript', 'C / C++', 'SQL',
-      'PyTorch', 'Hugging Face', 'Scikit-learn',
-      'FastAPI',
-      'Docker', 'Git', 'Ansible', 'Linux',
+      'Python', 'TypeScript', 'JavaScript', 'C / C++',
+      'Docker', 'Git',
       'NumPy', 'Pandas',
-      'Transformers', 'Attention Mechanisms', 'Gradient Optimization', 'Model Training / Fine-tuning',
-      'Matplotlib', 'Mixed-Precision Training',
-      'Jupyter',
+      'FastAPI', 'PyTorch', 'Hugging Face', 'Scikit-learn',
     ]
     for (const skill of required) {
       expect(screen.getByText(skill)).toBeInTheDocument()
@@ -147,79 +133,85 @@ describe('SkillsSection', () => {
     }
   })
 
-  it('renders 22 skill tiles (15 original + 7 new from resume)', () => {
+  it('grid container has class bento', () => {
+    render(<SkillsSection />)
+    const grid = screen.getByTestId('skills-grid')
+    expect(grid).toHaveClass('bento')
+  })
+
+  it('renders 12 skill tiles and 1 palette tile with bi class', () => {
     render(<SkillsSection />)
 
     const categoryLabels = screen.getAllByText(/^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/)
-    expect(categoryLabels).toHaveLength(22)
+    expect(categoryLabels).toHaveLength(12)
 
-    const gridContainer = document.querySelector('.grid')
-    const children = gridContainer?.children || []
-    expect(children.length).toBe(22)
+    const biTiles = document.querySelectorAll('.bi')
+    expect(biTiles).toHaveLength(13)
   })
 
-  it('desktop grid uses 6-column bento layout (md:grid-cols-6)', () => {
+  it('section header uses hscroll classes with orange slash and pixel font name', () => {
     render(<SkillsSection />)
-    const grid = screen.getByTestId('skills-grid')
-    expect(grid.classList).toContain('md:grid-cols-6')
+
+    expect(document.querySelector('.hscroll-head')).toBeInTheDocument()
+    expect(document.querySelector('.hscroll-no')?.textContent).toBe('// 02')
+    expect(document.querySelector('.hscroll-name')?.textContent).toBe('SKILLS')
+    expect(document.querySelector('.hscroll-rule')).toBeInTheDocument()
   })
 
-  it('mobile grid uses 2-column bento layout (grid-cols-2)', () => {
+  it('each skill tile has bi, bi-{area}, and c-{color} classes', () => {
     render(<SkillsSection />)
-    const grid = screen.getByTestId('skills-grid')
-    expect(grid.classList).toContain('grid-cols-2')
+
+    expect(getSkillTile('Python').className).toMatch(/\bbi\b/)
+    expect(getSkillTile('Python').className).toContain('bi-py')
+    expect(getSkillTile('Python').className).toContain('c-orange')
+    expect(getSkillTile('Python').className).toContain('bi-lg')
+
+    expect(getSkillTile('TypeScript').className).toContain('bi-js')
+    expect(getSkillTile('TypeScript').className).toContain('c-blue')
+
+    expect(getSkillTile('Docker').className).toContain('bi-dk')
+    expect(getSkillTile('Docker').className).toContain('c-platinum')
+
+    expect(getSkillTile('JavaScript').className).toContain('bi-re')
+    expect(getSkillTile('C / C++').className).toContain('bi-cc')
+    expect(getSkillTile('NumPy').className).toContain('bi-nd')
+    expect(getSkillTile('FastAPI').className).toContain('bi-nx')
+    expect(getSkillTile('PyTorch').className).toContain('bi-fl')
+    expect(getSkillTile('Hugging Face').className).toContain('bi-gt')
+    expect(getSkillTile('Scikit-learn').className).toContain('bi-pg')
+    expect(getSkillTile('Pandas').className).toContain('bi-fg')
+    expect(getSkillTile('Git').className).toContain('bi-mn')
   })
 
-  it('desktop grid has varied row heights creating asymmetric bento rhythm', () => {
+  it('uses bi-cat and bi-name hierarchy inside each tile', () => {
     render(<SkillsSection />)
-    const heights = getExplicitGridRows()
-    expect(new Set(heights).size).toBeGreaterThanOrEqual(2)
+
+    const pythonTile = getSkillTile('Python')
+    expect(pythonTile.querySelector('.bi-cat')?.textContent).toBe('LANGUAGE')
+    expect(pythonTile.querySelector('.bi-name')?.textContent).toBe('Python')
   })
 
-  it('at least two tiles cross the center column with md:col-span-3 on desktop', () => {
+  it('renders palette swatch tile in bottom-right grid area', () => {
     render(<SkillsSection />)
-    const grid = screen.getByTestId('skills-grid')
-    const tilesWithColSpan3 = Array.from(grid.children).filter(
-      el => el.className.includes('md:col-span-3')
-    )
-    expect(tilesWithColSpan3.length).toBeGreaterThanOrEqual(2)
+
+    const palette = screen.getByTestId('skills-palette')
+    expect(palette).toHaveClass('bi')
+    expect(palette).toHaveClass('bi-pal')
+    expect(palette.querySelectorAll('.pswatch')).toHaveLength(4)
   })
 
-  it('TypeScript tile spans 2 columns on desktop (md:col-span-2) to break repetitive right-side pattern', () => {
+  it('Python dominates top-left with bi-py and bi-lg', () => {
     render(<SkillsSection />)
-    const tsTile = screen.getByText('TypeScript').closest('div')
-    expect(tsTile).not.toBeNull()
-    expect(tsTile!.className).toContain('md:col-span-2')
-  })
-
-  it('Python tile spans at least 3 rows on desktop (md:row-span-3 or higher)', () => {
-    render(<SkillsSection />)
-    const pythonTile = screen.getByText('Python').closest('div')
-    expect(pythonTile).not.toBeNull()
-    expect(pythonTile!.className).toMatch(/md:row-span-[3-9]/)
-  })
-
-  it('anchor skills (Python, PyTorch) have visibly stronger layout weight with larger spans', () => {
-    render(<SkillsSection />)
-    
-    // Python should be the largest tile (3 cols × 3 rows)
-    const pythonTile = screen.getByText('Python').closest('div')
-    expect(pythonTile).not.toBeNull()
-    expect(pythonTile!.className).toContain('md:col-span-3')
-    expect(pythonTile!.className).toContain('md:row-span-3')
-    
-    // PyTorch should be second largest (3 cols × 2 rows)
-    const pytorchTile = screen.getByText('PyTorch').closest('div')
-    expect(pytorchTile).not.toBeNull()
-    expect(pytorchTile!.className).toContain('md:col-span-3')
-    expect(pytorchTile!.className).toContain('md:row-span-2')
+    const pythonTile = getSkillTile('Python')
+    expect(pythonTile.className).toContain('bi-py')
+    expect(pythonTile.className).toContain('bi-lg')
   })
 
   it('reveals larger anchor skill tiles before smaller supporting tiles', () => {
     render(<SkillsSection />)
 
     expect(getSkillAnimation('Python').custom).toBeLessThan(getSkillAnimation('Docker').custom as number)
-    expect(getSkillAnimation('PyTorch').custom).toBeLessThan(getSkillAnimation('FastAPI').custom as number)
+    expect(getSkillAnimation('PyTorch').custom).toBeLessThan(getSkillAnimation('Git').custom as number)
   })
 
   it('assigns every skill tile one deterministic reveal position across renders', () => {
@@ -238,50 +230,8 @@ describe('SkillsSection', () => {
       .filter(props => props.text !== undefined && props.text !== '')
       .map(props => [props.text, props.custom])
 
-    expect(new Set(firstOrder.map(([, order]) => order)).size).toBe(22)
+    expect(new Set(firstOrder.map(([, order]) => order)).size).toBe(12)
     expect(firstOrder).toEqual(secondOrder)
-  })
-
-  it('grid defines at least 11 explicit rows to accommodate all skill tiles', () => {
-    render(<SkillsSection />)
-    const heights = getExplicitGridRows()
-    expect(heights.length).toBeGreaterThanOrEqual(11)
-  })
-
-  it('new resume skills keep an asymmetric desktop layout', () => {
-    render(<SkillsSection />)
-
-    expect(getSkillTile('Transformers').className).toContain('md:col-span-2')
-    expect(getSkillTile('Attention Mechanisms').className).toContain('md:col-span-2')
-    expect(getSkillTile('Gradient Optimization').className).toContain('md:col-span-2')
-    expect(getSkillTile('Model Training / Fine-tuning').className).toContain('md:col-span-3')
-    expect(getSkillTile('Matplotlib').className).not.toContain('md:col-span-2')
-    expect(getSkillTile('Mixed-Precision Training').className).toContain('md:col-span-2')
-    expect(getSkillTile('Jupyter').className).not.toContain('md:col-span-3')
-  })
-
-  it('grid container has min-h-screen or min-h-svh class', () => {
-    render(<SkillsSection />)
-    const grid = screen.getByTestId('skills-grid')
-    const hasMinHeight = grid.classList.contains('min-h-screen') || 
-                         grid.classList.contains('min-h-svh')
-    expect(hasMinHeight).toBe(true)
-  })
-
-  it('grid rows use fr units instead of fixed px values', () => {
-    render(<SkillsSection />)
-    const rows = getExplicitGridRows()
-
-    expect(rows.every(row => /^(\d+|\d*\.\d+)fr$/.test(row))).toBe(true)
-  })
-
-  it('grid spans full-width section (no max-w constraint)', () => {
-    render(<SkillsSection />)
-    const grid = screen.getByTestId('skills-grid')
-
-    expect(grid.parentElement).not.toBeNull()
-    expect(grid.parentElement!.classList).not.toContain('max-w-7xl')
-    expect(grid.parentElement!.classList).toContain('w-full')
   })
 
   it('skill tiles use sharp edges (no rounded corners)', () => {
@@ -294,32 +244,12 @@ describe('SkillsSection', () => {
     }
   })
 
-  it('no accent tile renders at bottom of grid', () => {
+  it('palette tile is the last grid child', () => {
     render(<SkillsSection />)
 
-    const gridContainer = document.querySelector('.grid')
-    const children = Array.from(gridContainer?.children || [])
-
-    const lastChild = children[children.length - 1]
-    expect(lastChild.textContent).toContain('Jupyter')
-    expect(lastChild.textContent).not.toMatch(/^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/)
-
-    const allSkills = [
-      'Python', 'TypeScript', 'JavaScript', 'C / C++', 'SQL',
-      'PyTorch', 'Hugging Face', 'Scikit-learn',
-      'FastAPI', 'Docker', 'Git', 'Ansible', 'Linux',
-      'NumPy', 'Pandas',
-      'Transformers', 'Attention Mechanisms', 'Gradient Optimization', 'Model Training / Fine-tuning',
-      'Matplotlib', 'Mixed-Precision Training', 'Jupyter',
-    ]
-
-    const allHaveCategoryOrSkill = children.every(child => {
-      const text = child.textContent || ''
-      const isCategory = /^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/.test(text)
-      const isKnownSkill = allSkills.some(skill => text.includes(skill))
-      return isCategory || isKnownSkill
-    })
-    expect(allHaveCategoryOrSkill).toBe(true)
+    const grid = screen.getByTestId('skills-grid')
+    const children = Array.from(grid.children)
+    expect(children[children.length - 1]).toHaveAttribute('data-testid', 'skills-palette')
   })
 
   it('tiles animate from hidden opacity and scale to visible opacity and scale', () => {
@@ -327,7 +257,7 @@ describe('SkillsSection', () => {
 
     const tileAnimations = motionMock.divProps.filter(props => props.text !== undefined && props.text !== '')
 
-    expect(tileAnimations).toHaveLength(22)
+    expect(tileAnimations).toHaveLength(12)
 
     for (const tileAnimation of tileAnimations) {
       const variants = tileAnimation.variants as {
@@ -353,7 +283,7 @@ describe('SkillsSection', () => {
 
     render(<SkillsSection />)
 
-    const gridAnimation = motionMock.divProps.find(props => props.text === '')
+    const gridAnimation = getGridAnimation()
 
     expect(gridAnimation).toMatchObject({
       animate: 'visible',
@@ -372,7 +302,7 @@ describe('SkillsSection', () => {
   it('keeps tile animation hidden until the skills grid enters the viewport', () => {
     render(<SkillsSection />)
 
-    const gridAnimation = getLatestGridAnimation()
+    const gridAnimation = getGridAnimation()
 
     expect(gridAnimation).toMatchObject({
       animate: 'hidden',
@@ -385,17 +315,17 @@ describe('SkillsSection', () => {
     const { rerender } = render(<SkillsSection />)
 
     const firstRevealOrder = getLatestTileRevealOrder()
-    expect(getLatestGridAnimation()).toMatchObject({ animate: 'visible' })
+    expect(getGridAnimation()).toMatchObject({ animate: 'visible' })
 
     motionMock.isInView = false
     rerender(<SkillsSection />)
 
-    expect(getLatestGridAnimation()).toMatchObject({ animate: 'hidden' })
+    expect(getGridAnimation()).toMatchObject({ animate: 'hidden' })
 
     motionMock.isInView = true
     rerender(<SkillsSection />)
 
-    expect(getLatestGridAnimation()).toMatchObject({ animate: 'visible' })
+    expect(getGridAnimation()).toMatchObject({ animate: 'visible' })
     expect(getLatestTileRevealOrder()).toEqual(firstRevealOrder)
   })
 })

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -26,105 +26,73 @@ const tileVariants = {
 }
 
 type Category = 'LANGUAGE' | 'FRAMEWORK' | 'TOOL' | 'ML / DL' | 'DATA'
+type TileColor = 'orange' | 'blue' | 'fuchsia' | 'peri' | 'dark' | 'platinum' | 'yellow'
 
 interface SkillTile {
+  area: string
   category: Category
   name: string
-  colSpan: string
-  rowSpan: string
-  bg: string
-  fg: string
+  color: TileColor
+  large?: boolean
 }
 
-// Desktop (6-col, 11 rows — no two adjacent rows share the same span pattern):
-//   R1: Python(2) TypeScript(2)                    [2,2]
-//   R2: Python(2) Docker(1) C/C++(1)               [2,1,1]
-//   R3: Python(2) JavaScript(2)                    [2,2]
-//   R4: FastAPI(1) PyTorch(3)                      [1,3]
-//   R5: NumPy(2) Pandas(1) Ansible(1)              [2,1,1]
-//   R6: NumPy(2) HuggingFace(2)                    [2,2]
-//   R7: Scikit-learn(3) Linux(1)                   [3,1]
-//   R8: Git(1) SQL(3)                               [1,3]
-//   R9: Transformers(2) Attention Mechanisms(1) Gradient Opt(1) [2,1,1]
-//   R10: Model Training(3) Gradient Opt(1)        [3,1]
-//   R11: Matplotlib(1) Mixed-Precision(2) Jupyter(1) [1,2,1]
-//
-// Mobile (2-col):
-//   R1: Python(2)
-//   R2: Python(2)
-//   R3: TypeScript(1) Docker(1)
-//   R4: TypeScript(1) C/C++(1)
-//   R5: JavaScript(1) FastAPI(1)
-//   R6: PyTorch(2)
-//   R7: NumPy(1) Pandas(1)
-//   R8: NumPy(1) Ansible(1)
-//   R9: HuggingFace(1) Scikit-learn(1)
-//   R10: Linux(1) Git(1)
-//   R11: SQL(2)
-//   R12: Transformers(1) Attention Mechanisms(1)
-//   R13: Gradient Opt(1) Model Training(1)
-//   R14: Matplotlib(1) Mixed-Precision(1)
-//   R15: Jupyter(2)
 const tiles: SkillTile[] = [
-  { category: 'LANGUAGE',  name: 'Python',       colSpan: 'col-span-2 md:col-span-3',          rowSpan: 'row-span-2 md:row-span-3', bg: '#FF8547', fg: '#050609' },
-  { category: 'LANGUAGE',  name: 'TypeScript',   colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-2 md:row-span-2', bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'TOOL',      name: 'Docker',       colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
-  { category: 'LANGUAGE',  name: 'C / C++',      colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'LANGUAGE',  name: 'JavaScript',   colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
-  { category: 'FRAMEWORK', name: 'FastAPI',      colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'ML / DL',   name: 'PyTorch',      colSpan: 'col-span-2 md:col-span-3',          rowSpan: 'row-span-1 md:row-span-2', bg: '#FFC857', fg: '#050609' },
-  { category: 'DATA',      name: 'NumPy',        colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'DATA',      name: 'Pandas',       colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'TOOL',      name: 'Ansible',      colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Hugging Face', colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Scikit-learn', colSpan: 'col-span-1 md:col-span-3',          rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
-  { category: 'TOOL',      name: 'Linux',        colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
-  { category: 'TOOL',      name: 'Git',          colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#FF8547', fg: '#050609' },
-  { category: 'LANGUAGE',  name: 'SQL',          colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#5200E0', fg: '#EFF1F3' },
-  { category: 'ML / DL',   name: 'Transformers', colSpan: 'col-span-1 md:col-span-2',          rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Attention Mechanisms', colSpan: 'col-span-1 md:col-span-2',  rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Gradient Optimization', colSpan: 'col-span-1 md:col-span-2', rowSpan: 'row-span-1',               bg: '#FFC857', fg: '#050609' },
-  { category: 'ML / DL',   name: 'Model Training / Fine-tuning', colSpan: 'col-span-1 md:col-span-3', rowSpan: 'row-span-1',        bg: '#FFC857', fg: '#050609' },
-  { category: 'DATA',      name: 'Matplotlib',   colSpan: 'col-span-1',                        rowSpan: 'row-span-1',               bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'DATA',      name: 'Mixed-Precision Training', colSpan: 'col-span-1 md:col-span-2', rowSpan: 'row-span-1',            bg: '#E0007F', fg: '#EFF1F3' },
-  { category: 'TOOL',      name: 'Jupyter',      colSpan: 'col-span-2',                        rowSpan: 'row-span-1',               bg: '#EFF1F3', fg: '#2A2B2A' },
+  { area: 'py', category: 'LANGUAGE', name: 'Python', color: 'orange', large: true },
+  { area: 'js', category: 'LANGUAGE', name: 'TypeScript', color: 'blue' },
+  { area: 'dk', category: 'TOOL', name: 'Docker', color: 'platinum' },
+  { area: 're', category: 'LANGUAGE', name: 'JavaScript', color: 'peri' },
+  { area: 'cc', category: 'LANGUAGE', name: 'C / C++', color: 'fuchsia' },
+  { area: 'nd', category: 'DATA', name: 'NumPy', color: 'blue' },
+  { area: 'nx', category: 'FRAMEWORK', name: 'FastAPI', color: 'orange' },
+  { area: 'fl', category: 'ML / DL', name: 'PyTorch', color: 'yellow' },
+  { area: 'gt', category: 'ML / DL', name: 'Hugging Face', color: 'yellow' },
+  { area: 'pg', category: 'ML / DL', name: 'Scikit-learn', color: 'yellow' },
+  { area: 'fg', category: 'DATA', name: 'Pandas', color: 'fuchsia' },
+  { area: 'mn', category: 'TOOL', name: 'Git', color: 'dark' },
 ]
 
-function getResponsiveSpan(span: string, axis: 'col' | 'row') {
-  const mdMatch = span.match(new RegExp(`md:${axis}-span-(\\d+)`))
-  if (mdMatch) return Number(mdMatch[1])
+const REVEAL_ORDER = ['py', 'js', 'dk', 're', 'cc', 'nd', 'nx', 'fl', 'gt', 'pg', 'fg', 'mn', 'pal'] as const
 
-  const baseMatch = span.match(new RegExp(`${axis}-span-(\\d+)`))
-  return baseMatch ? Number(baseMatch[1]) : 1
-}
-
-function getTileArea(tile: SkillTile) {
-  return getResponsiveSpan(tile.colSpan, 'col') * getResponsiveSpan(tile.rowSpan, 'row')
-}
-
-const revealOrderByName = new Map(
-  [...tiles]
-    .sort((a, b) => getTileArea(b) - getTileArea(a) || tiles.indexOf(a) - tiles.indexOf(b))
-    .map((tile, index) => [tile.name, index]),
+const revealOrderByArea = new Map<string, number>(
+  REVEAL_ORDER.map((area, index) => [area, index]),
 )
 
+const PALETTE = [
+  'var(--color-atomic-tangerine)',
+  'var(--color-golden-pollen)',
+  'var(--color-fuchsia-flame)',
+  'var(--color-ultrasonic-blue)',
+] as const
+
 function SkillTileCard({ tile }: { tile: SkillTile }) {
-  const revealOrder = revealOrderByName.get(tile.name) ?? 0
+  const revealOrder = revealOrderByArea.get(tile.area) ?? 0
 
   return (
     <motion.div
       variants={tileVariants}
       custom={revealOrder}
       whileHover="hover"
-      className={`${tile.colSpan} ${tile.rowSpan} min-h-24 md:min-h-0 p-5 flex flex-col justify-between cursor-default`}
-      style={{ backgroundColor: tile.bg, color: tile.fg }}
+      className={`bi bi-${tile.area} c-${tile.color}${tile.large ? ' bi-lg' : ''}`}
     >
-      <span className="text-xs uppercase tracking-widest font-body">
-        {tile.category}
-      </span>
-      <span className="font-body font-bold text-lg leading-tight mt-4">
-        {tile.name}
-      </span>
+      <div className="bi-cat">{tile.category}</div>
+      <div className="bi-name">{tile.name}</div>
+    </motion.div>
+  )
+}
+
+function PaletteTile() {
+  const revealOrder = revealOrderByArea.get('pal') ?? 12
+
+  return (
+    <motion.div
+      variants={tileVariants}
+      custom={revealOrder}
+      className="bi bi-pal"
+      data-testid="skills-palette"
+    >
+      {PALETTE.map((color, index) => (
+        <div key={index} className="pswatch" style={{ background: color }} />
+      ))}
     </motion.div>
   )
 }
@@ -136,10 +104,10 @@ export function SkillsSection() {
   return (
     <StickySection id="skills" className="flex flex-col justify-center py-14 px-8 bg-graphite">
       <div className="w-full">
-        <div className="flex items-center gap-3 mb-12">
-          <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 02</span>
-          <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">SKILLS</span>
-          <hr className="flex-1 border-periwinkle/20" />
+        <div className="hscroll-head">
+          <span className="hscroll-no">// 02</span>
+          <span className="hscroll-name">SKILLS</span>
+          <div className="hscroll-rule" />
         </div>
 
         <motion.div
@@ -148,11 +116,12 @@ export function SkillsSection() {
           variants={gridStagger}
           initial="hidden"
           animate={isInView ? 'visible' : 'hidden'}
-          className="grid grid-cols-2 md:grid-cols-6 gap-3 min-h-screen md:grid-rows-[1fr_1.1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr_1fr]"
+          className="bento"
         >
           {tiles.map((tile) => (
-            <SkillTileCard key={tile.name} tile={tile} />
+            <SkillTileCard key={tile.area} tile={tile} />
           ))}
+          <PaletteTile />
         </motion.div>
       </div>
     </StickySection>


### PR DESCRIPTION
## Purpose
Align the Skills section with the reference bento mosaic: six-column `grid-template-areas`, portfolio tile classes, and consistent section header typography.

## What it does
Renders 12 skills in the reference bento grid (Python dominant top-left) plus a four-swatch palette tile, using `portfolio.css` classes instead of Tailwind grid spans.

## Changes made
- **SkillsSection**: grid container uses `bento`; each tile uses `bi bi-{area} c-{color}` with `bi-cat` / `bi-name` hierarchy and `bi-lg` on Python
- **Header**: `// 02  SKILLS` via `hscroll-head`, `hscroll-no`, `hscroll-name`, `hscroll-rule`
- **Palette**: `bi-pal` tile with four `pswatch` cells in the bottom-right area
- **Reveal**: deterministic largest-first order per PRD (`py` → `pal`)
- **Tests**: updated for bento/bi class assertions (RGR)

## Additional notes
`portfolio.css` already contained the bento rules from `ideas/Portfolio.html`; this PR wires the React component to them. Remaining resume skills beyond the 12 reference slots are out of scope for this layout issue.

Closes #183

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a color palette display showcasing available theme swatches in the skills section.

* **Style**
  * Redesigned the skills grid layout for improved visual organization and hierarchy.
  * Refined animations for skill tile reveal sequences.
  * Enhanced section header styling for a cleaner appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->