### PR TITLE
Contact: full-screen heading and blinking cursor

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -45,7 +45,7 @@ describe('App shell', () => {
     render(<App />)
     const section = document.getElementById(id)
     expect(section).toBeInTheDocument()
-    expect(section?.tagName.toLowerCase()).toBe('section')
+    expect(section?.tagName.toLowerCase()).toBe(id === 'contact' ? 'footer' : 'section')
   })
 
   it('renders sections in the correct order', () => {
@@ -155,8 +155,8 @@ describe('App shell', () => {
     })
 
     render(<App />)
-    const footer = document.querySelector('footer') as HTMLElement
-    const footerText = document.querySelector('footer [data-parallax]') as HTMLElement
+    const footer = document.querySelector('#footer') as HTMLElement
+    const footerText = document.querySelector('#footer [data-parallax]') as HTMLElement
 
     vi.spyOn(footer, 'getBoundingClientRect').mockReturnValue(rectAtTop(-80))
     vi.spyOn(footerText, 'getBoundingClientRect').mockReturnValue(rectAtTop(-20))

--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -24,11 +24,12 @@ describe('ContactSection', () => {
     vi.mocked(useInView).mockReturnValue(true)
     vi.useFakeTimers()
     render(<ContactSection />)
-    act(() => { vi.advanceTimersByTime(1000) })
+    act(() => { vi.advanceTimersByTime(250) })
+    act(() => { vi.advanceTimersByTime(400) })
     const section = document.querySelector('#contact') as HTMLElement
 
     expect(section).toBeInTheDocument()
-    expect(section).toHaveTextContent("LET'S CONNECT.")
+    expect(section).toHaveTextContent("LET'SCONNECT.")
 
     const links = within(section).getAllByRole('link')
     expect(links.map((link) => link.textContent)).toEqual([
@@ -47,7 +48,8 @@ describe('ContactSection', () => {
     vi.mocked(useInView).mockReturnValue(true)
     vi.useFakeTimers()
     render(<ContactSection />)
-    act(() => { vi.advanceTimersByTime(1000) })
+    act(() => { vi.advanceTimersByTime(250) })
+    act(() => { vi.advanceTimersByTime(400) })
     const sendMessageLink = screen.getByRole('link', { name: 'SEND_MESSAGE →' })
 
     expect(sendMessageLink).toHaveAttribute('href', canonicalEmailHref)
@@ -57,7 +59,8 @@ describe('ContactSection', () => {
     vi.mocked(useInView).mockReturnValue(true)
     vi.useFakeTimers()
     render(<ContactSection />)
-    act(() => { vi.advanceTimersByTime(1000) })
+    act(() => { vi.advanceTimersByTime(250) })
+    act(() => { vi.advanceTimersByTime(400) })
     const footerLinks = ['// GITHUB', '// LINKEDIN', '// EMAIL', '// RESUME'].map((name) =>
       screen.getByRole('link', { name }),
     )
@@ -74,12 +77,55 @@ describe('ContactSection', () => {
     })
   })
 
+  describe('issue #185 - full-screen contact heading', () => {
+    it('uses footer#contact as the root contact element', () => {
+      render(<ContactSection />)
+      const contact = document.querySelector('#contact')
+
+      expect(contact?.tagName.toLowerCase()).toBe('footer')
+    })
+
+    it('applies footer-big to the contact heading', () => {
+      render(<ContactSection />)
+      const heading = document.querySelector('#contact .footer-big')
+
+      expect(heading).toBeInTheDocument()
+    })
+
+    it('splits LET\'S and CONNECT. into footer-big-line spans', () => {
+      vi.mocked(useInView).mockReturnValue(true)
+      vi.useFakeTimers()
+      render(<ContactSection />)
+      act(() => { vi.advanceTimersByTime(250) })
+      act(() => { vi.advanceTimersByTime(400) })
+
+      const lines = document.querySelectorAll('#contact .footer-big-line')
+      expect(lines).toHaveLength(2)
+      expect(lines[0]).toHaveTextContent("LET'S")
+      expect(lines[1]).toHaveTextContent('CONNECT.')
+    })
+
+    it('styles the period in orange and uses a portfolio cursor block', () => {
+      vi.mocked(useInView).mockReturnValue(true)
+      vi.useFakeTimers()
+      render(<ContactSection />)
+      act(() => { vi.advanceTimersByTime(250) })
+      act(() => { vi.advanceTimersByTime(400) })
+
+      const period = document.querySelector('#contact .footer-big .period')
+      const cursor = document.querySelector('[data-testid="contact-cursor"]')
+
+      expect(period).toHaveTextContent('.')
+      expect(cursor).toHaveClass('cursor')
+    })
+  })
+
   describe('issue #87 - LET\'S CONNECT. typewriter', () => {
     it('heading is not visible when section is out of view', () => {
       vi.mocked(useInView).mockReturnValue(false)
       render(<ContactSection />)
 
-      expect(screen.queryByText("LET'S CONNECT.")).not.toBeInTheDocument()
+      expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
     })
 
     it('heading types out character by character when section enters viewport', () => {
@@ -92,9 +138,9 @@ describe('ContactSection', () => {
       act(() => { vi.advanceTimersByTime(250) })
       expect(screen.getByText("LET'S")).toBeInTheDocument()
 
-      // 14 chars × 50ms = 700ms for full text
-      act(() => { vi.advanceTimersByTime(500) })
-      expect(screen.getByText("LET'S CONNECT.")).toBeInTheDocument()
+      // 5 + 7 chars × 50ms = 600ms for full text plus period
+      act(() => { vi.advanceTimersByTime(400) })
+      expect(document.querySelector('#contact .footer-big')).toHaveTextContent("LET'SCONNECT.")
     })
 
     it('blinking cursor persists after typing completes', () => {
@@ -103,12 +149,13 @@ describe('ContactSection', () => {
 
       render(<ContactSection />)
 
-      // Wait for typing to complete: "LET'S CONNECT." = 14 chars × 50ms = 700ms + buffer
-      act(() => { vi.advanceTimersByTime(1000) })
+      // Wait for typing to complete: 12 chars × 50ms = 600ms + buffer
+      act(() => { vi.advanceTimersByTime(250) })
+      act(() => { vi.advanceTimersByTime(400) })
 
       const cursor = document.querySelector('[data-testid="contact-cursor"]')
       expect(cursor).toBeInTheDocument()
-      expect(cursor).toHaveClass('bg-atomic-tangerine')
+      expect(cursor).toHaveClass('cursor')
     })
   })
 })
@@ -117,7 +164,7 @@ describe('Footer', () => {
   it('renders a separate footer with social links and static labels', () => {
     render(<ContactSection />)
     const section = document.querySelector('#contact')
-    const footer = document.querySelector('footer')
+    const footer = document.querySelector('#footer')
 
     expect(footer).toBeInTheDocument()
     expect(section?.nextElementSibling).toBe(footer)

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -3,10 +3,8 @@ import { motion, useInView } from 'framer-motion'
 import { TypeIn } from '../animations/TypeIn'
 import { hoverEase } from '../animations/variants'
 import { StickySection } from './StickySection'
-import { cursorVariants } from './HeroSection.constants'
 
 const EMAIL = 'famohammed@shockers.wichita.edu'
-const CONTACT_HEADING = "LET'S CONNECT."
 const CONTACT_SPEED = 50
 
 const footerLinks = [
@@ -19,29 +17,34 @@ const footerLinks = [
 export default function ContactSection() {
   const ref = useRef(null)
   const isInView = useInView(ref, { once: true })
-  const [showCursor, setShowCursor] = useState(false)
+  const [step, setStep] = useState(0)
 
   return (
     <>
-      <StickySection id="contact" className="flex flex-col justify-center px-8 py-14 bg-graphite">
-        <div ref={ref} className="w-full">
-          <h2 className="font-display text-3xl md:text-5xl text-platinum leading-tight mb-12">
-            <TypeIn
-              start={isInView}
-              text={CONTACT_HEADING}
-              speed={CONTACT_SPEED}
-              onDone={() => setShowCursor(true)}
-            />
-            {showCursor && (
-              <motion.span
-                data-testid="contact-cursor"
-                aria-hidden="true"
-                className="inline-block w-[3px] h-[1.2em] bg-atomic-tangerine align-middle ml-1"
-                variants={cursorVariants}
-                animate="blink"
+      <StickySection as="footer" id="contact" className="bg-graphite">
+        <div ref={ref} className="footer-cta">
+          <div className="footer-big">
+            <span className="footer-big-line">
+              <TypeIn
+                start={isInView}
+                text="LET'S"
+                speed={CONTACT_SPEED}
+                onDone={() => setStep((s) => Math.max(s, 1))}
               />
-            )}
-          </h2>
+            </span>
+            <span className="footer-big-line">
+              <TypeIn
+                start={step >= 1}
+                text="CONNECT"
+                speed={CONTACT_SPEED}
+                onDone={() => setStep((s) => Math.max(s, 2))}
+              />
+              {step >= 2 && <span className="period">.</span>}
+              {step >= 2 && (
+                <span className="cursor" data-testid="contact-cursor" aria-hidden="true" />
+              )}
+            </span>
+          </div>
 
           <motion.a
             href={`mailto:${EMAIL}`}


### PR DESCRIPTION
## Purpose
Implement issue #185: a full-screen contact CTA with Press Start 2P typography matching the reference layout.

## What it does
- Renders the contact section as `<footer id="contact">` with centered `footer-cta` layout
- Types `LET'S` and `CONNECT` on separate `footer-big-line` spans, then reveals an orange period and blinking block cursor

## Changes made
- Updated `ContactSection` to use `footer-big`, `footer-big-line`, `period`, and `cursor` portfolio classes
- Replaced Tailwind heading styles and framer-motion cursor with the reference CSS cursor animation
- Added issue #185 test coverage and updated App/Footer tests for the new footer root element

## Additional notes
- `footer-big` / `footer-big-line` CSS was already present in `src/portfolio.css` from prior work
- Typewriter timing now runs in two phases (`LET'S` then `CONNECT`) matching `ideas/Portfolio.html`

Closes #185

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Contact section now renders as a footer element for improved semantic structure
* Contact heading animation refactored to display text in distinct typing steps
* Cursor styling and timing enhanced for better visual feedback during animation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->