### PR TITLE
Card-deck stacking: sticky depth transitions across all sections

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -36,6 +36,20 @@ function rectAtTop(top: number): DOMRect {
   }
 }
 
+function rectWithHeight(top: number, height: number): DOMRect {
+  return {
+    top,
+    right: 1000,
+    bottom: top + height,
+    left: 0,
+    width: 1000,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
 describe('App shell', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -294,6 +308,117 @@ describe('App shell', () => {
         expect(panel).toHaveClass('sticky')
         expect(panel).toHaveClass('top-0')
       })
+    })
+  })
+
+  describe('issue #187 - card-deck stacking across all sections', () => {
+    const stickyMajorSectionIds = ['home', 'skills', 'contact'] as const
+    const timelinePanelIds = ['timeline', 'timeline-a3f9d2b', 'timeline-b7c3e1a'] as const
+
+    it.each([...stickyMajorSectionIds, ...timelinePanelIds])(
+      '%s carries sticky top-0 positioning',
+      (id) => {
+        render(<App />)
+        const section = document.getElementById(id)
+
+        expect(section).toBeInTheDocument()
+        expect(section).toHaveClass('sticky')
+        expect(section).toHaveClass('top-0')
+      },
+    )
+
+    it('projects outer scroll host pins the carousel viewport at top: 0 independently', () => {
+      render(<App />)
+
+      const projects = document.getElementById('projects')
+      const stickyViewport = projects?.querySelector('[data-sticky-viewport="true"]')
+
+      expect(projects).toHaveAttribute('data-sticky-scroll-host', 'true')
+      expect(stickyViewport).toHaveClass('hscroll-sticky')
+    })
+
+    it('stack surfaces stay sharp with no blur or border-radius styling', () => {
+      render(<App />)
+
+      document.querySelectorAll('[data-sticky-section="true"]').forEach((surface) => {
+        const element = surface as HTMLElement
+
+        expect(element.className).not.toMatch(/blur|rounded/)
+        expect(element.style.filter).toBe('')
+        expect(element.style.borderRadius).toBe('')
+      })
+    })
+
+    it('scales and dims outgoing sections as the next section enters', async () => {
+      render(<App />)
+
+      const home = document.getElementById('home') as HTMLElement
+      const projects = document.getElementById('projects') as HTMLElement
+
+      vi.spyOn(projects, 'getBoundingClientRect').mockReturnValue(rectAtTop(400))
+      Object.defineProperty(window, 'innerHeight', {
+        configurable: true,
+        value: 800,
+      })
+
+      await act(async () => {
+        window.dispatchEvent(new Event('scroll'))
+      })
+
+      expect(home.style.transform).toBe('scale(0.975)')
+      expect(home.style.opacity).toBe('0.875')
+      expect(home.style.filter).toBe('')
+    })
+
+    it('clamps outgoing section depth once the next section passes the viewport top', async () => {
+      render(<App />)
+
+      const home = document.getElementById('home') as HTMLElement
+      const projects = document.getElementById('projects') as HTMLElement
+
+      vi.spyOn(projects, 'getBoundingClientRect').mockReturnValue(rectAtTop(-200))
+      Object.defineProperty(window, 'innerHeight', {
+        configurable: true,
+        value: 800,
+      })
+
+      await act(async () => {
+        window.dispatchEvent(new Event('scroll'))
+      })
+
+      expect(home.style.transform).toBe('scale(0.95)')
+      expect(home.style.opacity).toBe('0.75')
+    })
+
+    it('keeps projects carousel translateX independent from card-deck depth transforms', async () => {
+      render(<App />)
+
+      const projects = document.getElementById('projects') as HTMLElement
+      const skills = document.getElementById('skills') as HTMLElement
+      const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+
+      vi.spyOn(skills, 'getBoundingClientRect').mockReturnValue(rectAtTop(400))
+      vi.spyOn(projects, 'getBoundingClientRect').mockReturnValue(rectWithHeight(-800, 3200))
+      Object.defineProperty(window, 'innerHeight', {
+        configurable: true,
+        value: 800,
+      })
+      Object.defineProperty(carouselTrack, 'scrollWidth', {
+        configurable: true,
+        value: 2000,
+      })
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: 1000,
+      })
+
+      await act(async () => {
+        window.dispatchEvent(new Event('scroll'))
+      })
+
+      expect(projects.style.transform).toBe('scale(0.975)')
+      expect(projects.style.transform).not.toContain('translateX')
+      expect(carouselTrack.style.transform).toContain('translateX')
     })
   })
 })

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -340,11 +340,14 @@ describe('ProjectsSection', () => {
     const projectsSection = document.getElementById('projects')
     const stickyViewport = projectsSection?.querySelector('[data-sticky-viewport="true"]')
     expect(stickyViewport).toBeInTheDocument()
+    expect(stickyViewport).toHaveClass('hscroll-sticky')
+  })
 
-    const style = window.getComputedStyle(stickyViewport!)
-    expect(style.height).toBe('100vh')
-    expect(style.top).toBe('0px')
-    expect(style.position).toBe('sticky')
+  it('marks the outer projects wrapper as a card-deck scroll host', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const projectsSection = document.getElementById('projects')
+    expect(projectsSection).toHaveAttribute('data-sticky-scroll-host', 'true')
   })
 
   it('section header is outside the carousel track and remains pinned', () => {

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -43,10 +43,11 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
       ref={outerRef}
       id="projects"
       data-sticky-section="true"
+      data-sticky-scroll-host="true"
       className="relative min-h-screen px-8 bg-graphite-light origin-center transform-gpu"
       style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'hidden', willChange: 'transform, opacity' }}
     >
-      <div data-sticky-viewport="true" className="relative flex flex-col justify-center py-14" style={{ position: 'sticky', top: 0, height: '100vh' }}>
+      <div data-sticky-viewport="true" className="flex flex-col justify-center py-14 hscroll-sticky">
         <div className="w-full">
           <div className="flex items-center gap-3 mb-8">
             <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 01</span>

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -122,4 +122,24 @@ describe('portfolio.css CSS anchor', () => {
   it('anchors hero-inner horizontal padding from the reference', () => {
     expect(portfolioCss).toMatch(/\.hero-inner\{[^}]*padding:0 5vw/)
   })
+
+  it('anchors card-deck sticky stack surfaces without blur or border-radius', () => {
+    expect(portfolioCss).toContain('[data-sticky-section="true"]')
+    expect(portfolioCss).toMatch(
+      /\[data-sticky-section="true"\]:not\(\[data-sticky-scroll-host="true"\]\)\{[^}]*position:sticky/,
+    )
+    expect(portfolioCss).toMatch(
+      /\[data-sticky-section="true"\]:not\(\[data-sticky-scroll-host="true"\]\)\{[^}]*top:0/,
+    )
+    expect(portfolioCss).toMatch(
+      /\[data-sticky-section="true"\]:not\(\[data-sticky-scroll-host="true"\]\)\{[^}]*min-height:100vh/,
+    )
+    expect(portfolioCss).toMatch(
+      /\[data-sticky-section="true"\]:not\(\[data-sticky-scroll-host="true"\]\)\{[^}]*transform-origin:center/,
+    )
+    expect(portfolioCss).toContain('[data-sticky-scroll-host="true"]')
+    expect(portfolioCss).toContain('[data-sticky-viewport="true"]')
+    expect(portfolioCss).not.toMatch(/\[data-sticky-section="true"\]\{[^}]*filter:blur/)
+    expect(portfolioCss).not.toMatch(/\[data-sticky-section="true"\]\{[^}]*border-radius/)
+  })
 })

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -66,7 +66,7 @@
 
   /* ─── HORIZONTAL SCROLL SCAFFOLD ──── */
   .hscroll{position:relative;width:100vw;height:100%}
-  .hscroll-sticky{position:sticky;top:0;height:100vh;width:100vw;overflow:hidden;display:flex;flex-direction:column}
+  .hscroll-sticky,[data-sticky-viewport="true"]{position:sticky;top:0;height:100vh;width:100vw;overflow:hidden;display:flex;flex-direction:column}
   .hscroll-head{padding:74px 5vw 18px;display:flex;align-items:center;gap:18px;flex-shrink:0}
   .hscroll-no{font-size:14px;color:var(--color-atomic-tangerine);letter-spacing:3px}
   .hscroll-name{font-family:var(--font-display);font-size:18px;color:var(--color-platinum);letter-spacing:3px}
@@ -255,6 +255,10 @@
 
   /* parallax layers — transform driven by scrollY * factor in JS */
   [data-parallax]{will-change:transform}
+
+  /* ─── CARD-DECK STACK ──── */
+  [data-sticky-section="true"]:not([data-sticky-scroll-host="true"]){position:sticky;top:0;min-height:100vh;transform-origin:center center;will-change:transform,opacity}
+  [data-sticky-scroll-host="true"]{transform-origin:center center;will-change:transform,opacity}
 
   /* persistent title cursor (uses currentColor so it matches whichever text it sits next to) */
   .title-cursor{display:inline-block;width:.55ch;height:.9em;background:currentColor;vertical-align:-.13em;margin-left:6px;animation:blink-cursor 1.05s steps(1) infinite}


### PR DESCRIPTION
## Purpose

Complete issue #187 by anchoring card-deck stacking behavior in CSS and locking acceptance criteria with integration tests across the full section stack.

## What it does

Each major section (Hero, Skills, Timeline panels, Contact) sticks at `top: 0` and participates in the shared card-deck depth stack. As the next section scrolls in, the outgoing section scales toward 0.95 and dims toward 0.75 opacity via `useCardDeckDepth`. Section surfaces remain sharp — no blur and no border-radius.

## Changes made

- Added card-deck stack CSS anchors in `src/portfolio.css` for `[data-sticky-section]` surfaces and the Projects inner sticky viewport
- Marked the Projects outer wrapper as `data-sticky-scroll-host` so it participates in card-deck depth while the inner `hscroll-sticky` viewport pins the carousel independently
- Added issue #187 acceptance tests in `App.test.tsx` covering sticky positioning, depth transitions, sharp surfaces, and carousel independence
- Extended `portfolio-css.test.ts` and `ProjectsSection.test.tsx` for the new CSS and scroll-host contract

## Additional notes

- Depth scale/opacity transitions remain driven by `useCardDeckDepth` on scroll; CSS owns sticky positioning and transform origin
- Projects horizontal carousel translateX is applied only to the inner track, not the outer stack surface transform

Closes #187


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved sticky section stacking and scroll behavior across portfolio sections
  * Enhanced projects section horizontal scrolling layout
  * Refined visual transitions and depth effects during scroll interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->