### PR TITLE
Contact: CTA button, social links, and footer metadata

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,7 +11,6 @@ const sectionIds = [
   'timeline-a3f9d2b',
   'timeline-b7c3e1a',
   'contact',
-  'footer',
 ] as const
 const timelinePanelIds = ['timeline', 'timeline-a3f9d2b', 'timeline-b7c3e1a']
 const shellConstraintClasses = ['container', 'max-w-7xl', 'mx-auto'] as const
@@ -169,8 +168,8 @@ describe('App shell', () => {
     })
 
     render(<App />)
-    const footer = document.querySelector('#footer') as HTMLElement
-    const footerText = document.querySelector('#footer [data-parallax]') as HTMLElement
+    const footer = document.querySelector('#contact') as HTMLElement
+    const footerText = document.querySelector('#contact .footer-copy [data-parallax]') as HTMLElement
 
     vi.spyOn(footer, 'getBoundingClientRect').mockReturnValue(rectAtTop(-80))
     vi.spyOn(footerText, 'getBoundingClientRect').mockReturnValue(rectAtTop(-20))

--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -10,6 +10,14 @@ vi.mock('framer-motion', async () => {
 
 const canonicalEmailHref = 'mailto:famohammed@shockers.wichita.edu'
 
+function renderWithTypingComplete() {
+  vi.mocked(useInView).mockReturnValue(true)
+  vi.useFakeTimers()
+  render(<ContactSection />)
+  act(() => { vi.advanceTimersByTime(250) })
+  act(() => { vi.advanceTimersByTime(400) })
+}
+
 describe('ContactSection', () => {
 
   beforeEach(() => {
@@ -20,61 +28,11 @@ describe('ContactSection', () => {
     vi.useRealTimers()
   })
 
-  it('renders a contact section with only the CTA heading and send message link', () => {
-    vi.mocked(useInView).mockReturnValue(true)
-    vi.useFakeTimers()
-    render(<ContactSection />)
-    act(() => { vi.advanceTimersByTime(250) })
-    act(() => { vi.advanceTimersByTime(400) })
-    const section = document.querySelector('#contact') as HTMLElement
-
-    expect(section).toBeInTheDocument()
-    expect(section).toHaveTextContent("LET'SCONNECT.")
-
-    const links = within(section).getAllByRole('link')
-    expect(links.map((link) => link.textContent)).toEqual([
-      'SEND_MESSAGE →',
-    ])
-
-    expect(section).not.toHaveTextContent('// GITHUB')
-    expect(section).not.toHaveTextContent('// LINKEDIN')
-    expect(section).not.toHaveTextContent('// EMAIL')
-    expect(section).not.toHaveTextContent('// RESUME')
-    expect(section).not.toHaveTextContent('FARHAN_MOHAMMED © 2026')
-    expect(section).not.toHaveTextContent('PORTFOLIO.EXE')
-  })
-
   it('renders the send message link with the expected destination', () => {
-    vi.mocked(useInView).mockReturnValue(true)
-    vi.useFakeTimers()
-    render(<ContactSection />)
-    act(() => { vi.advanceTimersByTime(250) })
-    act(() => { vi.advanceTimersByTime(400) })
+    renderWithTypingComplete()
     const sendMessageLink = screen.getByRole('link', { name: 'SEND_MESSAGE →' })
 
     expect(sendMessageLink).toHaveAttribute('href', canonicalEmailHref)
-  })
-
-  it('renders footer link prefixes in orange and transitions the full link to white on hover', () => {
-    vi.mocked(useInView).mockReturnValue(true)
-    vi.useFakeTimers()
-    render(<ContactSection />)
-    act(() => { vi.advanceTimersByTime(250) })
-    act(() => { vi.advanceTimersByTime(400) })
-    const footerLinks = ['// GITHUB', '// LINKEDIN', '// EMAIL', '// RESUME'].map((name) =>
-      screen.getByRole('link', { name }),
-    )
-
-    footerLinks.forEach((link) => {
-      const spans = link.querySelectorAll('span')
-      const [prefix, label] = spans
-
-      expect(link).toHaveClass('group')
-      expect(spans).toHaveLength(2)
-      expect(prefix).toHaveTextContent('//')
-      expect(prefix).toHaveClass('text-atomic-tangerine', 'group-hover:text-white', 'transition-colors')
-      expect(label).toHaveClass('text-periwinkle', 'group-hover:text-white', 'transition-colors')
-    })
   })
 
   describe('issue #185 - full-screen contact heading', () => {
@@ -93,11 +51,7 @@ describe('ContactSection', () => {
     })
 
     it('splits LET\'S and CONNECT. into footer-big-line spans', () => {
-      vi.mocked(useInView).mockReturnValue(true)
-      vi.useFakeTimers()
-      render(<ContactSection />)
-      act(() => { vi.advanceTimersByTime(250) })
-      act(() => { vi.advanceTimersByTime(400) })
+      renderWithTypingComplete()
 
       const lines = document.querySelectorAll('#contact .footer-big-line')
       expect(lines).toHaveLength(2)
@@ -106,11 +60,7 @@ describe('ContactSection', () => {
     })
 
     it('styles the period in orange and uses a portfolio cursor block', () => {
-      vi.mocked(useInView).mockReturnValue(true)
-      vi.useFakeTimers()
-      render(<ContactSection />)
-      act(() => { vi.advanceTimersByTime(250) })
-      act(() => { vi.advanceTimersByTime(400) })
+      renderWithTypingComplete()
 
       const period = document.querySelector('#contact .footer-big .period')
       const cursor = document.querySelector('[data-testid="contact-cursor"]')
@@ -158,65 +108,96 @@ describe('ContactSection', () => {
       expect(cursor).toHaveClass('cursor')
     })
   })
-})
 
-describe('Footer', () => {
-  it('renders a separate footer with social links and static labels', () => {
-    render(<ContactSection />)
-    const section = document.querySelector('#contact')
-    const footer = document.querySelector('#footer')
+  describe('issue #186 - CTA button, social links, and footer metadata', () => {
+    it('merges contact CTA, social links, and footer metadata into a single footer#contact', () => {
+      render(<ContactSection />)
 
-    expect(footer).toBeInTheDocument()
-    expect(section?.nextElementSibling).toBe(footer)
-    expect(footer).toHaveTextContent('FARHAN_MOHAMMED © 2026')
-    expect(footer).toHaveTextContent('PORTFOLIO.EXE')
-    expect(footer).toHaveTextContent('// GITHUB')
-    expect(footer).toHaveTextContent('// LINKEDIN')
-    expect(footer).toHaveTextContent('// EMAIL')
-    expect(footer).toHaveTextContent('// RESUME')
-    expect(footer).not.toHaveTextContent("LET'S CONNECT.")
-    expect(footer).not.toHaveTextContent('SEND_MESSAGE →')
-  })
+      expect(document.querySelectorAll('footer')).toHaveLength(1)
+      expect(document.querySelector('#footer')).not.toBeInTheDocument()
+      expect(document.querySelector('#contact')).toBeInTheDocument()
+    })
 
-  it('makes the compact footer a stackable sticky surface after the contact CTA', () => {
-    render(<ContactSection />)
-    const contact = document.querySelector('#contact')
-    const footer = document.querySelector('#footer')
+    it('wraps the heading, CTA button, and social links in footer-cta', () => {
+      renderWithTypingComplete()
+      const contact = document.querySelector('#contact') as HTMLElement
+      const cta = contact.querySelector('.footer-cta')
 
-    expect(footer?.tagName.toLowerCase()).toBe('footer')
-    expect(contact?.nextElementSibling).toBe(footer)
-    expect(footer).toHaveAttribute('data-sticky-section', 'true')
-    expect(footer).toHaveClass('sticky', 'top-0', 'min-h-screen')
-  })
+      expect(cta).toBeInTheDocument()
+      expect(cta?.querySelector('.footer-big')).toBeInTheDocument()
+      expect(within(contact).getByRole('link', { name: 'SEND_MESSAGE →' })).toBeInTheDocument()
+      expect(cta?.querySelector('.footer-socials')).toBeInTheDocument()
+    })
 
-  it('renders footer social links with the expected destinations', () => {
-    render(<ContactSection />)
-    const githubLink = screen.getByRole('link', { name: '// GITHUB' })
-    const linkedInLink = screen.getByRole('link', { name: '// LINKEDIN' })
-    const emailLink = screen.getByRole('link', { name: '// EMAIL' })
-    const resumeLink = screen.getByRole('link', { name: '// RESUME' })
+    it('uses btn btn-fill for the centered SEND_MESSAGE CTA', () => {
+      renderWithTypingComplete()
+      const sendMessage = screen.getByRole('link', { name: 'SEND_MESSAGE →' })
 
-    expect(githubLink).toHaveAttribute('href', 'https://github.com/Nemesis-12')
-    expect(githubLink).not.toHaveAttribute('target')
-    expect(githubLink).not.toHaveAttribute('rel')
-    expect(linkedInLink).toHaveAttribute('href', 'https://linkedin.com/in/fa-mohammed')
-    expect(linkedInLink).not.toHaveAttribute('target')
-    expect(linkedInLink).not.toHaveAttribute('rel')
-    expect(emailLink).toHaveAttribute('href', canonicalEmailHref)
-    expect(emailLink).not.toHaveAttribute('target')
-    expect(emailLink).not.toHaveAttribute('rel')
-    expect(resumeLink).toHaveAttribute('href', '/resume.pdf')
-    expect(resumeLink).toHaveAttribute('target', '_blank')
-    expect(resumeLink).toHaveAttribute('rel', 'noopener noreferrer')
-  })
+      expect(sendMessage).toHaveClass('btn', 'btn-fill')
+      expect(sendMessage.closest('.footer-cta')).toBeInTheDocument()
+    })
 
-  it('marks footer text as a stronger parallax layer', () => {
-    render(<ContactSection />)
-    const footerText = Array.from(document.querySelectorAll('footer [data-parallax]'))
+    it('renders social links with slink inside footer-socials', () => {
+      renderWithTypingComplete()
+      const socials = document.querySelector('.footer-socials') as HTMLElement
 
-    expect(footerText).toHaveLength(2)
-    footerText.forEach((item) => {
-      expect(item).toHaveAttribute('data-parallax-factor', '0.5')
+      expect(socials).toBeInTheDocument()
+      ;['GITHUB', 'LINKEDIN', 'EMAIL', 'RESUME'].forEach((label) => {
+        const link = within(socials).getByRole('link', { name: `// ${label}` })
+        expect(link).toHaveClass('slink')
+        expect(link).toHaveTextContent(label)
+      })
+    })
+
+    it('renders footer social links with the expected destinations', () => {
+      render(<ContactSection />)
+      const githubLink = screen.getByRole('link', { name: '// GITHUB' })
+      const linkedInLink = screen.getByRole('link', { name: '// LINKEDIN' })
+      const emailLink = screen.getByRole('link', { name: '// EMAIL' })
+      const resumeLink = screen.getByRole('link', { name: '// RESUME' })
+
+      expect(githubLink).toHaveAttribute('href', 'https://github.com/Nemesis-12')
+      expect(githubLink).not.toHaveAttribute('target')
+      expect(githubLink).not.toHaveAttribute('rel')
+      expect(linkedInLink).toHaveAttribute('href', 'https://linkedin.com/in/fa-mohammed')
+      expect(linkedInLink).not.toHaveAttribute('target')
+      expect(linkedInLink).not.toHaveAttribute('rel')
+      expect(emailLink).toHaveAttribute('href', canonicalEmailHref)
+      expect(emailLink).not.toHaveAttribute('target')
+      expect(emailLink).not.toHaveAttribute('rel')
+      expect(resumeLink).toHaveAttribute('href', '/resume.pdf')
+      expect(resumeLink).toHaveAttribute('target', '_blank')
+      expect(resumeLink).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('pins footer metadata in footer-copy at the bottom of contact', () => {
+      render(<ContactSection />)
+      const contact = document.querySelector('#contact') as HTMLElement
+      const copy = contact.querySelector('.footer-copy')
+
+      expect(copy).toBeInTheDocument()
+      expect(copy).toHaveTextContent('FARHAN_MOHAMMED © 2026')
+      expect(copy).toHaveTextContent('PORTFOLIO.EXE')
+      expect(contact.lastElementChild).toBe(copy)
+    })
+
+    it('marks footer metadata text as a stronger parallax layer', () => {
+      render(<ContactSection />)
+      const footerText = Array.from(document.querySelectorAll('#contact .footer-copy [data-parallax]'))
+
+      expect(footerText).toHaveLength(2)
+      footerText.forEach((item) => {
+        expect(item).toHaveAttribute('data-parallax-factor', '0.5')
+      })
+    })
+
+    it('keeps contact as a stackable sticky surface', () => {
+      render(<ContactSection />)
+      const contact = document.querySelector('#contact')
+
+      expect(contact?.tagName.toLowerCase()).toBe('footer')
+      expect(contact).toHaveAttribute('data-sticky-section', 'true')
+      expect(contact).toHaveClass('sticky', 'top-0', 'min-h-screen')
     })
   })
 })

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -8,10 +8,10 @@ const EMAIL = 'famohammed@shockers.wichita.edu'
 const CONTACT_SPEED = 50
 
 const footerLinks = [
-  { prefix: '//', label: 'GITHUB', href: 'https://github.com/Nemesis-12' },
-  { prefix: '//', label: 'LINKEDIN', href: 'https://linkedin.com/in/fa-mohammed' },
-  { prefix: '//', label: 'EMAIL', href: `mailto:${EMAIL}` },
-  { prefix: '//', label: 'RESUME', href: '/resume.pdf', target: '_blank' as const },
+  { label: 'GITHUB', href: 'https://github.com/Nemesis-12' },
+  { label: 'LINKEDIN', href: 'https://linkedin.com/in/fa-mohammed' },
+  { label: 'EMAIL', href: `mailto:${EMAIL}` },
+  { label: 'RESUME', href: '/resume.pdf', target: '_blank' as const },
 ]
 
 export default function ContactSection() {
@@ -20,77 +20,68 @@ export default function ContactSection() {
   const [step, setStep] = useState(0)
 
   return (
-    <>
-      <StickySection as="footer" id="contact" className="bg-graphite">
-        <div ref={ref} className="footer-cta">
-          <div className="footer-big">
-            <span className="footer-big-line">
-              <TypeIn
-                start={isInView}
-                text="LET'S"
-                speed={CONTACT_SPEED}
-                onDone={() => setStep((s) => Math.max(s, 1))}
-              />
-            </span>
-            <span className="footer-big-line">
-              <TypeIn
-                start={step >= 1}
-                text="CONNECT"
-                speed={CONTACT_SPEED}
-                onDone={() => setStep((s) => Math.max(s, 2))}
-              />
-              {step >= 2 && <span className="period">.</span>}
-              {step >= 2 && (
-                <span className="cursor" data-testid="contact-cursor" aria-hidden="true" />
-              )}
-            </span>
-          </div>
-
-          <motion.a
-            href={`mailto:${EMAIL}`}
-            variants={hoverEase}
-            initial="idle"
-            whileHover="hover"
-            className="inline-block font-body text-sm border-2 border-platinum text-platinum px-8 py-4 hover:bg-platinum hover:text-graphite transition-colors"
-          >
-            SEND_MESSAGE →
-          </motion.a>
+    <StickySection as="footer" id="contact" className="bg-graphite">
+      <div ref={ref} className="footer-cta">
+        <div className="footer-big">
+          <span className="footer-big-line">
+            <TypeIn
+              start={isInView}
+              text="LET'S"
+              speed={CONTACT_SPEED}
+              onDone={() => setStep((s) => Math.max(s, 1))}
+            />
+          </span>
+          <span className="footer-big-line">
+            <TypeIn
+              start={step >= 1}
+              text="CONNECT"
+              speed={CONTACT_SPEED}
+              onDone={() => setStep((s) => Math.max(s, 2))}
+            />
+            {step >= 2 && <span className="period">.</span>}
+            {step >= 2 && (
+              <span className="cursor" data-testid="contact-cursor" aria-hidden="true" />
+            )}
+          </span>
         </div>
-      </StickySection>
 
-      <StickySection
-        as="footer"
-        id="footer"
-        className="flex flex-col justify-center gap-6 px-8 py-8 border-t border-periwinkle/20 text-xs font-body text-periwinkle bg-graphite"
-      >
-        <div className="flex flex-wrap gap-6">
-          {footerLinks.map(({ prefix, label, href, target }) => (
+        <motion.a
+          href={`mailto:${EMAIL}`}
+          variants={hoverEase}
+          initial="idle"
+          whileHover="hover"
+          className="btn btn-fill"
+        >
+          SEND_MESSAGE <span>→</span>
+        </motion.a>
+
+        <div className="footer-socials">
+          {footerLinks.map(({ label, href, target }) => (
             <motion.a
               key={label}
               href={href}
               target={target}
-              aria-label={`${prefix} ${label}`}
+              aria-label={`// ${label}`}
               rel={target === '_blank' ? 'noopener noreferrer' : undefined}
               variants={hoverEase}
               initial="idle"
               whileHover="hover"
-              className="group font-body text-sm"
+              className="slink"
             >
-              <span className="text-atomic-tangerine group-hover:text-white transition-colors">{prefix}{' '}</span>
-              <span className="text-periwinkle group-hover:text-white transition-colors">{label}</span>
+              {label}
             </motion.a>
           ))}
         </div>
+      </div>
 
-        <div className="flex justify-between items-center">
-          <span data-parallax data-parallax-factor="0.5">
-            FARHAN_MOHAMMED © 2026
-          </span>
-          <span data-parallax data-parallax-factor="0.5">
-            PORTFOLIO.EXE
-          </span>
-        </div>
-      </StickySection>
-    </>
+      <div className="footer-copy">
+        <span data-parallax data-parallax-factor="0.5">
+          FARHAN_MOHAMMED © 2026
+        </span>
+        <span data-parallax data-parallax-factor="0.5">
+          PORTFOLIO.EXE
+        </span>
+      </div>
+    </StickySection>
   )
 }

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -22,6 +22,8 @@ const REFERENCE_COMPONENT_CLASSES = [
   'bento',
   'tl-org',
   'footer-big',
+  'footer-cta',
+  'footer-copy',
   'slink',
   'reveal',
   'title-cursor',


### PR DESCRIPTION
## Purpose
Align the contact section with the reference design by merging the CTA, social links, and footer metadata into a single full-screen footer using portfolio CSS classes.

## What it does
- Consolidates `#contact` and the former `#footer` into one sticky footer surface
- Centers the `SEND_MESSAGE →` action as an orange fill button
- Renders social links as terminal-style `slink` entries with CSS `//` prefixes
- Pins copyright metadata in a `footer-copy` row at the bottom of the viewport

## Changes made
- Updated `ContactSection.tsx` to use `footer-cta`, `btn btn-fill`, `footer-socials`, `slink`, and `footer-copy`
- Added issue #186 acceptance tests in `ContactSection.test.tsx`
- Updated `App.test.tsx` stack order and parallax selectors after removing `#footer`
- Extended `portfolio-css.test.ts` to anchor `footer-cta` and `footer-copy` classes

## Additional notes
- Builds on #185 (full-screen contact heading) which is merged on this branch
- Footer CSS (`footer-cta`, `slink`, `footer-copy`) was already present in `portfolio.css`

Closes #186

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the contact section layout to consolidate footer elements, social links, and call-to-action into a unified section.
  * Updated the "Send Message" button styling for improved visual consistency.

* **Tests**
  * Updated test assertions to reflect the restructured contact section and consolidated footer layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->