### PR TITLE
mochi: use hscroll-* classes for Projects header

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -303,6 +303,18 @@ describe('ProjectsSection', () => {
     expect(carouselTrack.style.transform).toBe(`translateX(${-0.5 * (trackWidth - 1000)}px)`)
   })
 
+  it('section header uses hscroll classes with orange slash and pixel font name', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    expect(document.querySelector('.hscroll-head')).toBeInTheDocument()
+    expect(document.querySelector('.hscroll-no')?.textContent).toBe('// 01')
+    expect(document.querySelector('.hscroll-name')?.textContent).toBe('PROJECTS')
+    expect(document.querySelector('.hscroll-rule')).toBeInTheDocument()
+    expect(screen.getByTestId('progress-indicator')).toHaveClass('hscroll-progress')
+    expect(screen.getByTestId('progress-fill')).toHaveClass('hscroll-progress-fill')
+    expect(screen.getByTestId('progress-fill').parentElement).toHaveClass('hscroll-progress-track')
+  })
+
   it('section header is separate from carousel track', () => {
     render(<ProjectsSection projects={mockProjects} />)
 

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -49,26 +49,19 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
     >
       <div data-sticky-viewport="true" className="flex flex-col justify-center py-14 hscroll-sticky">
         <div className="w-full">
-          <div className="flex items-center gap-3 mb-8">
-            <span className="font-body text-xs text-atomic-tangerine tracking-widest whitespace-nowrap">// 01</span>
-            <span className="font-body text-xs text-periwinkle tracking-widest whitespace-nowrap">PROJECTS</span>
-            <hr className="flex-1 border-periwinkle/20" />
-            <div
-              data-testid="progress-indicator"
-              className="flex items-center gap-[10px] font-body text-periwinkle shrink-0"
-              style={{ fontSize: '9px', letterSpacing: '2px' }}
-            >
+          <div className="hscroll-head">
+            <span className="hscroll-no">// 01</span>
+            <span className="hscroll-name">PROJECTS</span>
+            <div className="hscroll-rule" />
+            <div data-testid="progress-indicator" className="hscroll-progress">
               <span data-testid="progress-count">
                 {String(activeIndex + 1).padStart(2, '0')} / {String(projects.length).padStart(2, '0')}
               </span>
-              <div
-                className="relative"
-                style={{ width: '80px', height: '1px', backgroundColor: 'rgba(178,182,210,0.2)' }}
-              >
+              <div className="hscroll-progress-track">
                 <div
                   data-testid="progress-fill"
-                  className="absolute left-0 top-0 h-full bg-atomic-tangerine"
-                  style={{ width: `${progress * 100}%`, transition: 'width 0.1s linear' }}
+                  className="hscroll-progress-fill"
+                  style={{ width: `${progress * 100}%` }}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replace Tailwind utility approximations in `ProjectsSection` header with portfolio `hscroll-head`, `hscroll-no`, `hscroll-name`, `hscroll-rule`, and `hscroll-progress*` classes
- Add regression test asserting header class usage and progress indicator structure
- Matches Skills section header implementation and reference typography (14px orange slash, 18px Press Start 2P platinum label)

Closes #207

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test`
- [ ] Visual check at 1440×900 against `ideas/proj.png` header typography


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Projects section, verifying header rendering with correct CSS classes, expected text content, and proper progress indicator styling.

* **Refactor**
  * Projects section header and progress indicator UI refactored with improved layout structure and simplified progress tracking implementation for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->