### PR TITLE
mochi: show > caret on active nav link

### DIFF
--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -125,7 +125,8 @@ describe('Navbar', () => {
       expect(skillsLabel).toHaveClass('nav-label')
       expect(skillsLabel.className).not.toContain('border-b-2')
       expect(skillsLabel.className).not.toContain('border-atomic-tangerine')
-      expect(skillsLink!.querySelector('[data-testid="nav-caret"]')).toBeNull()
+      expect(skillsLink!.querySelector('[data-testid="nav-caret"]')).not.toBeNull()
+      expect(skillsLink!.querySelector('[data-testid="nav-caret"]')).toHaveTextContent('>')
     })
 
     it('restores inactive link caret and removes label underline when active section changes', () => {
@@ -158,7 +159,8 @@ describe('Navbar', () => {
       expect(skillsLink).not.toHaveClass('active')
       expect(skillsLabel).toHaveClass('nav-label')
       expect(projectsLink).toHaveClass('nav-link', 'active')
-      expect(projectsLink!.querySelector('[data-testid="nav-caret"]')).toBeNull()
+      expect(projectsLink!.querySelector('[data-testid="nav-caret"]')).not.toBeNull()
+      expect(projectsLink!.querySelector('[data-testid="nav-caret"]')).toHaveTextContent('>')
       expect(projectsLabel).toHaveClass('nav-label')
     })
   })
@@ -243,11 +245,53 @@ describe('Navbar', () => {
         expect(skillsLabel.className).not.toContain('border-b-2')
         expect(skillsLabel.className).not.toContain('border-atomic-tangerine')
         expect(skillsLabel.className).not.toContain('text-atomic-tangerine')
-        expect(skillsLink!.querySelector('.nav-caret')).toBeNull()
+        expect(skillsLink!.querySelector('.nav-caret')).not.toBeNull()
+        expect(skillsLink!.querySelector('.nav-caret')).toHaveTextContent('>')
       } finally {
         vi.unstubAllGlobals()
         document.body.removeChild(section)
       }
+    })
+  })
+
+  describe('issue #208 - active link shows caret', () => {
+    let section: HTMLElement
+    let observerCallback!: IntersectionObserverCallback
+
+    beforeEach(() => {
+      section = document.createElement('section')
+      section.id = 'skills'
+      document.body.appendChild(section)
+
+      vi.stubGlobal('IntersectionObserver', vi.fn(function (cb: IntersectionObserverCallback) {
+        observerCallback = cb
+        return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() }
+      }))
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+      document.body.removeChild(section)
+    })
+
+    it('keeps nav-caret in DOM on active link for CSS visibility', () => {
+      render(<Navbar />)
+
+      act(() => {
+        observerCallback(
+          [{ target: section, isIntersecting: true } as unknown as IntersectionObserverEntry],
+          {} as IntersectionObserver,
+        )
+      })
+
+      const skillsLink = screen.getByRole('link', { name: /skills/i })
+      const caret = skillsLink.querySelector('[data-testid="nav-caret"]')
+
+      expect(skillsLink).toHaveClass('nav-link', 'active')
+      expect(caret).not.toBeNull()
+      expect(caret).toHaveTextContent('>')
+      expect(caret).toHaveClass('nav-caret')
+      expect((caret as HTMLElement).style.opacity).toBe('')
     })
   })
 
@@ -275,7 +319,7 @@ describe('Navbar', () => {
       }
     })
 
-    it('active link keeps the > prefix absent', () => {
+    it('active link keeps the > prefix in DOM for CSS-driven visibility', () => {
       const section = document.createElement('section')
       section.id = 'skills'
       document.body.appendChild(section)
@@ -300,7 +344,8 @@ describe('Navbar', () => {
         const labelSpan = skillsLink.querySelector('.nav-label')
         const caretSpan = skillsLink.querySelector('[data-testid="nav-caret"]')
         expect(labelSpan).toHaveClass('nav-label')
-        expect(caretSpan).toBeNull()
+        expect(caretSpan).not.toBeNull()
+        expect(caretSpan).toHaveTextContent('>')
       } finally {
         vi.unstubAllGlobals()
         document.body.removeChild(section)

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -47,11 +47,9 @@ export default function Navbar() {
                   href={href}
                   className={`nav-link${isActive ? ' active' : ''}`}
                 >
-                  {!isActive && (
-                    <span className="nav-caret" data-testid="nav-caret">
-                      &gt;
-                    </span>
-                  )}
+                  <span className="nav-caret" data-testid="nav-caret">
+                    &gt;
+                  </span>
                   <span className="nav-label">{label}</span>
                 </a>
               </li>

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -100,6 +100,7 @@ describe('portfolio.css CSS anchor', () => {
     expect(portfolioCss).toContain('.nav-caret{display:inline-block')
     expect(portfolioCss).toContain('.nav-caret{display:inline-block;color:var(--color-atomic-tangerine);opacity:0')
     expect(portfolioCss).toContain('.nav-link:hover .nav-caret')
+    expect(portfolioCss).toContain('.nav-link.active .nav-caret')
     expect(portfolioCss).toContain('.nav-label::after{content')
     expect(portfolioCss).toContain('.nav-link.active .nav-label{color:var(--color-atomic-tangerine)}')
   })


### PR DESCRIPTION
## Summary

- Always render `nav-caret` (`>`) in every desktop nav link so active sections match reference HTML and v4 screenshots
- Rely on existing `portfolio.css` rules (`.nav-link.active .nav-caret`) for visible caret on active links; hover-only behavior on inactive links unchanged
- Update Navbar and CSS anchor tests that previously expected caret removal on active links

## Test plan

- [x] `npm run typecheck`
- [x] `npm run test`
- [ ] Desktop: scroll to each section and confirm active nav shows orange `> SECTION` with underline
- [ ] Desktop: hover inactive links still reveal caret on hover only

Closes #208

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation active link indicator to consistently display when a section is active, improving visual navigation feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->