### PR TITLE
Timeline: add // 03 TIMELINE header, progress counter, and SCROLL ↓ hint

### DIFF
--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -3,8 +3,23 @@ import { render, screen, act } from '@testing-library/react'
 import TimelineSection from './TimelineSection'
 import { useActivePanel } from '../hooks/useActivePanel'
 
+const noopSetRef = () => () => {}
+
+function mockActivePanelState(
+  active: boolean[],
+  options: { activeIndex?: number; progress?: number } = {},
+) {
+  const detectedIndex = active.findIndex(Boolean)
+  return {
+    active,
+    activeIndex: options.activeIndex ?? (detectedIndex === -1 ? 0 : detectedIndex),
+    progress: options.progress ?? 0,
+    setRef: noopSetRef,
+  }
+}
+
 vi.mock('../hooks/useActivePanel', () => ({
-  useActivePanel: vi.fn(() => ({ active: [false, false, false], setRef: () => () => {} })),
+  useActivePanel: vi.fn(() => mockActivePanelState([false, false, false])),
 }))
 
 describe('TimelineSection', () => {
@@ -22,10 +37,7 @@ describe('TimelineSection', () => {
   })
 
   it('entries start empty when no panel is active', () => {
-    vi.mocked(useActivePanel).mockReturnValue({
-      active: [false, false, false],
-      setRef: () => () => {},
-    })
+    vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
 
     render(<TimelineSection />)
 
@@ -35,10 +47,7 @@ describe('TimelineSection', () => {
 
   describe('issue #78 - newest-first ordering', () => {
     it('entries render in newest-first order (NetApp before M.S. before B.S.)', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, true, true],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, true, true]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -116,10 +125,7 @@ describe('TimelineSection', () => {
     })
 
     it('Typewriter types commit metadata when panel becomes active', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -135,10 +141,7 @@ describe('TimelineSection', () => {
     })
 
     it('Typewriter types all fields to completion when panel stays active', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -158,10 +161,7 @@ describe('TimelineSection', () => {
     })
 
     it('Typewriter types bullets when present', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -177,10 +177,7 @@ describe('TimelineSection', () => {
     })
 
     it('inactive panels remain empty', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -196,10 +193,7 @@ describe('TimelineSection', () => {
     })
 
     it('Typewriter holds position when panel is scrolled away mid-type', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -210,10 +204,7 @@ describe('TimelineSection', () => {
 
       const partialText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [false, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
       rerender(<TimelineSection />)
 
       act(() => {
@@ -225,10 +216,7 @@ describe('TimelineSection', () => {
     })
 
     it('Typewriter resumes from held position when panel becomes active again', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -238,19 +226,13 @@ describe('TimelineSection', () => {
       })
       const partialText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [false, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
       rerender(<TimelineSection />)
       act(() => {
         vi.advanceTimersByTime(1000)
       })
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       rerender(<TimelineSection />)
       act(() => {
         vi.advanceTimersByTime(500)
@@ -261,10 +243,7 @@ describe('TimelineSection', () => {
     })
 
     it('issue #98 - longest bullet completes within 2.5s', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -283,10 +262,7 @@ describe('TimelineSection', () => {
 
   describe('issue #159 - preserve per-panel typewriter progress', () => {
     it('next panel activation does not clear previous panel partial text', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -299,10 +275,7 @@ describe('TimelineSection', () => {
       const panel1Partial = commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
       expect(panel1Partial.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [false, true, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, true, false]))
       rerender(<TimelineSection />)
 
       act(() => {
@@ -317,10 +290,7 @@ describe('TimelineSection', () => {
     })
 
     it('reactivate does not blank partial text before resuming', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -332,16 +302,10 @@ describe('TimelineSection', () => {
       const partialText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
       expect(partialText.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [false, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
       rerender(<TimelineSection />)
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       rerender(<TimelineSection />)
 
       const immediateText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
@@ -349,10 +313,7 @@ describe('TimelineSection', () => {
     })
 
     it('each panel retains independent partial progress when switching panels', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -366,10 +327,7 @@ describe('TimelineSection', () => {
         commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
       expect(panel1Partial.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [false, true, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, true, false]))
       rerender(<TimelineSection />)
 
       act(() => {
@@ -384,10 +342,7 @@ describe('TimelineSection', () => {
       expect(panel1Held).toBe(panel1Partial)
       expect(panel2Partial.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       rerender(<TimelineSection />)
 
       const panel1Immediate =
@@ -400,10 +355,7 @@ describe('TimelineSection', () => {
     })
 
     it('completed panel text remains when next panel activates', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -420,10 +372,7 @@ describe('TimelineSection', () => {
       expect(panel1Texts).toContain('commit d4e8f2c')
       expect(panel1Texts).toContain('NETAPP INC.')
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [false, true, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, true, false]))
       rerender(<TimelineSection />)
 
       act(() => {
@@ -441,10 +390,7 @@ describe('TimelineSection', () => {
 
   describe('issue #160 - structured resume-backed panel content', () => {
     it('renders commit metadata as distinct fields', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -468,10 +414,7 @@ describe('TimelineSection', () => {
     })
 
     it('renders institution as its own heading', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -487,10 +430,7 @@ describe('TimelineSection', () => {
     })
 
     it('renders role as its own line', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -505,10 +445,7 @@ describe('TimelineSection', () => {
     })
 
     it('renders bullets as semantic list items', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -527,10 +464,7 @@ describe('TimelineSection', () => {
     })
 
     it('preserves data-typewriter-line markers on typed fields', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -546,10 +480,7 @@ describe('TimelineSection', () => {
     })
 
     it('omits commit-details list when entry has no bullets', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [false, true, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, true, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -567,10 +498,7 @@ describe('TimelineSection', () => {
     })
 
     it('holds partial metadata within structured fields when panel deactivates', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -584,10 +512,7 @@ describe('TimelineSection', () => {
         commitEntries[0].querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
       expect(partialHash.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [false, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
       rerender(<TimelineSection />)
 
       act(() => {
@@ -604,10 +529,7 @@ describe('TimelineSection', () => {
 
   describe('issue #161 - v4 desktop panel visual hierarchy', () => {
     it('commit hash uses tl-commit, author and date use tl-meta', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -624,10 +546,7 @@ describe('TimelineSection', () => {
     })
 
     it('institution heading uses tl-org portfolio class', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -643,10 +562,7 @@ describe('TimelineSection', () => {
     })
 
     it('role uses tl-title portfolio class', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -662,10 +578,7 @@ describe('TimelineSection', () => {
     })
 
     it('bullets use tl-bullets portfolio class', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -689,10 +602,7 @@ describe('TimelineSection', () => {
     })
 
     it('inserts tl-sep spacer before institution heading', () => {
-      vi.mocked(useActivePanel).mockReturnValue({
-        active: [true, false, false],
-        setRef: () => () => {},
-      })
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -786,6 +696,87 @@ describe('TimelineSection', () => {
       stickyPanels.forEach((panel) => {
         expect((panel as HTMLElement).style.willChange).toBe('transform, opacity')
       })
+    })
+  })
+
+  describe('issue #206 - timeline section chrome', () => {
+    it('renders // 03 TIMELINE header with hscroll classes', () => {
+      render(<TimelineSection />)
+
+      expect(document.querySelector('.hscroll-head')).toBeInTheDocument()
+      expect(document.querySelector('.hscroll-no')?.textContent).toBe('// 03')
+      expect(document.querySelector('.hscroll-name')?.textContent).toBe('TIMELINE')
+      expect(document.querySelector('.hscroll-rule')).toBeInTheDocument()
+    })
+
+    it('renders progress counter with resume entry count 01 / 03', () => {
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+
+      render(<TimelineSection />)
+
+      expect(screen.getByTestId('progress-count')).toHaveTextContent('01 / 03')
+    })
+
+    it('progress counter advances with active panel index', () => {
+      vi.mocked(useActivePanel).mockReturnValue(
+        mockActivePanelState([false, true, false], { activeIndex: 1, progress: 0.5 }),
+      )
+
+      render(<TimelineSection />)
+
+      expect(screen.getByTestId('progress-count')).toHaveTextContent('02 / 03')
+    })
+
+    it('progress fill width reflects scroll progress', () => {
+      vi.mocked(useActivePanel).mockReturnValue(
+        mockActivePanelState([false, true, false], { activeIndex: 1, progress: 0.5 }),
+      )
+
+      render(<TimelineSection />)
+
+      expect(screen.getByTestId('progress-fill')).toHaveStyle({ width: '50%' })
+    })
+
+    it('uses hscroll-progress classes for counter and bar', () => {
+      render(<TimelineSection />)
+
+      expect(document.querySelector('.hscroll-progress')).toBeInTheDocument()
+      expect(document.querySelector('.hscroll-progress-track')).toBeInTheDocument()
+      expect(document.querySelector('.hscroll-progress-fill')).toBeInTheDocument()
+    })
+
+    it('section chrome renders once not per panel', () => {
+      render(<TimelineSection />)
+
+      expect(document.querySelectorAll('.hscroll-head')).toHaveLength(1)
+    })
+
+    it('renders SCROLL ↓ hint when on first panel', () => {
+      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+
+      render(<TimelineSection />)
+
+      const hint = screen.getByTestId('scroll-hint')
+      expect(hint).toHaveTextContent(/SCROLL/)
+      expect(hint).toHaveTextContent(/↓/)
+      expect(hint).toHaveAttribute('data-visible', 'true')
+      expect(hint).toHaveClass('hscroll-hint')
+    })
+
+    it('hides scroll hint after first panel beat', () => {
+      vi.mocked(useActivePanel).mockReturnValue(
+        mockActivePanelState([false, true, false], { activeIndex: 1, progress: 0.5 }),
+      )
+
+      render(<TimelineSection />)
+
+      expect(screen.getByTestId('scroll-hint')).toHaveAttribute('data-visible', 'false')
+    })
+
+    it('scroll hint is visually secondary (aria-hidden)', () => {
+      render(<TimelineSection />)
+
+      expect(screen.getByTestId('scroll-hint')).toHaveAttribute('aria-hidden', 'true')
     })
   })
 })

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -25,6 +25,7 @@ vi.mock('../hooks/useActivePanel', () => ({
 describe('TimelineSection', () => {
   afterEach(() => {
     vi.useRealTimers()
+    vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
   })
 
   it('each entry uses tl-panel layout class', () => {

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,7 +1,94 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTypewriter } from '../animations/useTypewriter'
 import { useActivePanel } from '../hooks/useActivePanel'
 import { StickySection } from './StickySection'
+
+const TIMELINE_SECTION_NO = '// 03'
+
+function formatPanelCount(index: number, total: number): string {
+  return `${String(index + 1).padStart(2, '0')} / ${String(total).padStart(2, '0')}`
+}
+
+function useTimelineInView(entryCount: number): boolean {
+  const [inView, setInView] = useState(true)
+
+  useEffect(() => {
+    const sections = [
+      document.getElementById('timeline'),
+      ...Array.from(document.querySelectorAll('[id^="timeline-"]')),
+    ].filter((section): section is HTMLElement => section instanceof HTMLElement)
+
+    if (sections.length !== entryCount) {
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        setInView(entries.some((entry) => entry.isIntersecting))
+      },
+      { threshold: 0 },
+    )
+
+    sections.forEach((section) => observer.observe(section))
+    return () => observer.disconnect()
+  }, [entryCount])
+
+  return inView
+}
+
+function TimelineChrome({
+  activeIndex,
+  progress,
+  total,
+  visible,
+}: {
+  activeIndex: number
+  progress: number
+  total: number
+  visible: boolean
+}) {
+  const showScrollHint = activeIndex === 0
+
+  return (
+    <div
+      data-testid="timeline-chrome"
+      className="pointer-events-none fixed inset-0 z-50"
+      aria-hidden={!visible}
+      style={{
+        opacity: visible ? 1 : 0,
+        transition: 'opacity 0.3s',
+      }}
+    >
+      <div data-sticky-viewport="true" className="relative h-full w-full hscroll-sticky">
+        <div className="hscroll-head">
+          <span className="hscroll-no">{TIMELINE_SECTION_NO}</span>
+          <span className="hscroll-name">TIMELINE</span>
+          <div className="hscroll-rule" />
+          <div data-testid="progress-indicator" className="hscroll-progress">
+            <span data-testid="progress-count">{formatPanelCount(activeIndex, total)}</span>
+            <div className="hscroll-progress-track">
+              <div
+                data-testid="progress-fill"
+                className="hscroll-progress-fill"
+                style={{ width: `${progress * 100}%` }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div
+          data-testid="scroll-hint"
+          data-visible={showScrollHint}
+          aria-hidden="true"
+          className="hscroll-hint"
+          style={{ opacity: showScrollHint ? 0.85 : 0, transition: 'opacity 0.3s' }}
+        >
+          SCROLL <span>↓</span>
+        </div>
+      </div>
+    </div>
+  )
+}
 
 const timelineEntries: TimelineEntry[] = [
   {
@@ -140,10 +227,18 @@ function TimelinePanel({
 }
 
 const TimelineSection: React.FC = () => {
-  const { active, setRef } = useActivePanel(timelineEntries.length)
+  const entryCount = timelineEntries.length
+  const { active, activeIndex, progress, setRef } = useActivePanel(entryCount)
+  const inView = useTimelineInView(entryCount)
 
   return (
     <>
+      <TimelineChrome
+        activeIndex={activeIndex}
+        progress={progress}
+        total={entryCount}
+        visible={inView}
+      />
       {timelineEntries.map((entry, i) => (
         <TimelinePanel
           key={entry.hash}

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTypewriter } from '../animations/useTypewriter'
 import { useActivePanel } from '../hooks/useActivePanel'
 import { StickySection } from './StickySection'
@@ -11,6 +11,7 @@ function formatPanelCount(index: number, total: number): string {
 
 function useTimelineInView(entryCount: number): boolean {
   const [inView, setInView] = useState(true)
+  const visibilityRef = useRef(new Map<Element, boolean>())
 
   useEffect(() => {
     const sections = [
@@ -22,9 +23,14 @@ function useTimelineInView(entryCount: number): boolean {
       return
     }
 
+    visibilityRef.current = new Map(sections.map((section) => [section, true]))
+
     const observer = new IntersectionObserver(
       (entries) => {
-        setInView(entries.some((entry) => entry.isIntersecting))
+        entries.forEach((entry) => {
+          visibilityRef.current.set(entry.target, entry.isIntersecting)
+        })
+        setInView(Array.from(visibilityRef.current.values()).some(Boolean))
       },
       { threshold: 0 },
     )

--- a/src/hooks/useActivePanel.test.ts
+++ b/src/hooks/useActivePanel.test.ts
@@ -450,5 +450,34 @@ describe('useActivePanel', () => {
 
       expect(result.current.progress).toBe(1)
     })
+
+    it('progress interpolates between panel beats', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        const rects = [
+          { top: -400, height: 800 },
+          { top: 400, height: 800 },
+          { top: 1200, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const hook = useActivePanel(3)
+        elements.forEach((el, i) => hook.setRef(i)(el))
+
+        return hook
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current.progress).toBeCloseTo(0.25)
+    })
   })
 })

--- a/src/hooks/useActivePanel.test.ts
+++ b/src/hooks/useActivePanel.test.ts
@@ -362,4 +362,93 @@ describe('useActivePanel', () => {
       expect(result.current).toEqual([false, true])
     })
   })
+
+  describe('issue #206 - timeline scroll progress', () => {
+    it('exposes activeIndex matching the active panel', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        const rects = [
+          { top: -800, height: 800 },
+          { top: 0, height: 800 },
+          { top: 800, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const hook = useActivePanel(3)
+        elements.forEach((el, i) => hook.setRef(i)(el))
+
+        return hook
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current.activeIndex).toBe(1)
+    })
+
+    it('progress is 0 at the first panel beat', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        const rects = [
+          { top: 0, height: 800 },
+          { top: 800, height: 800 },
+          { top: 1600, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const hook = useActivePanel(3)
+        elements.forEach((el, i) => hook.setRef(i)(el))
+
+        return hook
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current.progress).toBe(0)
+    })
+
+    it('progress reaches 1 on the last panel beat', () => {
+      setViewport(1000, 800)
+
+      const { result } = renderHook(() => {
+        const elements: HTMLElement[] = []
+        const rects = [
+          { top: -1600, height: 800 },
+          { top: -800, height: 800 },
+          { top: 0, height: 800 },
+        ]
+        for (let i = 0; i < 3; i++) {
+          const el = document.createElement('div')
+          el.getBoundingClientRect = vi.fn(() =>
+            createRect(rects[i].top, rects[i].height)
+          )
+          elements.push(el)
+        }
+
+        const hook = useActivePanel(3)
+        elements.forEach((el, i) => hook.setRef(i)(el))
+
+        return hook
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current.progress).toBe(1)
+    })
+  })
 })

--- a/src/hooks/useActivePanel.ts
+++ b/src/hooks/useActivePanel.ts
@@ -21,11 +21,13 @@ function computeActiveIndex(panelRefs: (HTMLElement | null)[]): number {
   return activeIndex
 }
 
-export function computeTimelineProgress(panelRefs: (HTMLElement | null)[]): number {
+export function computeTimelineProgress(
+  panelRefs: (HTMLElement | null)[],
+  activeIndex: number,
+): number {
   const count = panelRefs.length
   if (count <= 1) return 0
 
-  const activeIndex = computeActiveIndex(panelRefs)
   const activeRef = panelRefs[activeIndex]
   if (!activeRef) return activeIndex / (count - 1)
 
@@ -51,7 +53,7 @@ export function useActivePanel(panelCount: number): {
   const updateActiveIndex = useCallback(() => {
     const next = computeActiveIndex(panelRefs.current)
     setActiveIndex(next)
-    setProgress(computeTimelineProgress(panelRefs.current))
+    setProgress(computeTimelineProgress(panelRefs.current, next))
   }, [])
 
   useEffect(() => {

--- a/src/hooks/useActivePanel.ts
+++ b/src/hooks/useActivePanel.ts
@@ -21,16 +21,37 @@ function computeActiveIndex(panelRefs: (HTMLElement | null)[]): number {
   return activeIndex
 }
 
+export function computeTimelineProgress(panelRefs: (HTMLElement | null)[]): number {
+  const count = panelRefs.length
+  if (count <= 1) return 0
+
+  const activeIndex = computeActiveIndex(panelRefs)
+  const activeRef = panelRefs[activeIndex]
+  if (!activeRef) return activeIndex / (count - 1)
+
+  const viewportHeight = window.innerHeight
+  const rect = activeRef.getBoundingClientRect()
+  const segment = Math.min(1, Math.max(0, -rect.top / viewportHeight))
+  const base = activeIndex / (count - 1)
+  const next = Math.min(1, (activeIndex + 1) / (count - 1))
+
+  return base + segment * (next - base)
+}
+
 export function useActivePanel(panelCount: number): {
   active: boolean[]
+  activeIndex: number
+  progress: number
   setRef: (index: number) => (el: HTMLElement | null) => void
 } {
   const [activeIndex, setActiveIndex] = useState(0)
+  const [progress, setProgress] = useState(0)
   const panelRefs = useRef<(HTMLElement | null)[]>([])
 
   const updateActiveIndex = useCallback(() => {
     const next = computeActiveIndex(panelRefs.current)
     setActiveIndex(next)
+    setProgress(computeTimelineProgress(panelRefs.current))
   }, [])
 
   useEffect(() => {
@@ -54,7 +75,7 @@ export function useActivePanel(panelCount: number): {
   const active = Array(panelCount).fill(false)
   active[activeIndex] = true
 
-  return { active, setRef }
+  return { active, activeIndex, progress, setRef }
 }
 
 export default useActivePanel


### PR DESCRIPTION
## Summary
- Add shared timeline section chrome with `// 03 TIMELINE` header using existing `hscroll-*` classes
- Show entry progress counter (`01 / 03`) and orange progress bar tied to scroll position across timeline panels
- Add bottom `SCROLL ↓` hint that fades once the user advances past the first panel beat
- Extend `useActivePanel` with `activeIndex` and continuous `progress` for the counter and bar fill

## Test plan
- [x] `npm run typecheck`
- [x] `npm run test` (376 passing)
- [ ] Verify timeline header stays visible while scrolling through all three panels
- [ ] Confirm progress counter advances 01 → 02 → 03 and bar fill tracks scroll
- [ ] Confirm `SCROLL ↓` hint hides after leaving the first panel

Closes #206


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timeline chrome overlay with a fixed progress counter and dynamic progress bar that reflects continuous scroll progress and appears when timeline is visible
  * Added scroll hints with improved visibility and ARIA behavior; chrome shows once per view

* **Tests**
  * Centralized active-panel mocking and expanded tests for timeline chrome, progress formatting/advancement, progress interpolation, and typewriter/panel resume behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->