### PR TITLE
Update portfolio scroll behavior PRD

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,39 +1,39 @@
-# Portfolio v4 — PRD
+# Portfolio v4 - PRD
 
 ## Problem Statement
 
-The production portfolio app does not visually match its canonical reference design (`ideas/Portfolio.html` and the six reference screenshots in `ideas/`). The gap is not a missing spec — the design intent is well-understood. The gap is architectural: every time an agent rewrites a component, it translates the reference's precise vanilla CSS (`clamp()`, `vw` units, exact `px` values, exact `letter-spacing`) into Tailwind v4 utility classes. This translation is lossy.
+The portfolio now mostly follows the canonical visual language from `ideas/Portfolio.html`, but the interactive scroll behavior has drifted away from the reference. The largest regression is that a global card-deck/sticky-stack interpretation was applied to the whole app. That made normal sections, timeline entries, and the Projects carousel fight each other for scroll ownership.
 
-Concrete examples of the drift:
+The user-facing failures are:
 
-| Reference CSS value | What agents produce | Visual damage |
+| Desired behavior from the reference | Current failure mode | User impact |
 |---|---|---|
-| `font-size: clamp(40px, 12vw, 180px)` | `text-5xl` (48px fixed) | Hero name is 3–4× too small |
-| `padding: 0 5vw` | `px-8` (32px fixed) | Layout loses viewport-relative spacing |
-| `font-size: clamp(40px, 8vw, 120px)` | `text-3xl md:text-5xl` | Contact CTA is massively undersized |
-| `letter-spacing: 5px` | `tracking-widest` | Spacing is imprecise |
-| `border-radius: 0` on scrollbar | `border-radius: 4px` | Browser chrome has wrong feel |
-| `clip-path` notch card | `rounded` with `bg-platinum` | Cards look like generic portfolio tiles |
-| `grid-template-areas` bento | ad-hoc grid utilities | Skills bento loses size hierarchy |
+| Normal vertical page flow with sticky internals only where the reference uses them | Global sticky/card-stack behavior was applied across the app | Sections disappear, overlap, or become unreachable |
+| Projects scrolls horizontally inside a tall section with one landing point per project | Extra dead-zone math and card depth states alter the pacing | First/last cards and section exits feel wrong |
+| Timeline is one major section with a horizontal panel track | Each timeline entry became its own global sticky section | Only some timeline content appears and the intended slide direction is lost |
+| Page uses CSS scroll snap proximity and invisible anchors for Projects/Timeline stops | Snapping is missing or applied at the wrong level | Scrolling does not settle cleanly per section/card/entry |
+| Document itself has no horizontal overflow | `100vw` surfaces and wide tracks can leak beyond the viewport | A horizontal scrollbar appears |
 
-The result is that the site looks like a generic portfolio with the correct color scheme rather than the distinctive full-screen terminal artifact the reference describes.
+The design source of truth is still the standalone HTML reference. The implementation should use React modules and tests, but the behavior should match the reference instead of preserving accidental behavior introduced during the port.
 
 ## Solution
 
-The solution has three parts:
+The solution has four parts:
 
-**Part 1 — CSS anchor.** Create `src/portfolio.css` as a near-verbatim copy of the `<style>` block from `ideas/Portfolio.html` (lines 11–233), restructured as `@layer components { … }`. Color tokens already exist in `src/index.css`; only the component rules need to be ported. This gives every component a stable set of class names whose values are proven correct by the reference. Agents no longer derive CSS values — they apply class names.
+**Part 1 - Preserve the CSS anchor.** Keep `src/portfolio.css` as the visual anchor derived from `ideas/Portfolio.html`. Its component class names, typography, spacing, colors, sharp corners, clipped project cards, bento grid, browser chrome, and terminal visual language remain the source of truth for rendering.
 
-**Part 2 — Component fixes.** Update each component to use the ported class names instead of Tailwind approximations for all layout-critical and typography-critical properties.
+**Part 2 - Restore the HTML scroll model.** Replace the global card-deck sticky interpretation with the reference scroll model: normal vertical sections; `scroll-snap-type: y proximity`; no document horizontal overflow; smooth scroll only for explicit navigation/CTA jumps; sticky internal viewports only for Projects and Timeline.
 
-**Part 3 — Cursor rule.** Create `.cursor/rules/portfolio-css.md` instructing agents never to replace classes from `src/portfolio.css` with Tailwind equivalents.
+**Part 3 - Rebuild Projects and Timeline as deep scroll modules.** Projects should expose a simple horizontal-section progress interface that maps a tall vertical section to a horizontal track. Timeline should expose a simple quantized-panel-track interface that maps vertical progress to the intended newest-to-oldest horizontal slide. Both modules should be testable without relying on browser-only visual assertions.
+
+**Part 4 - Update tests and agent guidance.** Tests and PRD language must reject the old global sticky/card-deck stack. Future agents should not reintroduce `useCardDeckDepth`-style global section scaling, per-timeline-entry global sticky pages, or document-level horizontal overflow.
 
 ## User Stories
 
 ### Loading Screen
 1. As a visitor, I want the loading screen to be full-screen graphite so that the boot sequence feels immersive and intentional.
 2. As a visitor, I want to see a pixel-font `FARHAN / MOHAMMED` identity during boot so that the brand is established before the hero loads.
-3. As a visitor, I want a thin orange progress bar that fills over roughly 2.6–3.0s so that the load pacing feels deliberate.
+3. As a visitor, I want a thin orange progress bar that fills over roughly 2.6-3.0s so that the load pacing feels deliberate.
 4. As a visitor, I want rotating terminal status messages (`LOADING_ASSETS`, `COMPILING_MODULES`, etc.) so that the boot sequence reads as a real system init.
 5. As a visitor, I want the loading screen to fade smoothly into the hero so that there is no visual jump.
 
@@ -41,137 +41,157 @@ The solution has three parts:
 6. As a visitor, I want a fixed full-width navbar with translucent graphite background and backdrop blur so that it feels like a floating terminal bar.
 7. As a visitor, I want the logo `FM_` in pixel font on the left so that the brand mark is consistent.
 8. As a visitor, I want nav links in uppercase Space Mono with letter-spacing so that they read as terminal labels.
-9. As a visitor, I want the active nav link to show orange text and an orange underline scoped only to the label (not the caret) so that the active state is precise.
-10. As a visitor, I want the `>` caret to appear on hover only (not on active) so that hover and active feel distinct.
-11. As a visitor, I want the navbar to sit above all card-deck stack layers so that it is always accessible.
+9. As a visitor, I want the active nav link to show orange text and an orange underline scoped only to the label so that the active state is precise.
+10. As a visitor, I want the `>` caret to appear on hover only, not on active, so that hover and active feel distinct.
+11. As a visitor, I want the navbar to remain fixed above Projects and Timeline while those sections run their internal scroll interactions.
+12. As a visitor, I want the navbar active state to remain on Projects throughout the Projects internal scroll and on Timeline throughout the Timeline internal scroll so that the owning major section is clear.
 
 ### Hero
-12. As a visitor, I want the hero section to be full-viewport and full-width so that the name dominates the screen without centering constraints.
-13. As a visitor, I want `// PORTFOLIO_INIT` to type in character-by-character before the name starts so that the sequence feels like a system initializing.
-14. As a visitor, I want a short orange bar below `// PORTFOLIO_INIT` whose left edge is aligned with the `//` start so that the bar reads as an underline for that label specifically.
-15. As a visitor, I want the hero name (`FARHAN` / `MOHAMMED`) to be two separate stacked lines in Press Start 2P at `clamp(40px, 12vw, 180px)` so that the name dominates the viewport at any screen width.
-16. As a visitor, I want the name to type in line-by-line (FARHAN completes, then MOHAMMED starts) so that the sequence has rhythm.
-17. As a visitor, I want a blinking orange cursor at the end of MOHAMMED after it finishes typing so that it signals the terminal is waiting.
-18. As a visitor, I want the rotating role line (e.g. `BUILDER`) in periwinkle Space Mono at `clamp(11px, 1.1vw, 15px)` with `letter-spacing: 5px` so that it reads as a status label beneath the name.
-19. As a visitor, I want the value-prop line `// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.` in Space Mono below the role so that the one-line descriptor is readable and on-brand.
-20. As a visitor, I want the CTA buttons to appear after the value-prop types in, using rectangular sharp-edged buttons (no border-radius) so that they match the reference exactly.
-21. As a visitor, I want the fill CTA (`VIEW_WORK`) to be orange with graphite text, and the outline CTA (`VIEW_RESUME`) to be a platinum-bordered ghost button so that the hierarchy between actions is clear.
-22. As a visitor, I want the hero background to be a subtle line grid (not a dot grid) with a radial mask fade from the left so that the grid enhances depth without being decorative.
-23. As a visitor, I want hero content to use `padding: 0 5vw` so that the layout breathes at all viewport widths.
+13. As a visitor, I want the hero section to be full-viewport and full-width so that the name dominates the screen without centering constraints.
+14. As a visitor, I want the hero typing sequence to start after the loading screen leaves so that I can actually see the full intro.
+15. As a visitor, I want `// PORTFOLIO_INIT` to type in character-by-character before the name starts so that the sequence feels like a system initializing.
+16. As a visitor, I want a short orange bar below `// PORTFOLIO_INIT` whose left edge is aligned with the `//` start so that the bar reads as an underline for that label specifically.
+17. As a visitor, I want the hero name (`FARHAN` / `MOHAMMED`) to be two separate stacked lines in Press Start 2P at `clamp(40px, 12vw, 180px)` so that the name dominates the viewport at any screen width.
+18. As a visitor, I want the name to type in line-by-line (FARHAN completes, then MOHAMMED starts) so that the sequence has rhythm.
+19. As a visitor, I want a blinking orange cursor at the end of MOHAMMED after it finishes typing so that it signals the terminal is waiting.
+20. As a visitor, I want the rotating role line (e.g. `BUILDER`) in periwinkle Space Mono at `clamp(11px, 1.1vw, 15px)` with `letter-spacing: 5px` so that it reads as a status label beneath the name.
+21. As a visitor, I want the value-prop line `// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.` in Space Mono below the role so that the one-line descriptor is readable and on-brand.
+22. As a visitor, I want the CTA buttons to appear after the value-prop types in, using rectangular sharp-edged buttons so that they match the reference exactly.
+23. As a visitor, I want the fill CTA (`VIEW_WORK`) to be orange with graphite text, and the outline CTA (`VIEW_RESUME`) to be a platinum-bordered ghost button so that the hierarchy between actions is clear.
+24. As a visitor, I want the hero background to be a subtle line grid with a radial mask fade from the left so that the grid enhances depth without being decorative.
+25. As a visitor, I want hero content to use `padding: 0 5vw` so that the layout breathes at all viewport widths.
 
 ### Projects Carousel
-24. As a visitor, I want the Projects section to occupy `(projectCount * 1.5 + 1) * 100vh` of scroll height so that scrolling through six projects feels paced rather than rushed.
-25. As a visitor, I want the first and last 20–25vh of the Projects scroll range to be dead zones where the carousel does not move so that entering and exiting the section is comfortable.
-26. As a visitor, I want the active project card to be horizontally centered in the viewport at all times so that focus is always clear.
-27. As a visitor, I want immediate neighbor cards to be partially visible at reduced scale and opacity so that the carousel communicates there are more cards.
-28. As a visitor, I want far cards to be visually suppressed so that attention stays on the active card.
-29. As a visitor, I want each project card to be a large notched/clipped rectangle (`clip-path` polygon corners, not rounded) in platinum so that the cards feel physically distinct from the background.
-30. As a visitor, I want a large low-opacity ghost number (`_01`, `_02`, etc.) behind the card content so that the card has depth and identity.
-31. As a visitor, I want project titles to use Press Start 2P (`clamp(20px, 2vw, 26px)`) so that the name has display weight.
-32. As a visitor, I want tags to be sharp rectangular blocks using the palette colors (yellow, fuchsia, blue, orange-outline) with no border-radius so that they match the reference tile system.
-33. As a visitor, I want project links to use `// LABEL ↗` terminal language so that the link style is consistent with the rest of the site.
-34. As a visitor, I want a hover fill that moves diagonally from the top-left notch corner toward the bottom-right so that the fill feels physical and directional.
-35. As a visitor, I want card content (title, tags, links, ghost number) to remain readable and transition to platinum-on-graphite during the hover fill so that the card is usable in both states.
-36. As a visitor, I want a section header row showing `// 01  PROJECTS` (orange `//`, orange number, pixel font section name) so that the section is labeled in the reference style.
-37. As a visitor, I want a progress counter in the header (`02 / 06`) and a thin orange progress bar so that I know where I am in the carousel.
-38. As a visitor, I want a `SCROLL →` hint at the bottom that fades once the carousel starts moving so that the scroll interaction is discoverable.
-39. As a visitor, I want edge spacers before the first and after the last card so that the first and last cards can reach the centered position.
+26. As a visitor, I want the Projects section to occupy one viewport of vertical scroll per project so that each project has a clear moment on screen.
+27. As a visitor, I want the Projects sticky viewport to pin while the inner track translates horizontally so that the interaction matches the reference.
+28. As a visitor, I want invisible snap anchors, one per project, so that scrolling settles with each project card centered instead of stopping halfway between cards.
+29. As a visitor, I want the first and last cards to be reachable and centered through the same snap/pacing model as the middle cards so that no special dead-zone math is needed.
+30. As a visitor, I want project cards to keep the reference scale and opacity rather than being suppressed by active/neighbor/far states so that the carousel feels like the HTML source.
+31. As a visitor, I want each project card to be a large notched/clipped rectangle (`clip-path` polygon corners, not rounded) in platinum so that the cards feel physically distinct from the background.
+32. As a visitor, I want a large low-opacity ghost number (`_01`, `_02`, etc.) behind the card content so that the card has depth and identity.
+33. As a visitor, I want project titles to use Press Start 2P (`clamp(20px, 2vw, 26px)`) so that the name has display weight.
+34. As a visitor, I want tags to be sharp rectangular blocks using the palette colors (yellow, fuchsia, blue, orange-outline) with no border-radius so that they match the reference tile system.
+35. As a visitor, I want project links to use `// LABEL` plus an external-link arrow in terminal language so that the link style is consistent with the rest of the site.
+36. As a visitor, I want a hover fill that moves diagonally from the top-left notch corner toward the bottom-right so that the fill feels physical and directional.
+37. As a visitor, I want card content (title, tags, links, ghost number) to remain readable and transition to platinum-on-graphite during the hover fill so that the card is usable in both states.
+38. As a visitor, I want a section header row showing `// 01  PROJECTS` so that the section is labeled in the reference style.
+39. As a visitor, I want a progress counter in the header (`02 / 06`) and a thin orange progress bar so that I know where I am in the carousel.
+40. As a visitor, I want a `SCROLL ->` hint at the bottom of the pinned viewport so that the scroll interaction is discoverable.
+41. As a visitor, I want edge spacers before the first and after the last card so that the first and last cards can reach the centered position.
 
 ### Skills
-40. As a visitor, I want the skills section to use the exact six-column `grid-template-areas` bento layout from the reference so that Python dominates the top-left and tile sizes communicate skill importance.
-41. As a visitor, I want sharp rectangular bento tiles (no rounded corners) with strong palette blocks so that the grid feels like a physical mosaic.
-42. As a visitor, I want the palette swatch tile (four color swatches) in the bottom-right so that the design system is self-referential.
-43. As a visitor, I want tiles to reveal in deterministic largest-first order on section entry so that the cascade always feels intentional.
-44. As a visitor, I want the reveal to reset and replay when the section re-enters the viewport so that repeat visitors see the animation again.
-45. As a visitor, I want category labels in small uppercase mono and skill names in bold mono so that each tile has a consistent two-line hierarchy.
-46. As a visitor, I want the section header `// 02  SKILLS` in the reference style above the grid so that it is labeled consistently with Projects.
+42. As a visitor, I want the skills section to use the exact six-column `grid-template-areas` bento layout from the reference so that Python dominates the top-left and tile sizes communicate skill importance.
+43. As a visitor, I want sharp rectangular bento tiles with strong palette blocks so that the grid feels like a physical mosaic.
+44. As a visitor, I want the palette swatch tile in the bottom-right so that the design system is self-referential.
+45. As a visitor, I want tiles to reveal in a randomized order each time the section enters view so that the cascade matches the reference and feels fresh.
+46. As a visitor, I want the reveal to reset and replay when the section re-enters the viewport so that repeat visitors see the animation again.
+47. As a visitor, I want category labels in small uppercase mono and skill names in bold mono so that each tile has a consistent two-line hierarchy.
+48. As a visitor, I want the section header `// 02  SKILLS` in the reference style above the grid so that it is labeled consistently with Projects.
 
 ### Timeline
-47. As a visitor, I want each timeline entry to be a full-screen sticky panel so that one entry occupies the entire viewport at a time.
-48. As a visitor, I want entries in newest-first order so that the most recent work is encountered first.
-49. As a visitor, I want the section-type label (`// EDUCATION` or `// EXPERIENCE`) to appear at the top of each panel, with `//` in Space Mono and the section word in Press Start 2P, both in orange, so that the kind of entry is immediately clear.
-50. As a visitor, I want the `//` to be visually smaller than the section word so that the hierarchy within the label is preserved.
-51. As a visitor, I want the commit metadata (`commit <hash>`, `Author`, `Date`) to type in first in orange/periwinkle mono so that the git-log framing is established before the main content.
-52. As a visitor, I want the institution/company name to type in as large Press Start 2P text (`clamp(28px, 4vw, 52px)`) so that it dominates the panel the way the hero name dominates the hero.
-53. As a visitor, I want the role/title to appear in uppercase Space Mono below the institution name so that the content hierarchy goes: label → commit meta → institution → role → bullets.
-54. As a visitor, I want each bullet to type in sequentially with a small delay between bullets so that the panel feels like a log being printed.
-55. As a visitor, I want a panel's typed content to remain visible when it deactivates (user scrolls past it) so that it does not blank during stack transitions.
-56. As a visitor, I want a section header row `// 03  TIMELINE` with a progress counter (`01 / 05`) so that the entry position is always visible.
-57. As a visitor, I want a `SCROLL ↓` hint at the bottom of each timeline panel so that the scroll direction is always clear.
+49. As a visitor, I want Timeline to be one major section with a sticky viewport and an internal horizontal track so that it behaves like the reference instead of becoming several global sticky pages.
+50. As a visitor, I want the newest entry to start centered and scrolling to reveal older entries horizontally from the left so that the intentional reverse-chronological motion is preserved.
+51. As a visitor, I want invisible snap anchors, one per timeline entry, so that each entry settles firmly in the viewport.
+52. As a visitor, I want each timeline entry to occupy a full viewport-width panel within the horizontal track so that one entry is the clear focus at a time.
+53. As a visitor, I want the section-type label (`// EDUCATION` or `// EXPERIENCE`) to appear at the top of each panel, with `//` in Space Mono and the section word in Press Start 2P, both in orange, so that the kind of entry is immediately clear.
+54. As a visitor, I want the `//` to be visually smaller than the section word so that the hierarchy within the label is preserved.
+55. As a visitor, I want the commit metadata (`commit <hash>`, `Author`, `Date`) to type in first in orange/periwinkle mono so that the git-log framing is established before the main content.
+56. As a visitor, I want the institution/company name to type in as large Press Start 2P text (`clamp(28px, 4vw, 52px)`) so that it dominates the panel the way the hero name dominates the hero.
+57. As a visitor, I want the role/title to appear in uppercase Space Mono below the institution name so that the content hierarchy goes: label, commit meta, institution, role, bullets.
+58. As a visitor, I want each bullet to type in sequentially with a small delay between bullets so that the panel feels like a log being printed.
+59. As a visitor, I want a panel's typed content to remain visible when it deactivates so that it does not blank during horizontal slide transitions.
+60. As a visitor, I want a section header row `// 03  TIMELINE` with a progress counter (`01 / 05`) so that the entry position is always visible.
+61. As a visitor, I want a `SCROLL v` hint at the bottom of the pinned viewport so that the scroll direction is clear.
 
 ### Contact / CTA
-58. As a visitor, I want the contact section to be full-screen with `LET'S` on one line and `CONNECT.` on the next in Press Start 2P at `clamp(40px, 8vw, 120px)` so that the CTA dominates the viewport the same way the hero name does.
-59. As a visitor, I want the text to be centered (unlike the left-aligned hero) so that the CTA feels like a declaration.
-60. As a visitor, I want the period `.` to be orange and followed by a blinking orange block cursor so that the terminal punctuation lands as a visual beat.
-61. As a visitor, I want `SEND_MESSAGE →` as a centered orange fill button below the heading so that the primary action is unmissable.
-62. As a visitor, I want social links (`// GITHUB`, `// LINKEDIN`, `// EMAIL`, `// RESUME`) centered below the button in periwinkle mono with orange `//` prefix so that they feel like terminal directory entries.
-63. As a visitor, I want the footer metadata (`FARHAN_MOHAMMED © 2026` left, `PORTFOLIO.EXE` right) to be at the very bottom of the viewport, separated from the CTA area so that it does not crowd the CTA.
+62. As a visitor, I want the contact section to be full-screen with `LET'S` on one line and `CONNECT.` on the next in Press Start 2P at `clamp(40px, 8vw, 120px)` so that the CTA dominates the viewport the same way the hero name does.
+63. As a visitor, I want the text to be centered so that the CTA feels like a declaration.
+64. As a visitor, I want the period `.` to be orange and followed by a blinking orange block cursor so that the terminal punctuation lands as a visual beat.
+65. As a visitor, I want the contact type-in animation to reset and replay when the contact section re-enters view so that it matches the reference.
+66. As a visitor, I want `SEND_MESSAGE ->` as a centered orange fill button below the heading so that the primary action is unmissable.
+67. As a visitor, I want social links (`// GITHUB`, `// LINKEDIN`, `// EMAIL`, `// RESUME`) centered below the button in periwinkle mono with orange `//` prefix so that they feel like terminal directory entries.
+68. As a visitor, I want the footer metadata (`FARHAN_MOHAMMED © 2026` left, `PORTFOLIO.EXE` right) to be at the very bottom of the viewport, separated from the CTA area so that it does not crowd the CTA.
 
-### Card-Deck Stacking
-64. As a visitor, I want each major section (Hero, Projects outer, Skills, each Timeline panel, Contact) to be `position: sticky; top: 0` so that sections stack as I scroll.
-65. As a visitor, I want the outgoing section to scale down to ~0.95 and dim to ~0.75 opacity as the next section enters so that the depth layering is physically legible.
-66. As a visitor, I want no blur on stacked sections so that the visual stays clean.
-67. As a visitor, I want no border-radius on section surfaces so that the sharp edges are preserved throughout the stack.
-68. As a visitor, I want the Projects outer layer to participate in the card-deck stack while the inner carousel handles horizontal movement independently so that the two behaviors do not interfere.
+### Scroll, Snap, and Navigation
+69. As a visitor, I want the page to use normal vertical document flow so that major sections do not disappear behind a global sticky stack.
+70. As a visitor, I want CSS scroll snapping to be proximity-based so that scrolling can settle naturally without feeling locked or hijacked.
+71. As a visitor, I want Projects and Timeline to provide their own internal snap landing points so that multi-card/multi-entry sections are easy to navigate.
+72. As a visitor, I want manual scrolling to remain native, while navbar and CTA jumps scroll smoothly to their target section, so that intentional navigation feels polished without changing wheel/trackpad behavior.
+73. As a visitor, I want no global section scale-down, dimming, blur, or card-deck depth effect so that the app matches the reference scroll model.
+74. As a visitor, I want decorative parallax to be bounded relative to each owning section so that parallax never drifts across unrelated sections.
 
 ### Browser Chrome
-69. As a visitor, I want text selection to show orange background with graphite text so that the selection color is on-brand.
-70. As a visitor, I want the scrollbar thumb to be orange and square (no border-radius) on the graphite track so that the scrollbar is on-brand.
+75. As a visitor, I want text selection to show orange background with graphite text so that the selection color is on-brand.
+76. As a visitor, I want the scrollbar thumb to be orange and square on the graphite track so that the scrollbar is on-brand.
+77. As a visitor, I want the document itself to have no horizontal scrollbar so that wide internal tracks do not leak outside their clipped viewports.
 
 ## Implementation Decisions
 
-- **CSS anchor file.** Create `src/portfolio.css` as `@layer components { … }` containing the component rules from `ideas/Portfolio.html` lines 11–233 verbatim, adapted only to use the Tailwind v4 token variable names already defined in `src/index.css` (e.g. `var(--color-graphite)` instead of `var(--graphite)`). Import this file in `src/main.tsx`. Do not duplicate the `:root` token block.
+- **CSS anchor file.** Keep `src/portfolio.css` as `@layer components { ... }` containing the component rules from `ideas/Portfolio.html`, adapted only to use the Tailwind v4 token variable names already defined in `src/index.css` (e.g. `var(--color-graphite)` instead of `var(--graphite)`). Do not duplicate the `:root` token block.
 
-- **Class name convention.** Component rules use the same class names as `ideas/Portfolio.html`: `.hero-name`, `.pcard`, `.tl-org`, `.footer-big`, etc. React components apply these class names directly. Tailwind utilities may still be used for structural helpers not covered by `src/portfolio.css` (e.g. `flex`, `relative`, `z-10`), but must not override any property already set by a portfolio class.
+- **Class name convention.** Component rules use the same class names as `ideas/Portfolio.html`: `.hero-name`, `.pcard`, `.tl-org`, `.footer-big`, etc. React components apply these class names directly. Tailwind utilities may still be used for structural helpers not covered by `src/portfolio.css`, but must not override any property already set by a portfolio class.
 
-- **HeroSection.** The `<h1>` applies `hero-name`. Name is split into two `<span className="hero-name-line">` block elements. `// PORTFOLIO_INIT` uses `TypeIn` and gets class `hero-init`. The bar gets class `hero-bar`. Background grid element gets class `hero-grid` (line grid + radial mask fade, replaces current dot grid). Padding is set via `hero-inner` (5vw). CTA row uses `hero-cta`, buttons use `btn btn-fill` / `btn btn-outline`.
+- **Global scroll model.** Match the reference: `html` uses native scroll behavior and proximity vertical scroll snap; `body` clips horizontal overflow; only `#hero`, `#skills`, and `#contact` snap directly as major one-screen sections. Projects and Timeline own their internal snap anchors. Do not implement a global card-deck stack, global sticky section wrapper, or outgoing section scale/opacity depth effect.
 
-- **ProjectsSection.** Header row children get `hscroll-no`, `hscroll-name`, `hscroll-rule`. Progress counter and bar are added using `hscroll-progress`, `hscroll-progress-track`, `hscroll-progress-fill`. Scroll hint uses `hscroll-hint`. Edge spacers use `proj-edge`. Card uses `pcard` + `pcard-bg` + `pcard-fill` + `pcard-body` + `pcard-ghost` + `pcard-num` + `pcard-name` + `pcard-desc` + `pcard-tags` + `pcard-links`. Tag colors use `ptag ptag-{color}`. Links use `plink`. Card dimensions come from `.pcard` CSS (`min(560px, 78vw)` × `min(640px, 76vh)`). The diagonal fill animation uses the mask-position approach from the reference.
+- **HeroSection.** The hero intro starts only after the loading screen completes. The `<h1>` applies `hero-name`. Name is split into two `<span className="hero-name-line">` block elements. `// PORTFOLIO_INIT` uses `TypeIn` and gets class `hero-init`. The bar gets class `hero-bar`. Background grid element gets class `hero-grid`. Padding is set via `hero-inner` / section spacing. CTA row uses `hero-cta`, buttons use `btn btn-fill` / `btn btn-outline`.
 
-- **SkillsSection.** Grid container gets class `bento`. Each tile gets `bi bi-{area} c-{color}` classes. Reveal order is a static deterministic array sorted largest-first: `['py','js','dk','re','cc','nd','nx','fl','gt','pg','fg','mn']` then palette. `transitionDelay` is derived from this array index.
+- **Horizontal progress module.** Extract or keep a deep module that accepts an outer section and an inner track and returns `{ tx, progress }`. It computes progress from the section's bounding rect, the section height, and the viewport height. It computes horizontal distance from `track.scrollWidth - viewportWidth`. It does not know about Projects-specific card data.
 
-- **TimelineSection.** Section-type label uses two separate elements: `<span className="tl-section-slash">//</span>` + `<span className="tl-section-kind">{entry.kind}</span>` inside a `tl-section-tag` wrapper. Institution uses `tl-org`. Role uses `tl-title`. Bullets use `tl-bullets`. Commit/author/date use `tl-commit` / `tl-meta`. Timeline section header row uses the same `hscroll-head` / `hscroll-no` / `hscroll-name` / `hscroll-rule` / `hscroll-progress` pattern as Projects.
+- **ProjectsSection.** Projects uses one viewport of section height per project. The section contains an internal sticky viewport (`hscroll` / `hscroll-sticky`) and a horizontally translated `hscroll-track proj-track`. It renders one `snap-anchor` per project at `i * 100vh` so CSS snap settles per card. Header row children get `hscroll-no`, `hscroll-name`, `hscroll-rule`. Progress counter and bar use `hscroll-progress`, `hscroll-progress-track`, `hscroll-progress-fill`. Scroll hint uses `hscroll-hint`. Edge spacers use `proj-edge`. Card uses `pcard` + `pcard-bg` + `pcard-fill` + `pcard-body` + `pcard-ghost` + `pcard-num` + `pcard-name` + `pcard-desc` + `pcard-tags` + `pcard-links`. Tag colors use `ptag ptag-{color}`. Links use `plink`. Card dimensions come from `.pcard` CSS (`min(560px, 78vw)` by `min(640px, 76vh)`). The diagonal fill animation uses the mask-position approach from the reference. Do not add active/neighbor/far scale or opacity suppression.
 
-- **ContactSection.** Merged into a single `<footer id="contact">` element. Heading uses `footer-big` and `footer-big-line` spans. Layout uses `footer-cta`. Social links use `slink` class. Footer metadata row uses `footer-copy`.
+- **SkillsSection.** Grid container gets class `bento`. Each tile gets `bi bi-{area} c-{color}` classes. Reveal order is randomized each time the section enters view, matching the reference behavior. The reveal resets when the section leaves view so it can replay on re-entry.
 
-- **Cursor rule.** A file at `.cursor/rules/portfolio-css.md` with the following constraint: all classes defined in `src/portfolio.css` are verbatim from the reference and must not be replaced with Tailwind equivalents. Any new elements must check `src/portfolio.css` before reaching for Tailwind.
+- **TimelineSection.** Timeline is one major section, not one global sticky section per entry. It uses a tall section equal to `timelineEntryCount * viewportHeight`, an internal sticky viewport, and a horizontally translated track. Timeline entries remain newest-first in content semantics, but the rendered track order is reversed so the newest entry starts centered and scrolling reveals older entries horizontally from the left. The track translation is quantized to panel positions with a smooth transform transition. Render one `snap-anchor` per entry at `i * 100vh`. Section-type label uses two separate elements: `<span className="tl-section-slash">//</span>` + `<span className="tl-section-kind">{entry.kind}</span>` inside a `tl-section-tag` wrapper. Institution uses `tl-org`. Role uses `tl-title`. Bullets use `tl-bullets`. Commit/author/date use `tl-commit` / `tl-meta`. Timeline section header row uses the same `hscroll-head` / `hscroll-no` / `hscroll-name` / `hscroll-rule` / `hscroll-progress` pattern as Projects.
 
-- **Scrollbar.** Remove `border-radius: 4px` from `::-webkit-scrollbar-thumb` in `src/index.css`.
+- **ContactSection.** Merged into a single `<footer id="contact">` element. Heading uses `footer-big` and `footer-big-line` spans. Layout uses `footer-cta`. Social links use `slink` class. Footer metadata row uses `footer-copy`. The contact heading type-in resets and replays when Contact leaves and re-enters view.
 
-- **Nav active state.** The `>` caret appears on hover only, not on active. Active state = orange label text + orange `::after` underline scoped to the label only (not the caret area). No box border on active state.
+- **Active navigation.** Use major-section geometry sampling around 40% of the viewport height, as in the reference, so the active nav item remains `PROJECTS` for the whole Projects internal scroll and `TIMELINE` for the whole Timeline internal scroll. Navbar/CTA click handlers should call smooth `scrollTo` on explicit jumps; global CSS should not force smooth behavior on all scrolling.
 
-- **What does not change.** React component structure, hook interfaces (`useHorizontalScroll`, `useCardDeckDepth`, `useActivePanel`), Vitest test file structure, and Framer Motion usage for card-deck depth and the Projects carousel translate offset.
+- **Parallax.** Parallax transforms are section-relative. Each parallax element computes movement from scroll offset relative to its owning section or footer so transforms remain bounded inside that section.
+
+- **Browser chrome and overflow.** Remove `border-radius: 4px` from `::-webkit-scrollbar-thumb`. Set document horizontal overflow to hidden. Prefer `width: 100%` over `100vw` where it avoids scrollbar-induced overflow and does not change the rendered reference layout; keep intentionally wide internal tracks clipped by their sticky viewport.
+
+- **Nav active state.** The `>` caret appears on hover only, not on active. Active state = orange label text + orange `::after` underline scoped to the label only. No box border on active state.
+
+- **Content source.** Keep the current app's real project and timeline content. `ideas/Portfolio.html` is the motion/visual reference, not the content source.
+
+- **What must be removed.** Remove or stop using global card-deck depth behavior, per-entry global Timeline sticky sections, Projects dead-zone progress math, and Project active/neighbor/far scale/opacity states. These are incorrect interpretations of the reference.
 
 ## Testing Decisions
 
-Good tests verify observable output (rendered DOM structure, presence of expected elements, hook return values) rather than implementation details (which internal CSS class was chosen). Do not test font-size or color values — those are browser rendering concerns verified by manual QA against the reference screenshots.
+Good tests verify observable output (rendered DOM structure, presence of expected elements, hook return values, and scroll math outputs) rather than implementation details. Do not test font-size or color values; those are browser rendering concerns verified by manual QA against the reference screenshots.
 
-- `src/index-css.test.ts` — extend to assert `border-radius` is absent from the scrollbar thumb rule.
-- `HeroSection.test.tsx` — assert hero name renders two `hero-name-line` span elements; assert `hero-init` text is present; assert `hero-bar` element exists.
-- `ProjectsSection.test.tsx` — assert progress counter element is present; assert scroll hint element is present; assert each card has a `pcard-ghost` element; assert tag elements have `ptag` class.
-- `SkillsSection.test.tsx` — assert tile reveal `transitionDelay` values are identical across two renders (determinism check).
-- `TimelineSection.test.tsx` — assert `tl-section-slash` and `tl-section-kind` are separate sibling elements; assert `tl-org` element contains institution text.
-- `ContactSection.test.tsx` — assert heading element has `footer-big` class; assert social link elements have `slink` class.
-- Scroll hook behavior (`useHorizontalScroll`, `useCardDeckDepth`) is already tested; do not re-test.
-- Card-deck depth transitions and scroll motion are browser-only concerns and require manual verification against the reference screenshots.
+- `src/index-css.test.ts` - assert `body` clips horizontal overflow and `border-radius` is absent from the scrollbar thumb rule.
+- `HeroSection.test.tsx` - assert hero name renders two `hero-name-line` span elements; assert `hero-init` text is present; assert `hero-bar` element exists; assert intro can be started after loading completes.
+- `ProjectsSection.test.tsx` - assert the section height is one viewport per project; assert one `snap-anchor` per project; assert progress counter element is present; assert scroll hint element is present; assert each card has a `pcard-ghost` element; assert tag elements have `ptag` class; assert cards do not carry active/neighbor/far scale/opacity state attributes.
+- `SkillsSection.test.tsx` - assert tiles reset/replay on viewport re-entry; mock randomness or isolate reveal-order generation so tests verify "new order can be generated on entry" without depending on a specific random sequence.
+- `TimelineSection.test.tsx` - assert Timeline renders as one major section; assert entries are panels in one horizontal track; assert one `snap-anchor` per entry; assert newest content is the first user-facing panel; assert `tl-section-slash` and `tl-section-kind` are separate sibling elements; assert `tl-org` element contains institution text.
+- `ContactSection.test.tsx` - assert heading element has `footer-big` class; assert social link elements have `slink` class; assert type-in state resets when the section leaves view and restarts on re-entry.
+- Navbar/shell tests - assert active nav remains on the owning major section for the full Projects and Timeline scroll ranges. Assert explicit nav jumps use smooth scroll behavior.
+- Scroll hook tests - test horizontal progress math and Timeline quantization as pure or hook-level behavior. Do not re-test browser rendering.
+- Regression tests - assert no global card-deck depth hook/style mutates section scale or opacity, and assert document-level horizontal overflow is clipped.
+- Browser QA - card centering, CSS scroll snap feel, Timeline slide direction, parallax, and no horizontal scrollbar require manual verification against `ideas/Portfolio.html` and the `curr_*` screenshots.
 
 ## Out of Scope
 
 - Contact form backend or email service integration.
 - CMS or content management for projects and resume data.
-- Mobile responsive redesign — desktop visual alignment is the current priority; mobile work begins only after the desktop view passes visual QA against the reference screenshots.
+- Mobile responsive redesign; desktop visual and scroll alignment is the current priority.
 - Accessibility audit (`aria-*` attributes, keyboard navigation beyond existing focus handling, reduced-motion media query).
 - Performance optimization (bundle splitting, image optimization, Lighthouse audit).
 - Dark/light mode toggle.
 - Internationalization.
 - Analytics beyond the existing Vercel Analytics integration.
+- Replacing React with the standalone HTML implementation.
 
 ## Further Notes
 
-- **Visual source of truth.** `ideas/Portfolio.html` is the primary CSS reference. The six screenshots (`ideas/home.png`, `ideas/proj.png`, `ideas/skills.png`, `ideas/timeline.png`, `ideas/timeline 2.png`, `ideas/cta.png`) are the visual QA targets. For any ambiguity between the HTML source and a screenshot, the screenshot takes precedence since it reflects the rendered output.
+- **Visual and behavior source of truth.** `ideas/Portfolio.html` is the primary CSS and scroll-behavior reference. The `curr_*` screenshots in `ideas/` are current-state QA artifacts. For any ambiguity between the HTML source and a screenshot, the screenshot takes precedence only for rendered visual output; the HTML source takes precedence for scroll mechanics.
 
 - **Content source of truth.** `public/resume.pdf` is the canonical content source for names, dates, roles, institutions, project descriptions, and technologies. Do not invent content to fill layouts.
 
-- **Relation to existing issues.** Issues #154–161 and #164 describe specific sub-tasks that remain valid under this PRD. This document supersedes the deleted `PRD.md` and `DESIGN.md`.
+- **Reference scroll facts.** The reference uses `body { overflow-x: hidden }`, `html { scroll-snap-type: y proximity }`, `snap-anchor` elements with `scroll-snap-stop: always`, one viewport of Projects height per project, one viewport of Timeline height per entry, smooth scroll only for explicit nav jumps, section-relative parallax, and active nav sampling around 40% of viewport height.
 
-- **Desktop QA gate.** Before marking any issue done, run the app in a browser and compare the implemented section against `ideas/Portfolio.html` (opened in browser) and the matching reference screenshot. Note intentional deviations explicitly. Open a follow-up issue for any unexplained deviation.
+- **Relation to existing issues.** Issues #154-161 describe visual sub-tasks that remain valid under this PRD. Any issue or test that requires global sticky/card-deck stacking, `useCardDeckDepth`-style scale/opacity, or each Timeline entry as a global sticky section is superseded by this update.
+
+- **Desktop QA gate.** Before marking any issue done, run the app in a browser and compare the implemented behavior against `ideas/Portfolio.html` and the matching current/reference screenshot. Note intentional deviations explicitly. Open a follow-up issue for any unexplained deviation.


### PR DESCRIPTION
## Summary
- Reframes the PRD around matching the reference HTML scroll model instead of the accidental global card-deck stack behavior.
- Documents Projects and Timeline as internal sticky horizontal sections with snap anchors and no document horizontal overflow.
- Updates implementation and testing guidance to prevent reintroducing global section scale/dim behavior.

## Test plan
- Documentation-only change; no app tests run.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised portfolio architecture and acceptance criteria to prevent scroll behavior regressions.
  * Updated requirements around scroll ownership, vertical document flow, and overflow control.
  * Clarified user stories for Projects and Timeline sections with improved scroll and navigation handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->