### PR TITLE
Fix loader-to-hero intro handoff

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,11 @@
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { act, render } from '@testing-library/react'
 import App from './App'
+import {
+  BOOT_DURATION,
+  FADE_OUT_DURATION,
+} from './components/LoadingScreen.constants'
+import { FIRST_NAME, NAME_SPEED } from './components/HeroSection.constants'
 
 const sections = ['home', 'projects', 'skills', 'timeline', 'contact'] as const
 const sectionIds = [
@@ -337,6 +342,53 @@ describe('App shell', () => {
       expect(projects.style.transform).toBe('')
       expect(projects.style.transform).not.toContain('translateX')
       expect(carouselTrack.style.transform).toContain('translateX')
+    })
+  })
+
+  describe('issue #216 - loader-to-hero intro handoff', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('does not advance hero type-in while the loading screen is visible', () => {
+      render(<App />)
+
+      expect(document.getElementById('ls')).toBeInTheDocument()
+
+      act(() => {
+        vi.advanceTimersByTime(BOOT_DURATION + FADE_OUT_DURATION - 1)
+      })
+
+      const nameLines = document.getElementById('home')?.querySelectorAll('.hero-name-line')
+      expect(nameLines?.[0]?.textContent).toBe('')
+      expect(nameLines?.[1]?.textContent).toBe('')
+    })
+
+    it('starts hero intro from the beginning after loading completes', async () => {
+      render(<App />)
+
+      await act(async () => {
+        vi.advanceTimersByTime(BOOT_DURATION)
+      })
+      await act(async () => {
+        vi.advanceTimersByTime(FADE_OUT_DURATION)
+      })
+
+      expect(document.getElementById('ls')).not.toBeInTheDocument()
+
+      const nameLines = document.getElementById('home')?.querySelectorAll('.hero-name-line')
+      expect(nameLines?.[0]?.textContent).toBe('')
+
+      act(() => {
+        vi.advanceTimersByTime(NAME_SPEED)
+      })
+
+      expect(nameLines?.[0]?.textContent).toBe(FIRST_NAME.slice(0, 1))
+      expect(nameLines?.[1]?.textContent).toBe('')
     })
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ function App() {
       </AnimatePresence>
       <Navbar />
       <main>
-        <HeroSection />
+        <HeroSection introReady={!loading} />
         <ProjectsSection projects={projects} />
         <SkillsSection />
         <TimelineSection />

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -353,4 +353,38 @@ describe('HeroSection', () => {
       })
     })
   })
+
+  it('does not start name typing until introReady is true', () => {
+    render(<HeroSection introReady={false} />)
+
+    const nameLines = screen.getByTestId('hero-name').querySelectorAll('.hero-name-line')
+
+    act(() => {
+      vi.advanceTimersByTime(FIRST_NAME_DURATION + LAST_NAME_DURATION)
+    })
+
+    expect(nameLines[0]?.textContent).toBe('')
+    expect(nameLines[1]?.textContent).toBe('')
+    expect(screen.queryByTestId('hero-name-cursor')).not.toBeInTheDocument()
+  })
+
+  it('starts name typing from the beginning when introReady becomes true', () => {
+    const { rerender } = render(<HeroSection introReady={false} />)
+    const nameLines = screen.getByTestId('hero-name').querySelectorAll('.hero-name-line')
+
+    act(() => {
+      vi.advanceTimersByTime(FIRST_NAME_DURATION)
+    })
+
+    expect(nameLines[0]?.textContent).toBe('')
+
+    rerender(<HeroSection introReady={true} />)
+
+    act(() => {
+      vi.advanceTimersByTime(NAME_SPEED)
+    })
+
+    expect(nameLines[0]?.textContent).toBe(FIRST_NAME.slice(0, 1))
+    expect(nameLines[1]?.textContent).toBe('')
+  })
 })

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -19,7 +19,11 @@ const ctaVariants = {
   visible: { opacity: 1, y: 0 },
 }
 
-const HeroSection: React.FC = () => {
+interface HeroSectionProps {
+  introReady?: boolean
+}
+
+const HeroSection: React.FC<HeroSectionProps> = ({ introReady = true }) => {
   const [firstNameDone, setFirstNameDone] = useState(false)
   const [nameDone, setNameDone] = useState(false)
   const [showNameCursor, setShowNameCursor] = useState(false)
@@ -45,7 +49,7 @@ const HeroSection: React.FC = () => {
         <h1 data-testid="hero-name" className="hero-name">
           <span className="hero-name-line">
             <TypeIn
-              start={true}
+              start={introReady}
               text={FIRST_NAME}
               speed={NAME_SPEED}
               onDone={() => {


### PR DESCRIPTION
## Purpose
Ensure visitors see the full hero typing sequence instead of it advancing hidden behind the loading overlay.

## What it does
Gates the hero name TypeIn behind an `introReady` prop that App sets only after `LoadingScreen` completes its boot sequence and fade-out handoff.

## Changes made
- `HeroSection.tsx` — accept `introReady` prop and defer first-name TypeIn until it is true
- `App.tsx` — pass `introReady={!loading}` to HeroSection
- `HeroSection.test.tsx` — cover intro idle vs. start-on-ready behavior
- `App.test.tsx` — integration tests for loader-to-hero timing handoff (#216)

## Additional notes
- `introReady` defaults to `true` so existing isolated HeroSection unit tests remain unchanged
- Loading screen boot/fade timing unchanged; hero intro now starts from the beginning once the overlay unmounts

Closes #216

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the coordination between the loading screen and hero intro typing animation to ensure typing only begins after the loading screen completes.

* **Tests**
  * Added comprehensive test coverage for the loader-to-hero intro handoff, verifying that the hero type-in animation respects loading state and begins correctly after loading finishes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->