### PR TITLE
Reset and replay Contact type-in on re-entry

### DIFF
--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -110,6 +110,54 @@ describe('ContactSection', () => {
       expect(document.querySelector('#contact .footer-big')).toHaveTextContent("LET'SCONNECT.")
       expect(document.querySelector('[data-testid="contact-cursor"]')).toBeInTheDocument()
     })
+
+    it('clears partial type-in when section leaves mid-animation', () => {
+      let inView = false
+      vi.mocked(useInView).mockImplementation(() => inView)
+      vi.useFakeTimers()
+
+      const { rerender } = render(<ContactSection />)
+
+      inView = true
+      rerender(<ContactSection />)
+
+      act(() => { vi.advanceTimersByTime(250) })
+      expect(screen.getByText("LET'S")).toBeInTheDocument()
+
+      act(() => { vi.advanceTimersByTime(150) })
+      expect(screen.getByText('CON')).toBeInTheDocument()
+      expect(document.querySelector('[data-testid="contact-cursor"]')).not.toBeInTheDocument()
+
+      inView = false
+      rerender(<ContactSection />)
+
+      expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
+      expect(screen.queryByText('CON')).not.toBeInTheDocument()
+      expect(document.querySelector('#contact .period')).not.toBeInTheDocument()
+    })
+
+    it('does not flash cursor or period on immediate re-entry after full animation', () => {
+      let inView = false
+      vi.mocked(useInView).mockImplementation(() => inView)
+      vi.useFakeTimers()
+
+      const { rerender } = render(<ContactSection />)
+
+      inView = true
+      rerender(<ContactSection />)
+      act(() => { vi.advanceTimersByTime(250) })
+      act(() => { vi.advanceTimersByTime(400) })
+      expect(document.querySelector('[data-testid="contact-cursor"]')).toBeInTheDocument()
+
+      inView = false
+      rerender(<ContactSection />)
+      inView = true
+      rerender(<ContactSection />)
+
+      expect(document.querySelector('[data-testid="contact-cursor"]')).not.toBeInTheDocument()
+      expect(document.querySelector('#contact .period')).not.toBeInTheDocument()
+      expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
+    })
   })
 
   describe('issue #87 - LET\'S CONNECT. typewriter', () => {

--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -70,6 +70,48 @@ describe('ContactSection', () => {
     })
   })
 
+  describe('issue #222 - reset and replay type-in on re-entry', () => {
+    it('resets heading and cursor when section leaves view and replays from start on re-entry', () => {
+      let inView = false
+      vi.mocked(useInView).mockImplementation(() => inView)
+      vi.useFakeTimers()
+
+      const { rerender } = render(<ContactSection />)
+
+      expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
+
+      inView = true
+      rerender(<ContactSection />)
+
+      act(() => { vi.advanceTimersByTime(250) })
+      expect(screen.getByText("LET'S")).toBeInTheDocument()
+
+      act(() => { vi.advanceTimersByTime(400) })
+      expect(document.querySelector('#contact .footer-big')).toHaveTextContent("LET'SCONNECT.")
+      expect(document.querySelector('[data-testid="contact-cursor"]')).toBeInTheDocument()
+
+      inView = false
+      rerender(<ContactSection />)
+
+      expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
+      expect(document.querySelector('[data-testid="contact-cursor"]')).not.toBeInTheDocument()
+      expect(document.querySelector('#contact .period')).not.toBeInTheDocument()
+
+      inView = true
+      rerender(<ContactSection />)
+
+      expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
+
+      act(() => { vi.advanceTimersByTime(250) })
+      expect(screen.getByText("LET'S")).toBeInTheDocument()
+      expect(screen.queryByText('CONNECT')).not.toBeInTheDocument()
+
+      act(() => { vi.advanceTimersByTime(400) })
+      expect(document.querySelector('#contact .footer-big')).toHaveTextContent("LET'SCONNECT.")
+      expect(document.querySelector('[data-testid="contact-cursor"]')).toBeInTheDocument()
+    })
+  })
+
   describe('issue #87 - LET\'S CONNECT. typewriter', () => {
     it('heading is not visible when section is out of view', () => {
       vi.mocked(useInView).mockReturnValue(false)

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { motion, useInView } from 'framer-motion'
 import { TypeIn } from '../animations/TypeIn'
 import { hoverEase } from '../animations/variants'
@@ -16,8 +16,14 @@ const footerLinks = [
 
 export default function ContactSection() {
   const ref = useRef(null)
-  const isInView = useInView(ref, { once: true })
+  const isInView = useInView(ref)
   const [step, setStep] = useState(0)
+
+  useEffect(() => {
+    if (!isInView) {
+      setStep(0)
+    }
+  }, [isInView])
 
   return (
     <StickySection as="footer" id="contact" className="bg-graphite">
@@ -33,13 +39,13 @@ export default function ContactSection() {
           </span>
           <span className="footer-big-line">
             <TypeIn
-              start={step >= 1}
+              start={isInView && step >= 1}
               text="CONNECT"
               speed={CONTACT_SPEED}
               onDone={() => setStep((s) => Math.max(s, 2))}
             />
-            {step >= 2 && <span className="period">.</span>}
-            {step >= 2 && (
+            {isInView && step >= 2 && <span className="period">.</span>}
+            {isInView && step >= 2 && (
               <span className="cursor" data-testid="contact-cursor" aria-hidden="true" />
             )}
           </span>


### PR DESCRIPTION
## Purpose

Contact heading type-in should reset when the section leaves the viewport and replay from the beginning when the user scrolls back, matching the reference behavior (PRD user story 65).

## What it does

Tracks Contact section visibility continuously (no `once: true`), resets the typing step when the section leaves view, and gates the CONNECT line, period, and cursor on `isInView` so all animation state clears on exit and replays on re-entry.

## Changes made

- `ContactSection.tsx` — remove `useInView` `once: true`, reset `step` on leave, gate secondary type-in and cursor on visibility
- `ContactSection.test.tsx` — add leave-and-re-enter test simulating viewport exit and return

## Additional notes

Follows the same enter/leave visibility pattern as `SkillsSection`. `TypeIn` already restarts cleanly when `start` flips false → true.

Closes #222

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Typing animation in the Contact section now reliably resets when the section leaves view and restarts from the beginning when you scroll back, preventing partial or stale text/cursor from persisting.

* **Tests**
  * Added robust tests that validate restart, cleanup, and intermediate animation states across leave/re-enter scenarios to ensure consistent on-screen behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->