### PR TITLE
Randomize and replay Skills reveal on each entry

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { act, render, screen } from '@testing-library/react'
-import { REVEAL_ORDER, SkillsSection, revealTransitionDelay } from './SkillsSection'
+import {
+  REVEAL_AREAS,
+  SkillsSection,
+  createShuffledRevealOrder,
+  revealTransitionDelay,
+} from './SkillsSection'
 
 let observerCallback!: IntersectionObserverCallback
 let observedElement: Element | undefined
@@ -29,14 +34,6 @@ function getSkillTile(name: string) {
   return tile as HTMLElement
 }
 
-function getTileTransitionDelay(name: string) {
-  return getSkillTile(name).style.transitionDelay
-}
-
-function parseTransitionDelaySeconds(delay: string) {
-  return Number.parseFloat(delay)
-}
-
 function getLatestSkillTileTransitionDelays() {
   const grid = screen.getByTestId('skills-grid')
   return Array.from(grid.querySelectorAll('.bi')).map((tile) => {
@@ -54,6 +51,40 @@ function fireIntersection(isIntersecting: boolean) {
   })
 }
 
+describe('createShuffledRevealOrder', () => {
+  it('assigns every area a unique index from 0 through n - 1', () => {
+    const order = createShuffledRevealOrder(() => 0)
+
+    expect(order.size).toBe(REVEAL_AREAS.length)
+    expect([...order.values()].sort((a, b) => a - b)).toEqual(
+      REVEAL_AREAS.map((_, index) => index),
+    )
+  })
+
+  it('can produce a different order when randomness changes', () => {
+    const firstOrder = createShuffledRevealOrder(() => 0)
+    let call = 0
+    const secondOrder = createShuffledRevealOrder(() => {
+      call += 1
+      return call === 1 ? 0.99 : 0
+    })
+
+    expect([...firstOrder.entries()]).not.toEqual([...secondOrder.entries()])
+  })
+})
+
+describe('revealTransitionDelay', () => {
+  it('derives delay from the provided reveal-order index', () => {
+    const order = new Map([
+      ['py', 2],
+      ['pal', 5],
+    ])
+
+    expect(revealTransitionDelay('py', order)).toBe('0.24s')
+    expect(revealTransitionDelay('pal', order)).toBe('0.6s')
+  })
+})
+
 describe('SkillsSection', () => {
   beforeEach(() => {
     observedElement = undefined
@@ -63,6 +94,7 @@ describe('SkillsSection', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.restoreAllMocks()
   })
 
   it('renders a section element with id="skills"', () => {
@@ -167,38 +199,6 @@ describe('SkillsSection', () => {
     expect(pythonTile.className).toContain('bi-lg')
   })
 
-  it('reveals larger anchor skill tiles before smaller supporting tiles', () => {
-    render(<SkillsSection />)
-
-    expect(parseTransitionDelaySeconds(getTileTransitionDelay('Python')))
-      .toBeLessThan(parseTransitionDelaySeconds(getTileTransitionDelay('Docker')))
-    expect(parseTransitionDelaySeconds(getTileTransitionDelay('PyTorch')))
-      .toBeLessThan(parseTransitionDelaySeconds(getTileTransitionDelay('Git')))
-  })
-
-  it('assigns every skill tile one deterministic reveal position across renders', () => {
-    const { unmount } = render(<SkillsSection />)
-
-    const firstOrder = getLatestSkillTileTransitionDelays()
-
-    unmount()
-
-    render(<SkillsSection />)
-
-    const secondOrder = getLatestSkillTileTransitionDelays()
-
-    expect(new Set(firstOrder.map(([, delay]) => delay)).size).toBe(13)
-    expect(firstOrder).toEqual(secondOrder)
-  })
-
-  it('derives transitionDelay values from the static reveal-order array index', () => {
-    render(<SkillsSection />)
-
-    for (const [index, area] of REVEAL_ORDER.entries()) {
-      expect(revealTransitionDelay(area)).toBe(`${index * 0.12}s`)
-    }
-  })
-
   it('skill tiles use sharp edges (no rounded corners)', () => {
     render(<SkillsSection />)
     const grid = screen.getByTestId('skills-grid')
@@ -242,12 +242,19 @@ describe('SkillsSection', () => {
     }
   })
 
-  it('resets to hidden after leaving the viewport and replays the deterministic order on re-entry', () => {
+  it('assigns every tile a unique reveal delay when the grid enters the viewport', () => {
     render(<SkillsSection />)
 
     fireIntersection(true)
 
-    const firstRevealOrder = getLatestSkillTileTransitionDelays()
+    const delays = getLatestSkillTileTransitionDelays().map(([, delay]) => delay)
+    expect(new Set(delays).size).toBe(13)
+  })
+
+  it('resets to hidden after leaving the viewport', () => {
+    render(<SkillsSection />)
+
+    fireIntersection(true)
     expect(document.querySelectorAll('.bi.in')).toHaveLength(13)
 
     fireIntersection(false)
@@ -255,10 +262,33 @@ describe('SkillsSection', () => {
     for (const tile of document.querySelectorAll('.bi')) {
       expect(tile).not.toHaveClass('in')
     }
+  })
+
+  it('generates a fresh reveal order on each viewport entry and replays the reveal', () => {
+    const random = vi.spyOn(Math, 'random')
+    random.mockReturnValue(0)
+
+    render(<SkillsSection />)
 
     fireIntersection(true)
-
+    const firstDelays = getLatestSkillTileTransitionDelays()
     expect(document.querySelectorAll('.bi.in')).toHaveLength(13)
-    expect(getLatestSkillTileTransitionDelays()).toEqual(firstRevealOrder)
+
+    fireIntersection(false)
+    for (const tile of document.querySelectorAll('.bi')) {
+      expect(tile).not.toHaveClass('in')
+    }
+
+    let call = 0
+    random.mockImplementation(() => {
+      call += 1
+      return call === 1 ? 0.99 : 0
+    })
+
+    fireIntersection(true)
+    expect(document.querySelectorAll('.bi.in')).toHaveLength(13)
+
+    const secondDelays = getLatestSkillTileTransitionDelays()
+    expect(secondDelays).not.toEqual(firstDelays)
   })
 })

--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -264,6 +264,33 @@ describe('SkillsSection', () => {
     }
   })
 
+  it('clears transition delays after leaving the viewport', () => {
+    render(<SkillsSection />)
+
+    fireIntersection(true)
+    expect(new Set(getLatestSkillTileTransitionDelays().map(([, delay]) => delay)).size).toBe(13)
+
+    fireIntersection(false)
+
+    for (const [, delay] of getLatestSkillTileTransitionDelays()) {
+      expect(delay).toBe('0s')
+    }
+  })
+
+  it('keeps the same reveal order while the grid stays in the viewport', () => {
+    const random = vi.spyOn(Math, 'random')
+    random.mockReturnValue(0)
+
+    render(<SkillsSection />)
+
+    fireIntersection(true)
+    const firstDelays = getLatestSkillTileTransitionDelays()
+
+    fireIntersection(true)
+    expect(getLatestSkillTileTransitionDelays()).toEqual(firstDelays)
+    expect(random).toHaveBeenCalledTimes(12)
+  })
+
   it('generates a fresh reveal order on each viewport entry and replays the reveal', () => {
     const random = vi.spyOn(Math, 'random')
     random.mockReturnValue(0)

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -29,14 +29,21 @@ const tiles: SkillTile[] = [
   { area: 'mn', category: 'TOOL', name: 'Git', color: 'dark' },
 ]
 
-export const REVEAL_ORDER = ['py', 'js', 'dk', 're', 'cc', 'nd', 'nx', 'fl', 'gt', 'pg', 'fg', 'mn', 'pal'] as const
+export const REVEAL_AREAS = ['py', 'js', 'dk', 're', 'cc', 'nd', 'nx', 'fl', 'gt', 'pg', 'fg', 'mn', 'pal'] as const
 
-const revealOrderByArea = new Map<string, number>(
-  REVEAL_ORDER.map((area, index) => [area, index]),
-)
+export function createShuffledRevealOrder(
+  random: () => number = Math.random,
+): Map<string, number> {
+  const areas = [...REVEAL_AREAS]
+  for (let i = areas.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(random() * (i + 1))
+    ;[areas[i], areas[j]] = [areas[j], areas[i]]
+  }
+  return new Map(areas.map((area, index) => [area, index]))
+}
 
-export function revealTransitionDelay(area: string): string {
-  const index = revealOrderByArea.get(area) ?? 0
+export function revealTransitionDelay(area: string, revealOrder: Map<string, number>): string {
+  const index = revealOrder.get(area) ?? 0
   return `${index * TILE_REVEAL_STEP_S}s`
 }
 
@@ -47,11 +54,21 @@ const PALETTE = [
   'var(--color-ultrasonic-blue)',
 ] as const
 
-function SkillTileCard({ tile, visible }: { tile: SkillTile; visible: boolean }) {
+function SkillTileCard({
+  tile,
+  visible,
+  revealOrder,
+}: {
+  tile: SkillTile
+  visible: boolean
+  revealOrder: Map<string, number> | null
+}) {
   return (
     <div
       className={`bi bi-${tile.area} c-${tile.color}${tile.large ? ' bi-lg' : ''}${visible ? ' in' : ''}`}
-      style={{ transitionDelay: revealTransitionDelay(tile.area) }}
+      style={{
+        transitionDelay: revealOrder ? revealTransitionDelay(tile.area, revealOrder) : '0s',
+      }}
     >
       <div className="bi-cat">{tile.category}</div>
       <div className="bi-name">{tile.name}</div>
@@ -59,11 +76,19 @@ function SkillTileCard({ tile, visible }: { tile: SkillTile; visible: boolean })
   )
 }
 
-function PaletteTile({ visible }: { visible: boolean }) {
+function PaletteTile({
+  visible,
+  revealOrder,
+}: {
+  visible: boolean
+  revealOrder: Map<string, number> | null
+}) {
   return (
     <div
       className={`bi bi-pal${visible ? ' in' : ''}`}
-      style={{ transitionDelay: revealTransitionDelay('pal') }}
+      style={{
+        transitionDelay: revealOrder ? revealTransitionDelay('pal', revealOrder) : '0s',
+      }}
       data-testid="skills-palette"
     >
       {PALETTE.map((color, index) => (
@@ -76,6 +101,7 @@ function PaletteTile({ visible }: { visible: boolean }) {
 export function SkillsSection() {
   const gridRef = useRef<HTMLDivElement>(null)
   const [isInView, setIsInView] = useState(false)
+  const [revealOrder, setRevealOrder] = useState<Map<string, number> | null>(null)
 
   useEffect(() => {
     const grid = gridRef.current
@@ -85,7 +111,14 @@ export function SkillsSection() {
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        setIsInView(entry.isIntersecting)
+        if (entry.isIntersecting) {
+          setRevealOrder(createShuffledRevealOrder())
+          setIsInView(true)
+          return
+        }
+
+        setIsInView(false)
+        setRevealOrder(null)
       },
       { rootMargin: '-10% 0px -10% 0px' },
     )
@@ -105,9 +138,9 @@ export function SkillsSection() {
 
         <div ref={gridRef} data-testid="skills-grid" className="bento">
           {tiles.map((tile) => (
-            <SkillTileCard key={tile.area} tile={tile} visible={isInView} />
+            <SkillTileCard key={tile.area} tile={tile} visible={isInView} revealOrder={revealOrder} />
           ))}
-          <PaletteTile visible={isInView} />
+          <PaletteTile visible={isInView} revealOrder={revealOrder} />
         </div>
       </div>
     </StickySection>

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -112,7 +112,7 @@ export function SkillsSection() {
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
-          setRevealOrder(createShuffledRevealOrder())
+          setRevealOrder((current) => current ?? createShuffledRevealOrder())
           setIsInView(true)
           return
         }


### PR DESCRIPTION
## Purpose
Make the Skills bento tile reveal feel fresh on each visit by shuffling reveal order whenever the section enters the viewport.

## What it does
Replaces the static reveal-order array with a Fisher-Yates shuffle generated on each viewport entry. Leaving the viewport clears reveal state so the cascade can replay with a new order on re-entry.

## Changes made
- **`SkillsSection.tsx`** — added `createShuffledRevealOrder`, per-entry `revealOrder` state, reset on exit
- **`SkillsSection.test.tsx`** — unit tests for shuffle/delay helpers; integration tests for reveal, reset, and fresh order on re-entry using mocked `Math.random`

## Additional notes
- Transition delays remain staggered (0.12s steps) but tile sequence is randomized each entry
- Tests avoid asserting a fixed shuffle sequence; they verify unique delays and order change via controlled randomness

Closes #219

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skills tiles now reveal in a randomized order each time the section enters view; the sequence is stored while visible and refreshed with a new random order after leaving and re-entering.
* **Bug Fixes**
  * Reveal delays are cleared when the section exits the viewport to ensure a fresh animation on next entry.
* **Tests**
  * Unit and viewport tests added/updated to verify shuffle behavior, stable delays while visible, cleared delays on exit, and new randomization on re-entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->