### PR TITLE
Restore Projects horizontal scroll geometry and snap anchors

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -276,12 +276,13 @@ describe('ProjectsSection', () => {
     expect(cards).toHaveLength(2)
   })
 
-  it('carousel track has relative positioning for horizontal layout', () => {
+  it('carousel track uses hscroll-track layout classes', () => {
     render(<ProjectsSection projects={mockProjects} />)
 
     const carouselTrack = document.querySelector('[data-carousel-track="true"]')
     expect(carouselTrack).toBeInTheDocument()
-    expect(carouselTrack).toHaveClass('relative')
+    expect(carouselTrack).toHaveClass('hscroll-track')
+    expect(carouselTrack).toHaveClass('proj-track')
   })
 
   it('translates the carousel track from the projects section scroll position', () => {
@@ -291,7 +292,7 @@ describe('ProjectsSection', () => {
     const projectsSection = document.getElementById('projects') as HTMLElement
     const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
 
-    vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-800, 2400))
+    vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-400, 1600))
     const trackWidth = getCarouselTrackWidth(mockProjects.length, 1000)
     Object.defineProperty(carouselTrack, 'scrollWidth', {
       configurable: true,
@@ -335,15 +336,26 @@ describe('ProjectsSection', () => {
     expect(screen.queryByText('First bullet point for project one')).not.toBeInTheDocument()
   })
 
-  it('outer container uses the scroll range formula (projects.length * 1.5 + 1) * 100vh', () => {
+  it('outer container height is one viewport per project', () => {
     setViewport(1000, 800)
     render(<ProjectsSection projects={mockProjects} />)
 
     const projectsSection = document.getElementById('projects')
     expect(projectsSection).toBeInTheDocument()
 
-    const expectedHeightVh = mockProjects.length * 1.5 + 1
+    const expectedHeightVh = Math.max(mockProjects.length, 1)
     expect(projectsSection).toHaveStyle({ height: `${expectedHeightVh * 100}vh` })
+  })
+
+  it('renders one snap-anchor per project at expected vertical landing points', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const anchors = document.querySelectorAll('.snap-anchor')
+    expect(anchors).toHaveLength(mockProjects.length)
+
+    anchors.forEach((anchor, index) => {
+      expect(anchor).toHaveStyle({ top: `${index * 100}vh` })
+    })
   })
 
   it('sticky viewport child has 100vh height and top: 0', () => {
@@ -407,21 +419,21 @@ describe('ProjectsSection', () => {
     expect(projectsSection.style.opacity).toBe('')
   })
 
-  it('scroll range calculation matches the desktop geometry contract', () => {
+  it('scroll range calculation matches the one-viewport-per-project contract', () => {
     const projectCount = 2
     const viewportHeight = 800
-    const expectedScrollRangeVh = projectCount * 1.5 + 1
-    const expectedScrollRangePx = expectedScrollRangeVh * viewportHeight
+    const expectedScrollRangeVh = projectCount
+    const expectedScrollRangePx = (expectedScrollRangeVh - 1) * viewportHeight
 
-    expect(expectedScrollRangeVh).toBe(4)
-    expect(expectedScrollRangePx).toBe(3200)
+    expect(expectedScrollRangeVh).toBe(2)
+    expect(expectedScrollRangePx).toBe(800)
   })
 
-  it('getScrollRangeVh returns correct vh multiplier for various project counts', () => {
-    expect(getScrollRangeVh(1)).toBe(2.5)
-    expect(getScrollRangeVh(2)).toBe(4)
-    expect(getScrollRangeVh(3)).toBe(5.5)
-    expect(getScrollRangeVh(4)).toBe(7)
+  it('getScrollRangeVh returns one viewport per project', () => {
+    expect(getScrollRangeVh(1)).toBe(1)
+    expect(getScrollRangeVh(2)).toBe(2)
+    expect(getScrollRangeVh(3)).toBe(3)
+    expect(getScrollRangeVh(4)).toBe(4)
     expect(getScrollRangeVh(0)).toBe(1)
   })
 
@@ -492,7 +504,7 @@ describe('ProjectsSection', () => {
       const projectsSection = document.getElementById('projects') as HTMLElement
       const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
 
-      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-800, 2400))
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-400, 1600))
       Object.defineProperty(carouselTrack, 'scrollWidth', {
         configurable: true,
         value: getCarouselTrackWidth(mockProjects.length, 1000),
@@ -582,7 +594,7 @@ describe('ProjectsSection', () => {
       const projectsSection = document.getElementById('projects') as HTMLElement
       const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
 
-      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-800, 2400))
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-400, 1600))
       Object.defineProperty(carouselTrack, 'scrollWidth', {
         configurable: true,
         value: getCarouselTrackWidth(mockProjects.length, 1000),

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -347,6 +347,13 @@ describe('ProjectsSection', () => {
     expect(projectsSection).toHaveStyle({ height: `${expectedHeightVh * 100}vh` })
   })
 
+  it('outer container uses the hscroll section wrapper class', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const projectsSection = document.getElementById('projects')
+    expect(projectsSection).toHaveClass('hscroll')
+  })
+
   it('renders one snap-anchor per project at expected vertical landing points', () => {
     render(<ProjectsSection projects={mockProjects} />)
 
@@ -356,6 +363,14 @@ describe('ProjectsSection', () => {
     anchors.forEach((anchor, index) => {
       expect(anchor).toHaveStyle({ top: `${index * 100}vh` })
     })
+  })
+
+  it('renders a single snap anchor at 0vh for one project', () => {
+    render(<ProjectsSection projects={[mockProjects[0]]} />)
+
+    const anchors = screen.getAllByTestId('snap-anchor')
+    expect(anchors).toHaveLength(1)
+    expect(anchors[0]).toHaveStyle({ top: '0vh' })
   })
 
   it('sticky viewport child has 100vh height and top: 0', () => {
@@ -427,14 +442,6 @@ describe('ProjectsSection', () => {
 
     expect(expectedScrollRangeVh).toBe(2)
     expect(expectedScrollRangePx).toBe(800)
-  })
-
-  it('getScrollRangeVh returns one viewport per project', () => {
-    expect(getScrollRangeVh(1)).toBe(1)
-    expect(getScrollRangeVh(2)).toBe(2)
-    expect(getScrollRangeVh(3)).toBe(3)
-    expect(getScrollRangeVh(4)).toBe(4)
-    expect(getScrollRangeVh(0)).toBe(1)
   })
 
   it('derives active index from adjusted progress using Math.round(progress * (projects.length - 1))', () => {

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -41,9 +41,19 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
       ref={outerRef}
       id="projects"
       data-sticky-scroll-host="true"
-      className="relative min-h-screen px-8 bg-graphite-light"
+      className="relative hscroll min-h-screen px-8 bg-graphite-light"
       style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'hidden' }}
     >
+      {projects.map((_, index) => (
+        <div
+          key={`snap-${index}`}
+          className="snap-anchor"
+          style={{ top: `${index * 100}vh` }}
+          aria-hidden="true"
+          data-testid="snap-anchor"
+        />
+      ))}
+
       <div data-sticky-viewport="true" className="flex flex-col justify-center py-14 hscroll-sticky">
         <div className="w-full">
           <div className="hscroll-head">
@@ -64,14 +74,17 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
             </div>
           </div>
 
-          <div ref={innerRef as React.RefObject<HTMLDivElement>} data-carousel-track="true" className="relative" style={{ transform: `translateX(${tx}px)` }}>
-            <div className="flex proj-track pb-4">
-              <div className="proj-edge" aria-hidden="true" />
-              {projects.map((project, index) => (
-                <ProjectCard key={project.id} project={project} index={index} activeIndex={activeIndex} />
-              ))}
-              <div className="proj-edge" aria-hidden="true" />
-            </div>
+          <div
+            ref={innerRef as React.RefObject<HTMLDivElement>}
+            data-carousel-track="true"
+            className="hscroll-track proj-track pb-4"
+            style={{ transform: `translateX(${tx}px)` }}
+          >
+            <div className="proj-edge" aria-hidden="true" />
+            {projects.map((project, index) => (
+              <ProjectCard key={project.id} project={project} index={index} activeIndex={activeIndex} />
+            ))}
+            <div className="proj-edge" aria-hidden="true" />
           </div>
         </div>
 

--- a/src/components/projectsGeometry.test.ts
+++ b/src/components/projectsGeometry.test.ts
@@ -32,6 +32,13 @@ describe('projectsGeometry', () => {
     it('returns 1 when there are no projects', () => {
       expect(getScrollRangeVh(0)).toBe(1)
     })
+
+    it('returns one viewport per project', () => {
+      expect(getScrollRangeVh(1)).toBe(1)
+      expect(getScrollRangeVh(2)).toBe(2)
+      expect(getScrollRangeVh(3)).toBe(3)
+      expect(getScrollRangeVh(6)).toBe(6)
+    })
   })
 
   it('exports the reference proj-track gap in pixels', () => {

--- a/src/components/projectsGeometry.ts
+++ b/src/components/projectsGeometry.ts
@@ -4,9 +4,6 @@ export const PROJECT_CARD_WIDTH = 560
 /** Gap between project cards in the carousel track (matches `.proj-track` CSS). */
 export const PROJECT_CARD_GAP = 56
 
-/** Fraction of viewport height reserved as entry/exit dead zones in the Projects scroll range. */
-export const DEAD_ZONE_VIEWPORT_RATIO = 0.25
-
 /** Returns edge spacer width in px (matches `.proj-edge` calc for a fixed card width). */
 export function getEdgeSpacerWidth(viewportWidth: number, cardWidth = PROJECT_CARD_WIDTH) {
   return viewportWidth / 2 - Math.min(cardWidth / 2, viewportWidth * 0.39)
@@ -28,9 +25,9 @@ export function getCarouselTrackWidth(
   return edgeWidth * 2 + cardsWidth
 }
 
-/** Returns the Projects section height multiplier in viewport-height units. */
+/** Returns the Projects section height multiplier in viewport-height units (one viewport per project). */
 export function getScrollRangeVh(projectCount: number) {
-  return projectCount * 1.5 + 1
+  return Math.max(projectCount, 1)
 }
 
 /** Formats a project id as the v4 card number prefix (e.g. "1" → "_01"). */

--- a/src/hooks/useHorizontalScroll.test.tsx
+++ b/src/hooks/useHorizontalScroll.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { useRef } from 'react'
-import { useHorizontalScroll, applyDeadZones, clamp01 } from './useHorizontalScroll'
+import { useHorizontalScroll, clamp01 } from './useHorizontalScroll'
 
 function setViewport(width: number, height: number) {
   Object.defineProperty(window, 'innerWidth', {
@@ -72,8 +72,8 @@ describe('useHorizontalScroll', () => {
     setViewport(1000, 800)
 
     const { result } = renderHorizontalScrollHook({
-      outerTop: -800,
-      outerHeight: 2400,
+      outerTop: -400,
+      outerHeight: 1600,
       innerScrollWidth: 2600,
     })
 
@@ -88,7 +88,7 @@ describe('useHorizontalScroll', () => {
 
     const { result } = renderHorizontalScrollHook({
       outerTop: 800,
-      outerHeight: 2400,
+      outerHeight: 1600,
       innerScrollWidth: 2600,
     })
 
@@ -97,69 +97,41 @@ describe('useHorizontalScroll', () => {
     expect(result.current).toEqual({ progress: 0, tx: 0 })
   })
 
-  it('holds the first card in place through the leading dead zone', () => {
+  it('maps scroll position linearly from section start to end', () => {
     setViewport(1000, 800)
 
     const { result } = renderHorizontalScrollHook({
       outerTop: -160,
-      outerHeight: 2400,
+      outerHeight: 1600,
       innerScrollWidth: 2600,
     })
 
     act(() => window.dispatchEvent(new Event('scroll')))
 
-    expect(result.current).toEqual({ progress: 0, tx: 0 })
+    expect(result.current.progress).toBeCloseTo(0.2, 4)
+    expect(result.current.tx).toBeCloseTo(-320, 0)
   })
 
   it('returns full progress and max translate after the outer container scrolls fully past', () => {
     setViewport(1000, 800)
 
     const { result } = renderHorizontalScrollHook({
-      outerTop: -1600,
-      outerHeight: 2400,
+      outerTop: -800,
+      outerHeight: 1600,
       innerScrollWidth: 2600,
     })
 
     act(() => window.dispatchEvent(new Event('scroll')))
 
     expect(result.current).toEqual({ progress: 1, tx: -1600 })
-  })
-
-  it('holds the last card in place through the trailing dead zone', () => {
-    setViewport(1000, 800)
-
-    const { result } = renderHorizontalScrollHook({
-      outerTop: -1440,
-      outerHeight: 2400,
-      innerScrollWidth: 2600,
-    })
-
-    act(() => window.dispatchEvent(new Event('scroll')))
-
-    expect(result.current).toEqual({ progress: 1, tx: -1600 })
-  })
-
-  it('moves linearly between the leading and trailing dead zones', () => {
-    setViewport(1000, 800)
-
-    const { result } = renderHorizontalScrollHook({
-      outerTop: -400,
-      outerHeight: 2400,
-      innerScrollWidth: 2600,
-    })
-
-    act(() => window.dispatchEvent(new Event('scroll')))
-
-    expect(result.current.progress).toBeCloseTo(0.1667, 4)
-    expect(result.current.tx).toBeCloseTo(-266.67, 2)
   })
 
   it('returns zero translate when the inner track does not overflow the viewport', () => {
     setViewport(1000, 800)
 
     const { result } = renderHorizontalScrollHook({
-      outerTop: -800,
-      outerHeight: 2400,
+      outerTop: -400,
+      outerHeight: 1600,
       innerScrollWidth: 800,
     })
 
@@ -184,11 +156,11 @@ describe('useHorizontalScroll', () => {
 
   it('recalculates translate from the current viewport width on resize', () => {
     setViewport(1000, 800)
-    const outerTop = -800
+    const outerTop = -400
 
     const { result } = renderHorizontalScrollHook({
       outerTop: () => outerTop,
-      outerHeight: 2400,
+      outerHeight: 1600,
       innerScrollWidth: 2600,
     })
 
@@ -211,7 +183,7 @@ describe('useHorizontalScroll', () => {
 
     const { result } = renderHorizontalScrollHook({
       outerTop: 0,
-      outerHeight: 2400,
+      outerHeight: 1600,
       innerScrollWidth,
     })
 
@@ -231,8 +203,8 @@ describe('useHorizontalScroll', () => {
     const innerScrollWidth = edgeWidth * 2 + cardWidth * 2 + cardGap
 
     const { result } = renderHorizontalScrollHook({
-      outerTop: -1600,
-      outerHeight: 2400,
+      outerTop: -800,
+      outerHeight: 1600,
       innerScrollWidth,
     })
 
@@ -240,89 +212,6 @@ describe('useHorizontalScroll', () => {
 
     expect(result.current.progress).toBe(1)
     expect(cardCenterX(result.current.tx, 1, cardWidth, cardGap, edgeWidth)).toBe(1000 / 2)
-  })
-
-  it('holds the first card centered through the leading dead zone', () => {
-    setViewport(1000, 800)
-
-    const cardWidth = 480
-    const cardGap = 56
-    const edgeWidth = 1000 / 2 - Math.min(cardWidth / 2, 1000 * 0.39)
-    const innerScrollWidth = edgeWidth * 2 + cardWidth * 2 + cardGap
-
-    const { result } = renderHorizontalScrollHook({
-      outerTop: -160,
-      outerHeight: 2400,
-      innerScrollWidth,
-    })
-
-    act(() => window.dispatchEvent(new Event('scroll')))
-
-    expect(result.current.progress).toBe(0)
-    expect(result.current.tx).toBe(0)
-    expect(cardCenterX(result.current.tx, 0, cardWidth, cardGap, edgeWidth)).toBe(1000 / 2)
-  })
-
-  it('holds the last card centered through the trailing dead zone', () => {
-    setViewport(1000, 800)
-
-    const cardWidth = 480
-    const cardGap = 56
-    const edgeWidth = 1000 / 2 - Math.min(cardWidth / 2, 1000 * 0.39)
-    const innerScrollWidth = edgeWidth * 2 + cardWidth * 2 + cardGap
-
-    const { result } = renderHorizontalScrollHook({
-      outerTop: -1440,
-      outerHeight: 2400,
-      innerScrollWidth,
-    })
-
-    act(() => window.dispatchEvent(new Event('scroll')))
-
-    expect(result.current.progress).toBe(1)
-    expect(cardCenterX(result.current.tx, 1, cardWidth, cardGap, edgeWidth)).toBe(1000 / 2)
-  })
-})
-
-describe('applyDeadZones', () => {
-  it('returns 0 when raw progress is before start', () => {
-    expect(applyDeadZones(0, 0.125)).toBe(0)
-  })
-
-  it('returns 0 within the first dead zone', () => {
-    expect(applyDeadZones(0.06, 0.125)).toBe(0)
-    expect(applyDeadZones(0.125, 0.125)).toBe(0)
-  })
-
-  it('maps the midpoint linearly between dead zones', () => {
-    const result = applyDeadZones(0.5, 0.125)
-    expect(result).toBeCloseTo(0.5, 4)
-  })
-
-  it('returns 1 within the final dead zone', () => {
-    expect(applyDeadZones(0.875, 0.125)).toBe(1)
-    expect(applyDeadZones(0.94, 0.125)).toBe(1)
-  })
-
-  it('returns 1 after end', () => {
-    expect(applyDeadZones(1, 0.125)).toBe(1)
-    expect(applyDeadZones(1.2, 0.125)).toBe(1)
-  })
-
-  it('maps linearly between the leading and trailing dead zones', () => {
-    const deadZone = 0.125
-    const result = applyDeadZones(0.3, deadZone)
-    const expected = (0.3 - deadZone) / (1 - deadZone * 2)
-    expect(result).toBeCloseTo(expected, 4)
-  })
-
-  it('returns raw progress when dead zone is zero', () => {
-    expect(applyDeadZones(0.25, 0)).toBe(0.25)
-    expect(applyDeadZones(0.75, 0)).toBe(0.75)
-  })
-
-  it('returns 0 for negative raw progress (falls within leading dead zone)', () => {
-    expect(applyDeadZones(-0.1, 0.125)).toBe(0)
   })
 })
 

--- a/src/hooks/useHorizontalScroll.test.tsx
+++ b/src/hooks/useHorizontalScroll.test.tsx
@@ -126,6 +126,20 @@ describe('useHorizontalScroll', () => {
     expect(result.current).toEqual({ progress: 1, tx: -1600 })
   })
 
+  it('clamps progress to 1 when scrolled past the section end', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHorizontalScrollHook({
+      outerTop: -1200,
+      outerHeight: 1600,
+      innerScrollWidth: 2600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current).toEqual({ progress: 1, tx: -1600 })
+  })
+
   it('returns zero translate when the inner track does not overflow the viewport', () => {
     setViewport(1000, 800)
 

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState, type RefObject } from 'react'
-import { DEAD_ZONE_VIEWPORT_RATIO } from '../components/projectsGeometry'
 
 interface HorizontalScrollState {
   tx: number
@@ -8,22 +7,6 @@ interface HorizontalScrollState {
 
 export function clamp01(value: number) {
   return Math.min(Math.max(value, 0), 1)
-}
-
-export function applyDeadZones(rawProgress: number, deadZoneProgress: number) {
-  if (deadZoneProgress <= 0) {
-    return rawProgress
-  }
-
-  if (rawProgress <= deadZoneProgress) {
-    return 0
-  }
-
-  if (rawProgress >= 1 - deadZoneProgress) {
-    return 1
-  }
-
-  return (rawProgress - deadZoneProgress) / (1 - deadZoneProgress * 2)
 }
 
 function getHorizontalScrollState(
@@ -38,9 +21,7 @@ function getHorizontalScrollState(
   const viewportWidth = window.innerWidth
   const viewportHeight = window.innerHeight
   const scrollRange = Math.max(rect.height - viewportHeight, 0)
-  const rawProgress = scrollRange === 0 ? 0 : clamp01(-rect.top / scrollRange)
-  const deadZoneProgress = scrollRange === 0 ? 0 : (viewportHeight * DEAD_ZONE_VIEWPORT_RATIO) / scrollRange
-  const progress = clamp01(applyDeadZones(rawProgress, deadZoneProgress))
+  const progress = scrollRange === 0 ? 0 : clamp01(-rect.top / scrollRange)
   const trackWidth = Math.max(inner.scrollWidth - viewportWidth, 0)
   const tx = progress === 0 || trackWidth === 0 ? 0 : -(progress * trackWidth)
 


### PR DESCRIPTION
## Purpose
Restore the reference Projects scroll model so vertical progress maps linearly to a sticky horizontal track with per-project snap landing points.

## What it does
Projects section height is now one viewport per project. Dead-zone progress math is removed in favor of linear `-rect.top / scrollRange` mapping. One `snap-anchor` is rendered per project at `i * 100vh`, and the carousel track uses the `hscroll-track proj-track` scaffold.

## Changes made
- `projectsGeometry.ts` — `getScrollRangeVh` returns `max(projectCount, 1)`; removed `DEAD_ZONE_VIEWPORT_RATIO`
- `useHorizontalScroll.ts` — removed `applyDeadZones`; progress is linear from section scroll range
- `ProjectsSection.tsx` — snap anchors, `hscroll` section wrapper, consolidated horizontal track
- Updated hook and section tests for the new geometry contract

## Additional notes
Active/neighbor/far card scale/opacity states are intentionally unchanged (scoped to #218).

Closes #217

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Projects carousel now uses a one-viewport-per-project scroll model for simpler, consistent paging.
  * Horizontal scroll progress no longer uses dead-zone shaping — scrolling feels more direct and responsive.
  * Added snap anchors so each project snaps to its own viewport for more reliable vertical snap behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->