### PR TITLE
Rebuild Timeline as one internal horizontal track

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -8,11 +8,8 @@ const sectionIds = [
   'projects',
   'skills',
   'timeline',
-  'timeline-a3f9d2b',
-  'timeline-b7c3e1a',
   'contact',
 ] as const
-const timelinePanelIds = ['timeline', 'timeline-a3f9d2b', 'timeline-b7c3e1a']
 const shellConstraintClasses = ['container', 'max-w-7xl', 'mx-auto'] as const
 
 function expectNoShellConstraint(element: Element) {
@@ -53,12 +50,6 @@ function getMajorSectionElements() {
   return sectionIds
     .map((id) => document.getElementById(id))
     .filter((section): section is HTMLElement => section instanceof HTMLElement)
-}
-
-function getTimelinePanels() {
-  return timelinePanelIds
-    .map((id) => document.getElementById(id))
-    .filter((panel): panel is HTMLElement => panel instanceof HTMLElement)
 }
 
 describe('App shell', () => {
@@ -249,7 +240,7 @@ describe('App shell', () => {
   })
 
   describe('issue #214 - global scroll shell regression', () => {
-    const majorSectionIds = ['home', 'projects', 'skills', 'contact', ...timelinePanelIds] as const
+    const majorSectionIds = ['home', 'projects', 'skills', 'timeline', 'contact'] as const
 
     it('does not mount a global sticky section stack', () => {
       render(<App />)
@@ -269,11 +260,14 @@ describe('App shell', () => {
       expect(section.style.zIndex).toBe('')
     })
 
-    it('timeline panels render in newest-first document order', () => {
+    it('timeline is one major section with an internal horizontal track', () => {
       render(<App />)
 
-      const ids = getTimelinePanels().map((panel) => panel.id)
-      expect(ids).toEqual([...timelinePanelIds])
+      const timeline = document.getElementById('timeline')
+      expect(timeline).toBeInTheDocument()
+      expect(document.getElementById('timeline-a3f9d2b')).not.toBeInTheDocument()
+      expect(timeline?.querySelector('[data-timeline-track="true"]')).toBeInTheDocument()
+      expect(timeline?.querySelectorAll('.snap-anchor')).toHaveLength(3)
     })
 
     it('projects outer scroll host keeps an internal sticky viewport only', () => {

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -1,31 +1,36 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
 import TimelineSection from './TimelineSection'
-import { useActivePanel } from '../hooks/useActivePanel'
+import { useTimelineScroll } from '../hooks/useTimelineScroll'
 
-const noopSetRef = () => () => {}
-
-function mockActivePanelState(
+function mockTimelineScrollState(
   active: boolean[],
-  options: { activeIndex?: number; progress?: number } = {},
+  options: { activeIndex?: number; progress?: number; tx?: number } = {},
 ) {
   const detectedIndex = active.findIndex(Boolean)
+  const activeIndex = options.activeIndex ?? (detectedIndex === -1 ? 0 : detectedIndex)
+  const entryCount = active.length
+
   return {
     active,
-    activeIndex: options.activeIndex ?? (detectedIndex === -1 ? 0 : detectedIndex),
-    progress: options.progress ?? 0,
-    setRef: noopSetRef,
+    activeIndex,
+    progress: options.progress ?? (entryCount <= 1 ? 0 : activeIndex / (entryCount - 1)),
+    tx: options.tx ?? 0,
   }
 }
 
-vi.mock('../hooks/useActivePanel', () => ({
-  useActivePanel: vi.fn(() => mockActivePanelState([false, false, false])),
+vi.mock('../hooks/useTimelineScroll', () => ({
+  useTimelineScroll: vi.fn(() => mockTimelineScrollState([false, false, false])),
 }))
+
+function getTimelinePanel(contentIndex: number) {
+  return document.querySelector(`[data-content-index="${contentIndex}"]`) as HTMLElement
+}
 
 describe('TimelineSection', () => {
   afterEach(() => {
     vi.useRealTimers()
-    vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
+    vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, false]))
   })
 
   it('each entry uses tl-panel layout class', () => {
@@ -38,7 +43,7 @@ describe('TimelineSection', () => {
   })
 
   it('entries start empty when no panel is active', () => {
-    vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
+    vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, false]))
 
     render(<TimelineSection />)
 
@@ -47,8 +52,8 @@ describe('TimelineSection', () => {
   })
 
   describe('issue #78 - newest-first ordering', () => {
-    it('entries render in newest-first order (NetApp before M.S. before B.S.)', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, true, true]))
+    it('newest entry is the first user-facing panel at section start', () => {
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -56,37 +61,29 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const allLines = document.querySelectorAll('[data-typewriter-line]')
-      const texts = Array.from(allLines)
-        .map((el) => el.textContent)
-        .filter((t) => t !== '')
-
-      expect(texts[0]).toBe('commit d4e8f2c')
-      expect(texts[3]).toBe('NETAPP INC.')
-      expect(texts[4]).toBe('SOFTWARE_ENGINEER_IN_TEST')
-
-      expect(texts[9]).toBe('commit a3f9d2b')
-      expect(texts[12]).toBe('WICHITA STATE UNIVERSITY')
-      expect(texts[13]).toBe('ACCELERATED_M.S._COMPUTER_SCIENCE')
-
-      expect(texts[14]).toBe('commit b7c3e1a')
-      expect(texts[17]).toBe('WICHITA STATE UNIVERSITY')
-      expect(texts[18]).toBe('B.S._COMPUTER_SCIENCE')
+      const newestPanel = document.querySelector('[data-content-index="0"]')
+      expect(newestPanel?.querySelector('[data-testid="commit-hash"]')?.textContent).toBe(
+        'commit d4e8f2c',
+      )
+      expect(newestPanel?.querySelector('[data-testid="commit-institution"]')?.textContent).toBe(
+        'NETAPP INC.',
+      )
     })
   })
 
   describe('issue #97 - full-screen stacked panels', () => {
-    it('each timeline entry is its own full-viewport section panel', () => {
+    it('timeline entries are full-viewport panels inside one horizontal track', () => {
       render(<TimelineSection />)
 
-      const panelIds = ['timeline', 'timeline-a3f9d2b', 'timeline-b7c3e1a']
-      const panels = panelIds.map((id) => document.getElementById(id))
-      expect(panels.every(Boolean)).toBe(true)
+      const timelineSection = document.getElementById('timeline')
+      const track = document.querySelector('[data-timeline-track="true"]')
+      const panels = document.querySelectorAll('[data-testid="timeline-panel"]')
 
+      expect(timelineSection).toBeInTheDocument()
+      expect(track).toBeInTheDocument()
+      expect(panels).toHaveLength(3)
       panels.forEach((panel) => {
-        expect(panel).toHaveClass('min-h-screen')
-        expect(panel).not.toHaveClass('sticky', 'top-0')
-        expect(panel).not.toHaveAttribute('data-sticky-section')
+        expect(panel.querySelector('.tl-panel')).toBeInTheDocument()
       })
     })
 
@@ -128,7 +125,7 @@ describe('TimelineSection', () => {
     })
 
     it('Typewriter types commit metadata when panel becomes active', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -144,7 +141,7 @@ describe('TimelineSection', () => {
     })
 
     it('Typewriter types all fields to completion when panel stays active', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -164,7 +161,7 @@ describe('TimelineSection', () => {
     })
 
     it('Typewriter types bullets when present', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -180,7 +177,7 @@ describe('TimelineSection', () => {
     })
 
     it('inactive panels remain empty', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -188,15 +185,14 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(100)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const panel2Lines = commitEntries[1].querySelectorAll('[data-typewriter-line]')
-      const panel3Lines = commitEntries[2].querySelectorAll('[data-typewriter-line]')
+      const panel1Lines = getTimelinePanel(1).querySelectorAll('[data-typewriter-line]')
+      const panel2Lines = getTimelinePanel(2).querySelectorAll('[data-typewriter-line]')
+      expect(panel1Lines.length).toBe(0)
       expect(panel2Lines.length).toBe(0)
-      expect(panel3Lines.length).toBe(0)
     })
 
     it('Typewriter holds position when panel is scrolled away mid-type', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -207,7 +203,7 @@ describe('TimelineSection', () => {
 
       const partialText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, false]))
       rerender(<TimelineSection />)
 
       act(() => {
@@ -219,7 +215,7 @@ describe('TimelineSection', () => {
     })
 
     it('Typewriter resumes from held position when panel becomes active again', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -229,13 +225,13 @@ describe('TimelineSection', () => {
       })
       const partialText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, false]))
       rerender(<TimelineSection />)
       act(() => {
         vi.advanceTimersByTime(1000)
       })
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       rerender(<TimelineSection />)
       act(() => {
         vi.advanceTimersByTime(500)
@@ -246,7 +242,7 @@ describe('TimelineSection', () => {
     })
 
     it('issue #98 - longest bullet completes within 2.5s', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -265,7 +261,7 @@ describe('TimelineSection', () => {
 
   describe('issue #159 - preserve per-panel typewriter progress', () => {
     it('next panel activation does not clear previous panel partial text', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -274,26 +270,27 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(100)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const panel1Partial = commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+      const panel1Partial =
+        getTimelinePanel(0).querySelector('[data-typewriter-line]')?.textContent ?? ''
       expect(panel1Partial.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, true, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, true, false]))
       rerender(<TimelineSection />)
 
       act(() => {
         vi.advanceTimersByTime(5000)
       })
 
-      const panel1Held = commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+      const panel1Held =
+        getTimelinePanel(0).querySelector('[data-typewriter-line]')?.textContent ?? ''
       expect(panel1Held).toBe(panel1Partial)
 
-      const panel2Lines = commitEntries[1].querySelectorAll('[data-typewriter-line]')
+      const panel2Lines = getTimelinePanel(1).querySelectorAll('[data-typewriter-line]')
       expect(panel2Lines.length).toBeGreaterThan(0)
     })
 
     it('reactivate does not blank partial text before resuming', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -305,10 +302,10 @@ describe('TimelineSection', () => {
       const partialText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
       expect(partialText.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, false]))
       rerender(<TimelineSection />)
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       rerender(<TimelineSection />)
 
       const immediateText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
@@ -316,7 +313,7 @@ describe('TimelineSection', () => {
     })
 
     it('each panel retains independent partial progress when switching panels', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -325,12 +322,11 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(100)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
       const panel1Partial =
-        commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+        getTimelinePanel(0).querySelector('[data-typewriter-line]')?.textContent ?? ''
       expect(panel1Partial.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, true, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, true, false]))
       rerender(<TimelineSection />)
 
       act(() => {
@@ -338,27 +334,27 @@ describe('TimelineSection', () => {
       })
 
       const panel1Held =
-        commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+        getTimelinePanel(0).querySelector('[data-typewriter-line]')?.textContent ?? ''
       const panel2Partial =
-        commitEntries[1].querySelector('[data-typewriter-line]')?.textContent ?? ''
+        getTimelinePanel(1).querySelector('[data-typewriter-line]')?.textContent ?? ''
 
       expect(panel1Held).toBe(panel1Partial)
       expect(panel2Partial.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       rerender(<TimelineSection />)
 
       const panel1Immediate =
-        commitEntries[0].querySelector('[data-typewriter-line]')?.textContent ?? ''
+        getTimelinePanel(0).querySelector('[data-typewriter-line]')?.textContent ?? ''
       const panel2Held =
-        commitEntries[1].querySelector('[data-typewriter-line]')?.textContent ?? ''
+        getTimelinePanel(1).querySelector('[data-typewriter-line]')?.textContent ?? ''
 
       expect(panel1Immediate).toBe(panel1Partial)
       expect(panel2Held).toBe(panel2Partial)
     })
 
     it('completed panel text remains when next panel activates', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -367,15 +363,14 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
       const panel1Texts = Array.from(
-        commitEntries[0].querySelectorAll('[data-typewriter-line]')
+        getTimelinePanel(0).querySelectorAll('[data-typewriter-line]'),
       ).map((el) => el.textContent)
 
       expect(panel1Texts).toContain('commit d4e8f2c')
       expect(panel1Texts).toContain('NETAPP INC.')
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, true, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, true, false]))
       rerender(<TimelineSection />)
 
       act(() => {
@@ -383,7 +378,7 @@ describe('TimelineSection', () => {
       })
 
       const panel1TextsAfter = Array.from(
-        commitEntries[0].querySelectorAll('[data-typewriter-line]')
+        getTimelinePanel(0).querySelectorAll('[data-typewriter-line]'),
       ).map((el) => el.textContent)
 
       expect(panel1TextsAfter).toContain('commit d4e8f2c')
@@ -393,7 +388,7 @@ describe('TimelineSection', () => {
 
   describe('issue #160 - structured resume-backed panel content', () => {
     it('renders commit metadata as distinct fields', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -402,8 +397,7 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const metadata = commitEntries[0].querySelector('[data-testid="commit-metadata"]')
+      const metadata = getTimelinePanel(0).querySelector('[data-testid="commit-metadata"]')
       expect(metadata).toBeInTheDocument()
       expect(metadata?.querySelector('[data-testid="commit-hash"]')?.textContent).toBe(
         'commit d4e8f2c'
@@ -417,7 +411,7 @@ describe('TimelineSection', () => {
     })
 
     it('renders institution as its own heading', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -426,14 +420,13 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const institution = commitEntries[0].querySelector('[data-testid="commit-institution"]')
+      const institution = getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')
       expect(institution?.tagName).toBe('H2')
       expect(institution?.textContent).toBe('NETAPP INC.')
     })
 
     it('renders role as its own line', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -442,13 +435,12 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const role = commitEntries[0].querySelector('[data-testid="commit-role"]')
+      const role = getTimelinePanel(0).querySelector('[data-testid="commit-role"]')
       expect(role?.textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
     })
 
     it('renders bullets as semantic list items', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -457,8 +449,7 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const details = commitEntries[0].querySelector('[data-testid="commit-details"]')
+      const details = getTimelinePanel(0).querySelector('[data-testid="commit-details"]')
       expect(details?.tagName).toBe('UL')
 
       const items = details?.querySelectorAll('li') ?? []
@@ -467,7 +458,7 @@ describe('TimelineSection', () => {
     })
 
     it('preserves data-typewriter-line markers on typed fields', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -476,14 +467,13 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(500)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const typedFields = commitEntries[0].querySelectorAll('[data-typewriter-line]')
+      const typedFields = getTimelinePanel(0).querySelectorAll('[data-typewriter-line]')
       expect(typedFields.length).toBeGreaterThan(0)
       expect(typedFields[0].closest('[data-testid="commit-metadata"]')).toBeTruthy()
     })
 
     it('omits commit-details list when entry has no bullets', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, true, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, true, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -492,8 +482,7 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const msPanel = commitEntries[1]
+      const msPanel = getTimelinePanel(1)
       expect(msPanel.querySelector('[data-testid="commit-details"]')).not.toBeInTheDocument()
       expect(msPanel.querySelector('[data-testid="commit-institution"]')?.textContent).toBe(
         'WICHITA STATE UNIVERSITY'
@@ -501,7 +490,7 @@ describe('TimelineSection', () => {
     })
 
     it('holds partial metadata within structured fields when panel deactivates', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -510,29 +499,27 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(100)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
       const partialHash =
-        commitEntries[0].querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+        getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
       expect(partialHash.length).toBeGreaterThan(0)
 
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([false, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, false]))
       rerender(<TimelineSection />)
 
       act(() => {
         vi.advanceTimersByTime(5000)
       })
 
-      const heldEntries = screen.getAllByTestId('commit-entry')
       const heldHash =
-        heldEntries[0].querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+        getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
       expect(heldHash).toBe(partialHash)
-      expect(heldEntries[0].querySelector('[data-testid="commit-institution"]')).toBeNull()
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')).toBeNull()
     })
   })
 
   describe('issue #161 - v4 desktop panel visual hierarchy', () => {
     it('commit hash uses tl-commit, author and date use tl-meta', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -541,15 +528,14 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const metadata = commitEntries[0].querySelector('[data-testid="commit-metadata"]')
+      const metadata = getTimelinePanel(0).querySelector('[data-testid="commit-metadata"]')
       expect(metadata?.querySelector('[data-testid="commit-hash"]')).toHaveClass('tl-commit')
       expect(metadata?.querySelector('[data-testid="commit-author"]')).toHaveClass('tl-meta')
       expect(metadata?.querySelector('[data-testid="commit-date"]')).toHaveClass('tl-meta')
     })
 
     it('institution heading uses tl-org portfolio class', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -558,14 +544,13 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const institution = commitEntries[0].querySelector('[data-testid="commit-institution"]')
+      const institution = getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')
       expect(institution).toHaveClass('tl-org')
       expect(institution?.textContent).toBe('NETAPP INC.')
     })
 
     it('role uses tl-title portfolio class', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -574,14 +559,13 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const role = commitEntries[0].querySelector('[data-testid="commit-role"]')
+      const role = getTimelinePanel(0).querySelector('[data-testid="commit-role"]')
       expect(role).toHaveClass('tl-title')
       expect(role?.textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
     })
 
     it('bullets use tl-bullets portfolio class', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -590,22 +574,26 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const details = commitEntries[0].querySelector('[data-testid="commit-details"]')
+      const details = getTimelinePanel(0).querySelector('[data-testid="commit-details"]')
       expect(details).toHaveClass('tl-bullets')
     })
 
     it('section tag carries experience or education category class', () => {
       render(<TimelineSection />)
 
-      const sectionLabels = document.querySelectorAll('[data-testid="section-label"]')
-      expect(sectionLabels[0].className).toContain('experience')
-      expect(sectionLabels[1].className).toContain('education')
-      expect(sectionLabels[2].className).toContain('education')
+      expect(getTimelinePanel(0).querySelector('[data-testid="section-label"]')?.className).toContain(
+        'experience',
+      )
+      expect(getTimelinePanel(1).querySelector('[data-testid="section-label"]')?.className).toContain(
+        'education',
+      )
+      expect(getTimelinePanel(2).querySelector('[data-testid="section-label"]')?.className).toContain(
+        'education',
+      )
     })
 
     it('inserts tl-sep spacer before institution heading', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -614,79 +602,103 @@ describe('TimelineSection', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const commitEntries = screen.getAllByTestId('commit-entry')
-      const institution = commitEntries[0].querySelector('[data-testid="commit-institution"]')
+      const institution = getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')
       expect(institution?.previousElementSibling).toHaveClass('tl-sep')
     })
   })
 
   describe('issue #214 - timeline scroll shell regression', () => {
-    const timelinePanelIds = ['timeline', 'timeline-a3f9d2b', 'timeline-b7c3e1a'] as const
-
-    function getTimelinePanels() {
-      return timelinePanelIds
-        .map((id) => document.getElementById(id))
-        .filter((panel): panel is HTMLElement => panel instanceof HTMLElement)
-    }
-
-    it('timeline panels do not use horizontal scroll or translateX on section surfaces', () => {
+    it('timeline is one major section without per-entry global sticky surfaces', () => {
       render(<TimelineSection />)
 
-      getTimelinePanels().forEach((panel) => {
-        expect(panel.style.transform).not.toContain('translateX')
-        expect(panel.style.transform).not.toContain('translate3d')
-      })
-    })
-
-    it('timeline panels do not have a horizontal track element', () => {
-      render(<TimelineSection />)
-
-      getTimelinePanels().forEach((panel) => {
-        const children = panel.querySelectorAll('[data-testid]')
-        const hasTrack = Array.from(children).some(
-          (child) =>
-            child.getAttribute('data-testid')?.includes('track') ||
-            child.getAttribute('data-testid')?.includes('carousel')
-        )
-        expect(hasTrack).toBe(false)
-      })
-    })
-
-    it('timeline panels do not participate in global card-deck stack depth', () => {
-      render(<TimelineSection />)
-
+      expect(document.getElementById('timeline')).toBeInTheDocument()
+      expect(document.getElementById('timeline-a3f9d2b')).not.toBeInTheDocument()
+      expect(document.getElementById('timeline-b7c3e1a')).not.toBeInTheDocument()
       expect(document.querySelectorAll('[data-sticky-section="true"]')).toHaveLength(0)
-
-      getTimelinePanels().forEach((panel) => {
-        expect(panel.style.zIndex).toBe('')
-        expect(panel.style.transform).toBe('')
-        expect(panel.style.opacity).toBe('')
-      })
     })
 
-    it('each timeline panel occupies a full desktop viewport beat (min-h-screen)', () => {
+    it('timeline outer section keeps an internal sticky viewport only', () => {
       render(<TimelineSection />)
 
-      getTimelinePanels().forEach((panel) => {
-        expect(panel).toHaveClass('min-h-screen')
-        expect(panel).not.toHaveClass('sticky', 'top-0')
-      })
+      const timeline = document.getElementById('timeline')
+      const stickyViewport = timeline?.querySelector('[data-sticky-viewport="true"]')
+
+      expect(timeline).toHaveAttribute('data-sticky-scroll-host', 'true')
+      expect(timeline).not.toHaveAttribute('data-sticky-section')
+      expect(stickyViewport).toHaveClass('hscroll-sticky')
     })
 
-    it('timeline panels are in DOM order matching newest-first scroll progression', () => {
+    it('timeline track translateX is independent from the outer section transform', () => {
+      vi.mocked(useTimelineScroll).mockReturnValue({
+        active: [false, true, false],
+        activeIndex: 1,
+        progress: 0.5,
+        tx: -1000,
+      })
+
       render(<TimelineSection />)
 
-      const ids = getTimelinePanels().map((panel) => panel.id)
-      expect(ids).toEqual([...timelinePanelIds])
+      const timeline = document.getElementById('timeline') as HTMLElement
+      const track = document.querySelector('[data-timeline-track="true"]') as HTMLElement
+
+      expect(timeline.style.transform).toBe('')
+      expect(track.style.transform).toContain('translateX(-1000px)')
+    })
+  })
+
+  describe('issue #220 - one internal horizontal track', () => {
+    it('renders one major section with id timeline', () => {
+      render(<TimelineSection />)
+
+      const sections = document.querySelectorAll('#timeline')
+      expect(sections).toHaveLength(1)
+      expect(sections[0]?.tagName.toLowerCase()).toBe('section')
     })
 
-    it('timeline panels do not carry card-deck animation classes or inline compositing hints', () => {
+    it('places all entries as panels inside one horizontal track', () => {
       render(<TimelineSection />)
 
-      getTimelinePanels().forEach((panel) => {
-        expect(panel).not.toHaveClass('origin-center', 'transform-gpu')
-        expect(panel.style.willChange).toBe('')
-      })
+      const track = document.querySelector('[data-timeline-track="true"]')
+      const panels = track?.querySelectorAll('[data-testid="timeline-panel"]')
+
+      expect(track).toHaveClass('hscroll-track')
+      expect(panels).toHaveLength(3)
+    })
+
+    it('renders one snap anchor per timeline entry', () => {
+      render(<TimelineSection />)
+
+      const timeline = document.getElementById('timeline')
+      const anchors = timeline?.querySelectorAll('.snap-anchor')
+
+      expect(anchors).toHaveLength(3)
+      expect(anchors?.[0]).toHaveStyle({ top: '0vh' })
+      expect(anchors?.[1]).toHaveStyle({ top: '100vh' })
+      expect(anchors?.[2]).toHaveStyle({ top: '200vh' })
+    })
+
+    it('uses one viewport of section height per entry', () => {
+      render(<TimelineSection />)
+
+      const timeline = document.getElementById('timeline')
+      expect(timeline).toHaveStyle({ height: '300vh' })
+    })
+
+    it('does not render each entry as a separate global sticky section', () => {
+      render(<TimelineSection />)
+
+      expect(document.querySelectorAll('section[id^="timeline-"]')).toHaveLength(0)
+      expect(document.querySelectorAll('[data-sticky-section="true"]')).toHaveLength(0)
+    })
+
+    it('renders track panels oldest-to-newest while newest is the first user-facing panel', () => {
+      render(<TimelineSection />)
+
+      const panels = Array.from(document.querySelectorAll('[data-testid="timeline-panel"]'))
+      const contentIndexes = panels.map((panel) => panel.getAttribute('data-content-index'))
+
+      expect(contentIndexes).toEqual(['2', '1', '0'])
+      expect(panels[2]?.getAttribute('data-content-index')).toBe('0')
     })
   })
 
@@ -701,7 +713,7 @@ describe('TimelineSection', () => {
     })
 
     it('renders progress counter with resume entry count 01 / 03', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
 
       render(<TimelineSection />)
 
@@ -709,8 +721,8 @@ describe('TimelineSection', () => {
     })
 
     it('progress counter advances with active panel index', () => {
-      vi.mocked(useActivePanel).mockReturnValue(
-        mockActivePanelState([false, true, false], { activeIndex: 1, progress: 0.5 }),
+      vi.mocked(useTimelineScroll).mockReturnValue(
+        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5 }),
       )
 
       render(<TimelineSection />)
@@ -719,8 +731,8 @@ describe('TimelineSection', () => {
     })
 
     it('progress fill width reflects scroll progress', () => {
-      vi.mocked(useActivePanel).mockReturnValue(
-        mockActivePanelState([false, true, false], { activeIndex: 1, progress: 0.5 }),
+      vi.mocked(useTimelineScroll).mockReturnValue(
+        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5 }),
       )
 
       render(<TimelineSection />)
@@ -743,7 +755,7 @@ describe('TimelineSection', () => {
     })
 
     it('renders SCROLL ↓ hint when on first panel', () => {
-      vi.mocked(useActivePanel).mockReturnValue(mockActivePanelState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
 
       render(<TimelineSection />)
 
@@ -755,8 +767,8 @@ describe('TimelineSection', () => {
     })
 
     it('hides scroll hint after first panel beat', () => {
-      vi.mocked(useActivePanel).mockReturnValue(
-        mockActivePanelState([false, true, false], { activeIndex: 1, progress: 0.5 }),
+      vi.mocked(useTimelineScroll).mockReturnValue(
+        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5 }),
       )
 
       render(<TimelineSection />)

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,99 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useRef } from 'react'
 import { useTypewriter } from '../animations/useTypewriter'
-import { useActivePanel } from '../hooks/useActivePanel'
-import { StickySection } from './StickySection'
+import { useTimelineScroll } from '../hooks/useTimelineScroll'
+import { getTimelineScrollRangeVh } from './timelineGeometry'
 
 const TIMELINE_SECTION_NO = '// 03'
 
 function formatPanelCount(index: number, total: number): string {
   return `${String(index + 1).padStart(2, '0')} / ${String(total).padStart(2, '0')}`
-}
-
-function useTimelineInView(entryCount: number): boolean {
-  const [inView, setInView] = useState(true)
-  const visibilityRef = useRef(new Map<Element, boolean>())
-
-  useEffect(() => {
-    const sections = [
-      document.getElementById('timeline'),
-      ...Array.from(document.querySelectorAll('[id^="timeline-"]')),
-    ].filter((section): section is HTMLElement => section instanceof HTMLElement)
-
-    if (sections.length !== entryCount) {
-      return
-    }
-
-    visibilityRef.current = new Map(sections.map((section) => [section, true]))
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          visibilityRef.current.set(entry.target, entry.isIntersecting)
-        })
-        setInView(Array.from(visibilityRef.current.values()).some(Boolean))
-      },
-      { threshold: 0 },
-    )
-
-    sections.forEach((section) => observer.observe(section))
-    return () => observer.disconnect()
-  }, [entryCount])
-
-  return inView
-}
-
-function TimelineChrome({
-  activeIndex,
-  progress,
-  total,
-  visible,
-}: {
-  activeIndex: number
-  progress: number
-  total: number
-  visible: boolean
-}) {
-  const showScrollHint = activeIndex === 0
-
-  return (
-    <div
-      data-testid="timeline-chrome"
-      className="pointer-events-none fixed inset-0 z-50"
-      aria-hidden={!visible}
-      style={{
-        opacity: visible ? 1 : 0,
-        transition: 'opacity 0.3s',
-      }}
-    >
-      <div data-sticky-viewport="true" className="relative h-full w-full hscroll-sticky">
-        <div className="hscroll-head">
-          <span className="hscroll-no">{TIMELINE_SECTION_NO}</span>
-          <span className="hscroll-name">TIMELINE</span>
-          <div className="hscroll-rule" />
-          <div data-testid="progress-indicator" className="hscroll-progress">
-            <span data-testid="progress-count">{formatPanelCount(activeIndex, total)}</span>
-            <div className="hscroll-progress-track">
-              <div
-                data-testid="progress-fill"
-                className="hscroll-progress-fill"
-                style={{ width: `${progress * 100}%` }}
-              />
-            </div>
-          </div>
-        </div>
-
-        <div
-          data-testid="scroll-hint"
-          data-visible={showScrollHint}
-          aria-hidden="true"
-          className="hscroll-hint"
-          style={{ opacity: showScrollHint ? 0.85 : 0, transition: 'opacity 0.3s' }}
-        >
-          SCROLL <span>↓</span>
-        </div>
-      </div>
-    </div>
-  )
 }
 
 const timelineEntries: TimelineEntry[] = [
@@ -143,7 +56,7 @@ function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean 
       entry.role,
       ...entry.bullets,
     ],
-    [entry]
+    [entry],
   )
 
   const displayedLines = useTypewriter(active, lines, 16)
@@ -206,55 +119,106 @@ function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean 
 function TimelinePanel({
   entry,
   active,
-  panelRef,
-  id,
+  contentIndex,
 }: {
   entry: TimelineEntry
   active: boolean
-  panelRef: (el: HTMLElement | null) => void
-  id: string
+  contentIndex: number
 }) {
   return (
-    <StickySection id={id} className="bg-graphite-light">
-      <div ref={panelRef} className="relative min-h-screen">
-        <div
-          data-testid="section-label"
-          className={`tl-section-tag ${entry.category}`}
-        >
-          <span className="tl-section-slash">//</span>
-          <span className="tl-section-kind">
-            {entry.category === 'experience' ? 'EXPERIENCE' : 'EDUCATION'}
-          </span>
-        </div>
-        <CommitEntry entry={entry} active={active} />
+    <div
+      data-testid="timeline-panel"
+      data-content-index={contentIndex}
+      className="relative shrink-0"
+    >
+      <div
+        data-testid="section-label"
+        className={`tl-section-tag ${entry.category}`}
+      >
+        <span className="tl-section-slash">//</span>
+        <span className="tl-section-kind">
+          {entry.category === 'experience' ? 'EXPERIENCE' : 'EDUCATION'}
+        </span>
       </div>
-    </StickySection>
+      <CommitEntry entry={entry} active={active} />
+    </div>
   )
 }
 
 const TimelineSection: React.FC = () => {
+  const outerRef = useRef<HTMLElement>(null)
   const entryCount = timelineEntries.length
-  const { active, activeIndex, progress, setRef } = useActivePanel(entryCount)
-  const inView = useTimelineInView(entryCount)
+  const scrollRangeVh = getTimelineScrollRangeVh(entryCount)
+  const { active, activeIndex, progress, tx } = useTimelineScroll(outerRef, entryCount)
+  const trackEntries = useMemo(() => [...timelineEntries].reverse(), [])
 
   return (
-    <>
-      <TimelineChrome
-        activeIndex={activeIndex}
-        progress={progress}
-        total={entryCount}
-        visible={inView}
-      />
-      {timelineEntries.map((entry, i) => (
-        <TimelinePanel
+    <section
+      ref={outerRef}
+      id="timeline"
+      data-sticky-scroll-host="true"
+      className="relative min-h-screen bg-graphite-light"
+      style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'hidden' }}
+    >
+      {timelineEntries.map((entry, index) => (
+        <div
           key={entry.hash}
-          entry={entry}
-          active={active[i]}
-          panelRef={setRef(i)}
-          id={i === 0 ? 'timeline' : `timeline-${entry.hash}`}
+          data-testid="timeline-snap-anchor"
+          className="snap-anchor"
+          style={{ top: `${index * 100}vh` }}
+          aria-hidden="true"
         />
       ))}
-    </>
+
+      <div data-sticky-viewport="true" className="hscroll-sticky flex flex-col">
+        <div className="hscroll-head">
+          <span className="hscroll-no">{TIMELINE_SECTION_NO}</span>
+          <span className="hscroll-name">TIMELINE</span>
+          <div className="hscroll-rule" />
+          <div data-testid="progress-indicator" className="hscroll-progress">
+            <span data-testid="progress-count">{formatPanelCount(activeIndex, entryCount)}</span>
+            <div className="hscroll-progress-track">
+              <div
+                data-testid="progress-fill"
+                className="hscroll-progress-fill"
+                style={{ width: `${progress * 100}%` }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div
+          data-timeline-track="true"
+          className="hscroll-track"
+          style={{
+            transform: `translateX(${tx}px)`,
+            transition: 'transform 0.35s var(--ease)',
+          }}
+        >
+          {trackEntries.map((entry, reversedIndex) => {
+            const contentIndex = entryCount - 1 - reversedIndex
+            return (
+              <TimelinePanel
+                key={entry.hash}
+                entry={entry}
+                active={active[contentIndex]}
+                contentIndex={contentIndex}
+              />
+            )
+          })}
+        </div>
+
+        <div
+          data-testid="scroll-hint"
+          data-visible={activeIndex === 0}
+          aria-hidden="true"
+          className="hscroll-hint"
+          style={{ opacity: activeIndex === 0 ? 0.85 : 0, transition: 'opacity 0.3s' }}
+        >
+          SCROLL <span>↓</span>
+        </div>
+      </div>
+    </section>
   )
 }
 

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef } from 'react'
 import { useTypewriter } from '../animations/useTypewriter'
 import { useTimelineScroll } from '../hooks/useTimelineScroll'
-import { getTimelineScrollRangeVh } from './timelineGeometry'
+import { getTimelineScrollRangeVh, getTimelineSnapAnchorTopVh } from './timelineGeometry'
 
 const TIMELINE_SECTION_NO = '// 03'
 
@@ -165,7 +165,7 @@ const TimelineSection: React.FC = () => {
           key={entry.hash}
           data-testid="timeline-snap-anchor"
           className="snap-anchor"
-          style={{ top: `${index * 100}vh` }}
+          style={{ top: `${getTimelineSnapAnchorTopVh(index)}vh` }}
           aria-hidden="true"
         />
       ))}

--- a/src/components/timelineGeometry.test.ts
+++ b/src/components/timelineGeometry.test.ts
@@ -19,6 +19,12 @@ describe('timelineGeometry', () => {
     expect(getTimelineActiveIndex(1, 3)).toBe(2)
   })
 
+  it('keeps the sole entry active when only one timeline entry exists', () => {
+    expect(getTimelineActiveIndex(0, 1)).toBe(0)
+    expect(getTimelineActiveIndex(0.75, 1)).toBe(0)
+    expect(getTimelineTrackTranslate(0, 1, 1000)).toBe(0)
+  })
+
   it('computes raw vertical progress from section geometry', () => {
     expect(getTimelineScrollProgress(800, 2400, 800)).toBe(0)
     expect(getTimelineScrollProgress(-800, 2400, 800)).toBe(0.5)

--- a/src/components/timelineGeometry.test.ts
+++ b/src/components/timelineGeometry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getTimelineActiveIndex,
+  getTimelineScrollProgress,
+  getTimelineScrollRangeVh,
+  getTimelineSnapAnchorTopVh,
+  getTimelineTrackTranslate,
+} from './timelineGeometry'
+
+describe('timelineGeometry', () => {
+  it('uses one viewport height per timeline entry', () => {
+    expect(getTimelineScrollRangeVh(3)).toBe(3)
+    expect(getTimelineScrollRangeVh(0)).toBe(1)
+  })
+
+  it('maps scroll progress to quantized active indices', () => {
+    expect(getTimelineActiveIndex(0, 3)).toBe(0)
+    expect(getTimelineActiveIndex(0.49, 3)).toBe(1)
+    expect(getTimelineActiveIndex(1, 3)).toBe(2)
+  })
+
+  it('computes raw vertical progress from section geometry', () => {
+    expect(getTimelineScrollProgress(800, 2400, 800)).toBe(0)
+    expect(getTimelineScrollProgress(-800, 2400, 800)).toBe(0.5)
+    expect(getTimelineScrollProgress(-1600, 2400, 800)).toBe(1)
+  })
+
+  it('translates the reversed track so newest starts centered', () => {
+    expect(getTimelineTrackTranslate(0, 3, 1000)).toBe(-2000)
+    expect(getTimelineTrackTranslate(1, 3, 1000)).toBe(-1000)
+    expect(getTimelineTrackTranslate(2, 3, 1000)).toEqual(0)
+  })
+
+  it('places snap anchors at one viewport per entry', () => {
+    expect(getTimelineSnapAnchorTopVh(0)).toBe(0)
+    expect(getTimelineSnapAnchorTopVh(1)).toBe(100)
+    expect(getTimelineSnapAnchorTopVh(2)).toBe(200)
+  })
+})

--- a/src/components/timelineGeometry.ts
+++ b/src/components/timelineGeometry.ts
@@ -1,0 +1,47 @@
+import { clamp01 } from '../hooks/useHorizontalScroll'
+
+/** Returns the Timeline section height multiplier in viewport-height units. */
+export function getTimelineScrollRangeVh(entryCount: number) {
+  return Math.max(entryCount, 1)
+}
+
+/** Maps vertical scroll progress to the active timeline content index (0 = newest). */
+export function getTimelineActiveIndex(progress: number, entryCount: number) {
+  if (entryCount <= 1) {
+    return 0
+  }
+
+  return Math.max(0, Math.min(entryCount - 1, Math.round(progress * (entryCount - 1))))
+}
+
+/** Returns raw vertical scroll progress for a tall timeline section. */
+export function getTimelineScrollProgress(sectionTop: number, sectionHeight: number, viewportHeight: number) {
+  const scrollRange = Math.max(sectionHeight - viewportHeight, 0)
+  if (scrollRange === 0) {
+    return 0
+  }
+
+  return clamp01(-sectionTop / scrollRange)
+}
+
+/**
+ * Quantized horizontal translate for a reversed track (oldest left, newest right).
+ * Content index 0 (newest) starts centered at progress 0.
+ */
+export function getTimelineTrackTranslate(contentIndex: number, entryCount: number, viewportWidth: number) {
+  if (entryCount <= 1) {
+    return 0
+  }
+
+  const domIndex = entryCount - 1 - contentIndex
+  if (domIndex === 0) {
+    return 0
+  }
+
+  return -domIndex * viewportWidth
+}
+
+/** Returns snap-anchor top offset in viewport-height units. */
+export function getTimelineSnapAnchorTopVh(index: number) {
+  return index * 100
+}

--- a/src/hooks/useTimelineScroll.test.ts
+++ b/src/hooks/useTimelineScroll.test.ts
@@ -50,6 +50,39 @@ describe('useTimelineScroll', () => {
     expect(result.current.tx).toBe(-2000)
   })
 
+  it('defaults to the newest panel before the section ref attaches', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderHook(() => {
+      const outerRef = useRef<HTMLElement>(null)
+      return useTimelineScroll(outerRef, 3)
+    })
+
+    expect(result.current.activeIndex).toBe(0)
+    expect(result.current.active).toEqual([true, false, false])
+    expect(result.current.progress).toBe(0)
+    expect(result.current.tx).toBe(-2000)
+  })
+
+  it('selects the middle panel at mid-section scroll progress', () => {
+    setViewport(1000, 800)
+
+    const outer = document.createElement('section')
+    outer.getBoundingClientRect = vi.fn(() => createRect(-800, 2400))
+
+    const { result } = renderHook(() => {
+      const outerRef = useRef<HTMLElement>(outer)
+      return useTimelineScroll(outerRef, 3)
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current.activeIndex).toBe(1)
+    expect(result.current.active).toEqual([false, true, false])
+    expect(result.current.progress).toBe(0.5)
+    expect(result.current.tx).toBe(-1000)
+  })
+
   it('advances to older panels as the section scrolls', () => {
     setViewport(1000, 800)
 

--- a/src/hooks/useTimelineScroll.test.ts
+++ b/src/hooks/useTimelineScroll.test.ts
@@ -1,0 +1,71 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useRef } from 'react'
+import { useTimelineScroll } from './useTimelineScroll'
+
+function setViewport(width: number, height: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value: height,
+  })
+}
+
+function createRect(top: number, height: number): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: window.innerWidth,
+    width: window.innerWidth,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
+describe('useTimelineScroll', () => {
+  it('activates the newest panel and offsets the track at section entry', () => {
+    setViewport(1000, 800)
+
+    const outer = document.createElement('section')
+    outer.getBoundingClientRect = vi.fn(() => createRect(0, 2400))
+
+    const { result } = renderHook(() => {
+      const outerRef = useRef<HTMLElement>(outer)
+      return useTimelineScroll(outerRef, 3)
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current.activeIndex).toBe(0)
+    expect(result.current.active).toEqual([true, false, false])
+    expect(result.current.progress).toBe(0)
+    expect(result.current.tx).toBe(-2000)
+  })
+
+  it('advances to older panels as the section scrolls', () => {
+    setViewport(1000, 800)
+
+    const outer = document.createElement('section')
+    outer.getBoundingClientRect = vi.fn(() => createRect(-1600, 2400))
+
+    const { result } = renderHook(() => {
+      const outerRef = useRef<HTMLElement>(outer)
+      return useTimelineScroll(outerRef, 3)
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current.activeIndex).toBe(2)
+    expect(result.current.active).toEqual([false, false, true])
+    expect(result.current.progress).toBe(1)
+    expect(result.current.tx).toEqual(0)
+  })
+})

--- a/src/hooks/useTimelineScroll.ts
+++ b/src/hooks/useTimelineScroll.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState, type RefObject } from 'react'
+import {
+  getTimelineActiveIndex,
+  getTimelineScrollProgress,
+  getTimelineTrackTranslate,
+} from '../components/timelineGeometry'
+
+interface TimelineScrollState {
+  active: boolean[]
+  activeIndex: number
+  progress: number
+  tx: number
+}
+
+function getTimelineScrollState(
+  outer: HTMLElement | null,
+  entryCount: number,
+): TimelineScrollState {
+  if (!outer || entryCount === 0) {
+    return { active: [], activeIndex: 0, progress: 0, tx: 0 }
+  }
+
+  const rect = outer.getBoundingClientRect()
+  const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
+  const progress = getTimelineScrollProgress(rect.top, rect.height, viewportHeight)
+  const activeIndex = getTimelineActiveIndex(progress, entryCount)
+  const tx = getTimelineTrackTranslate(activeIndex, entryCount, viewportWidth)
+  const active = Array.from({ length: entryCount }, (_, index) => index === activeIndex)
+
+  return { active, activeIndex, progress, tx }
+}
+
+export function useTimelineScroll(
+  outerRef: RefObject<HTMLElement | null>,
+  entryCount: number,
+): TimelineScrollState {
+  const [state, setState] = useState<TimelineScrollState>(() =>
+    getTimelineScrollState(outerRef.current, entryCount),
+  )
+
+  useEffect(() => {
+    const update = () => {
+      setState(getTimelineScrollState(outerRef.current, entryCount))
+    }
+
+    update()
+
+    window.addEventListener('scroll', update, { passive: true })
+    window.addEventListener('resize', update)
+
+    return () => {
+      window.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+    }
+  }, [outerRef, entryCount])
+
+  return state
+}
+
+export default useTimelineScroll

--- a/src/hooks/useTimelineScroll.ts
+++ b/src/hooks/useTimelineScroll.ts
@@ -16,8 +16,17 @@ function getTimelineScrollState(
   outer: HTMLElement | null,
   entryCount: number,
 ): TimelineScrollState {
-  if (!outer || entryCount === 0) {
+  if (entryCount === 0) {
     return { active: [], activeIndex: 0, progress: 0, tx: 0 }
+  }
+
+  if (!outer) {
+    return {
+      active: Array.from({ length: entryCount }, (_, index) => index === 0),
+      activeIndex: 0,
+      progress: 0,
+      tx: getTimelineTrackTranslate(0, entryCount, window.innerWidth),
+    }
   }
 
   const rect = outer.getBoundingClientRect()


### PR DESCRIPTION
## Purpose
Restore the reference scroll model by making Timeline one tall major section with an internal horizontal panel track instead of separate global sticky pages per entry.

## What it does
Timeline now renders as a single `#timeline` section with `entryCount * 100vh` height, one internal sticky viewport, a reversed horizontal track (`data-timeline-track`), and one `.snap-anchor` per entry. Vertical scroll progress drives quantized horizontal translation via `useTimelineScroll` and `timelineGeometry`.

## Changes made
- **`TimelineSection.tsx`** — one scroll host, inline chrome, horizontal panel track
- **`timelineGeometry.ts`** — scroll range, progress, active index, and translate helpers
- **`useTimelineScroll.ts`** — scroll hook returning `{ active, activeIndex, progress, tx }`
- **`TimelineSection.test.tsx`** — issue #220 structure assertions; updated panel lookups for reversed DOM
- **`App.test.tsx`** — single `#timeline` major section in shell order

## Additional notes
- Track DOM order is oldest→newest (left→right); newest content index `0` starts centered at section entry.
- Panel progression/typewriter persistence refinements remain scoped to #221.
- `npm run typecheck` and `npm run test` pass (383 tests).

Closes #220

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Timeline rewritten to a scroll-driven layout with a single consolidated timeline section, smoother horizontal track movement, and vertical snap anchors for predictable navigation.
  * Per-entry visual state preserved across switches (typewriter/text progress) and improved desktop/mobile presentation (chrome, scroll hint, progress counter).

* **Tests**
  * Expanded and added tests covering scroll geometry, active-index mapping, track translation, and multiple scroll scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->