### PR TITLE
Remove Projects active-neighbor-far behavioral state

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -776,23 +776,40 @@ describe('ProjectsSection', () => {
       expectNoScrollDrivenCardDepthState(cards)
     })
 
-    it('scroll position does not add active/neighbor/far scale or opacity attributes', () => {
-      setViewport(1440, 900)
-      render(<ProjectsSection projects={threeProjects} />)
-
+    function simulateProjectsScroll(projectCount: number, scrolledPx: number, viewportWidth = 1440, viewportHeight = 900) {
+      setViewport(viewportWidth, viewportHeight)
       const projectsSection = document.getElementById('projects') as HTMLElement
       const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+      const sectionHeight = getScrollRangeVh(projectCount) * viewportHeight
 
-      const sectionHeight = getScrollRangeVh(threeProjects.length) * 900
       vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(
-        createRect(-(sectionHeight - 900), sectionHeight),
+        createRect(-scrolledPx, sectionHeight),
       )
       Object.defineProperty(carouselTrack, 'scrollWidth', {
         configurable: true,
-        value: getCarouselTrackWidth(threeProjects.length, 1440),
+        value: getCarouselTrackWidth(projectCount, viewportWidth),
       })
 
       act(() => window.dispatchEvent(new Event('scroll')))
+    }
+
+    it('scroll position does not add active/neighbor/far scale or opacity attributes at end of range', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const sectionHeight = getScrollRangeVh(threeProjects.length) * 900
+      simulateProjectsScroll(threeProjects.length, sectionHeight - 900)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      expectNoScrollDrivenCardDepthState(cards)
+    })
+
+    it('scroll position does not add active/neighbor/far scale or opacity attributes at mid range', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const scrollRangePx = (getScrollRangeVh(threeProjects.length) - 1) * 900
+      simulateProjectsScroll(threeProjects.length, scrollRangePx / 2)
 
       const cards = document.querySelectorAll('[data-testid="project-card"]')
       expectNoScrollDrivenCardDepthState(cards)
@@ -802,25 +819,33 @@ describe('ProjectsSection', () => {
       setViewport(1440, 900)
       render(<ProjectsSection projects={threeProjects} />)
 
-      const projectsSection = document.getElementById('projects') as HTMLElement
-      const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
-
       const sectionHeight = getScrollRangeVh(threeProjects.length) * 900
-      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(
-        createRect(-(sectionHeight - 900), sectionHeight),
-      )
-      Object.defineProperty(carouselTrack, 'scrollWidth', {
-        configurable: true,
-        value: getCarouselTrackWidth(threeProjects.length, 1440),
-      })
-
-      act(() => window.dispatchEvent(new Event('scroll')))
+      simulateProjectsScroll(threeProjects.length, sectionHeight - 900)
 
       const cards = document.querySelectorAll('[data-testid="project-card"]')
       cards.forEach((card) => {
         expect(card).toHaveAttribute('data-fill-active', 'false')
         expect(card.querySelector('[data-testid="project-card-fill"]')).toHaveAttribute('data-active', 'false')
       })
+    })
+
+    it('hover fill still activates after scrolling', async () => {
+      const user = userEvent.setup()
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const sectionHeight = getScrollRangeVh(threeProjects.length) * 900
+      simulateProjectsScroll(threeProjects.length, sectionHeight - 900)
+
+      const card = screen.getByRole('heading', { name: 'Project Three' }).closest('[data-testid="project-card"]')
+      expect(card).not.toBeNull()
+
+      const fill = card!.querySelector('[data-testid="project-card-fill"]')
+      expect(fill).toHaveAttribute('data-active', 'false')
+
+      await user.hover(card!)
+      expect(card).toHaveAttribute('data-fill-active', 'true')
+      expect(fill).toHaveAttribute('data-active', 'true')
     })
 
     it('outer container does not introduce horizontal page overflow from carousel cards', () => {

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -747,7 +747,7 @@ describe('ProjectsSection', () => {
     })
   })
 
-  describe('desktop active card and neighbor model', () => {
+  describe('issue #218 - no scroll-driven card scale or opacity state', () => {
     const threeProjects = [
       ...mockProjects,
       {
@@ -759,124 +759,34 @@ describe('ProjectsSection', () => {
       }
     ]
 
-    it('active card renders at full scale (1.0) and full opacity (1.0)', () => {
+    function expectNoScrollDrivenCardDepthState(cards: NodeListOf<Element>) {
+      cards.forEach((card) => {
+        expect(card).not.toHaveAttribute('data-card-state')
+        expect(card).not.toHaveAttribute('data-card-scale')
+        expect(card).not.toHaveAttribute('data-card-opacity')
+      })
+    }
+
+    it('cards do not expose active/neighbor/far scale or opacity attributes on initial render', () => {
       setViewport(1440, 900)
       render(<ProjectsSection projects={threeProjects} />)
 
       const cards = document.querySelectorAll('[data-testid="project-card"]')
       expect(cards).toHaveLength(3)
-
-      // At progress 0, card 0 is active
-      const activeCard = cards[0]
-      expect(activeCard).toHaveAttribute('data-card-state', 'active')
-      expect(activeCard).toHaveAttribute('data-card-scale', '1')
-      expect(activeCard).toHaveAttribute('data-card-opacity', '1')
+      expectNoScrollDrivenCardDepthState(cards)
     })
 
-    it('active card remains unfilled by default (no orange fill when not hovered)', () => {
-      setViewport(1440, 900)
-      render(<ProjectsSection projects={threeProjects} />)
-
-      const cards = document.querySelectorAll('[data-testid="project-card"]')
-      const activeCard = cards[0]
-      const fill = activeCard.querySelector('[data-testid="project-card-fill"]')
-
-      expect(fill).toHaveAttribute('data-active', 'false')
-    })
-
-    it('immediate left and right neighbor cards remain partially visible', () => {
-      setViewport(1440, 900)
-      render(<ProjectsSection projects={threeProjects} />)
-
-      const cards = document.querySelectorAll('[data-testid="project-card"]')
-
-      // At progress 0, card 0 is active, card 1 is right neighbor
-      const rightNeighbor = cards[1]
-      const neighborOpacity = Number(rightNeighbor.getAttribute('data-card-opacity'))
-      expect(neighborOpacity).toBeGreaterThan(0)
-      expect(neighborOpacity).toBeLessThan(1)
-    })
-
-    it('neighbor cards use reduced opacity relative to the active card', () => {
-      setViewport(1440, 900)
-      render(<ProjectsSection projects={threeProjects} />)
-
-      const cards = document.querySelectorAll('[data-testid="project-card"]')
-      const activeCard = cards[0]
-      const neighborCard = cards[1]
-
-      const activeOpacity = Number(activeCard.getAttribute('data-card-opacity'))
-      const neighborOpacity = Number(neighborCard.getAttribute('data-card-opacity'))
-
-      expect(neighborOpacity).toBeLessThan(activeOpacity)
-    })
-
-    it('neighbor cards use reduced scale relative to the active card', () => {
-      setViewport(1440, 900)
-      render(<ProjectsSection projects={threeProjects} />)
-
-      const cards = document.querySelectorAll('[data-testid="project-card"]')
-      const activeCard = cards[0]
-      const neighborCard = cards[1]
-
-      const activeScale = Number(activeCard.getAttribute('data-card-scale'))
-      const neighborScale = Number(neighborCard.getAttribute('data-card-scale'))
-
-      expect(neighborScale).toBeLessThan(activeScale)
-    })
-
-    it('far cards are visually suppressed with low opacity and scale', () => {
-      setViewport(1440, 900)
-      render(<ProjectsSection projects={threeProjects} />)
-
-      const cards = document.querySelectorAll('[data-testid="project-card"]')
-
-      // At progress 0, card 0 is active, card 1 is neighbor, card 2 is far
-      const farCard = cards[2]
-      const activeCard = cards[0]
-
-      const farOpacity = Number(farCard.getAttribute('data-card-opacity'))
-      const activeOpacity = Number(activeCard.getAttribute('data-card-opacity'))
-
-      expect(farOpacity).toBeLessThan(activeOpacity)
-
-      const farScale = Number(farCard.getAttribute('data-card-scale'))
-      const activeScale = Number(activeCard.getAttribute('data-card-scale'))
-
-      expect(farScale).toBeLessThan(activeScale)
-    })
-
-    it('no layout jump occurs when active index changes (smooth transition)', () => {
-      setViewport(1440, 900)
-      render(<ProjectsSection projects={threeProjects} />)
-
-      const cards = document.querySelectorAll('[data-testid="project-card"]')
-
-      // All cards should have transition properties for smooth scale/opacity changes
-      cards.forEach((card) => {
-        const style = (card as HTMLElement).style
-        expect(style.transition).toBeDefined()
-      })
-    })
-
-    it('outer container does not introduce horizontal page overflow from neighbor cards', () => {
-      setViewport(1440, 900)
-      render(<ProjectsSection projects={threeProjects} />)
-
-      const projectsSection = document.getElementById('projects')
-      expect(projectsSection).toHaveStyle({ overflowX: 'hidden' })
-    })
-
-    it('active card updates correctly at end of scroll range', () => {
+    it('scroll position does not add active/neighbor/far scale or opacity attributes', () => {
       setViewport(1440, 900)
       render(<ProjectsSection projects={threeProjects} />)
 
       const projectsSection = document.getElementById('projects') as HTMLElement
       const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
 
-      // Simulate scrolled to end position
       const sectionHeight = getScrollRangeVh(threeProjects.length) * 900
-      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-(sectionHeight - 900), sectionHeight))
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(
+        createRect(-(sectionHeight - 900), sectionHeight),
+      )
       Object.defineProperty(carouselTrack, 'scrollWidth', {
         configurable: true,
         value: getCarouselTrackWidth(threeProjects.length, 1440),
@@ -885,13 +795,40 @@ describe('ProjectsSection', () => {
       act(() => window.dispatchEvent(new Event('scroll')))
 
       const cards = document.querySelectorAll('[data-testid="project-card"]')
-      const lastIndex = threeProjects.length - 1
+      expectNoScrollDrivenCardDepthState(cards)
+    })
 
-      // At progress 1, last card should be active
-      const lastCard = cards[lastIndex]
-      expect(lastCard).toHaveAttribute('data-card-state', 'active')
-      expect(lastCard).toHaveAttribute('data-card-scale', '1')
-      expect(lastCard).toHaveAttribute('data-card-opacity', '1')
+    it('cards remain unfilled by default regardless of scroll position', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const projectsSection = document.getElementById('projects') as HTMLElement
+      const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+
+      const sectionHeight = getScrollRangeVh(threeProjects.length) * 900
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(
+        createRect(-(sectionHeight - 900), sectionHeight),
+      )
+      Object.defineProperty(carouselTrack, 'scrollWidth', {
+        configurable: true,
+        value: getCarouselTrackWidth(threeProjects.length, 1440),
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      cards.forEach((card) => {
+        expect(card).toHaveAttribute('data-fill-active', 'false')
+        expect(card.querySelector('[data-testid="project-card-fill"]')).toHaveAttribute('data-active', 'false')
+      })
+    })
+
+    it('outer container does not introduce horizontal page overflow from carousel cards', () => {
+      setViewport(1440, 900)
+      render(<ProjectsSection projects={threeProjects} />)
+
+      const projectsSection = document.getElementById('projects')
+      expect(projectsSection).toHaveStyle({ overflowX: 'hidden' })
     })
   })
 })

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -12,14 +12,8 @@ const TAG_VARIANTS = ['fuchsia', 'blue', 'orange', 'yellow'] as const
 
 const INVERTED_TAG_CLASS = 'ptag-inverted'
 
-const NEIGHBOR_SCALE = 0.92
-const NEIGHBOR_OPACITY = 0.6
-const FAR_SCALE = 0.85
-const FAR_OPACITY = 0.25
-const CARD_STATE_TRANSITION = {
+const CARD_HOVER_TRANSITION = {
   y: { duration: 0.2, ease: 'easeOut' },
-  scale: { duration: 0.3, ease: 'easeOut' },
-  opacity: { duration: 0.3, ease: 'easeOut' },
 } as const
 
 function clampIndex(index: number, projectCount: number) {
@@ -81,8 +75,8 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
             style={{ transform: `translateX(${tx}px)` }}
           >
             <div className="proj-edge" aria-hidden="true" />
-            {projects.map((project, index) => (
-              <ProjectCard key={project.id} project={project} index={index} activeIndex={activeIndex} />
+            {projects.map((project) => (
+              <ProjectCard key={project.id} project={project} />
             ))}
             <div className="proj-edge" aria-hidden="true" />
           </div>
@@ -115,18 +109,10 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
   )
 }
 
-const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: number }> = ({ project, index, activeIndex }) => {
+const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
   const [isHovered, setIsHovered] = useState(false)
   const [hasFocus, setHasFocus] = useState(false)
   const isFillActive = isHovered || hasFocus
-
-  const distance = Math.abs(index - activeIndex)
-  const isActive = distance === 0
-  const isNeighbor = distance === 1
-  const cardState = isActive ? 'active' : isNeighbor ? 'neighbor' : 'far'
-
-  const scale = isActive ? 1 : isNeighbor ? NEIGHBOR_SCALE : FAR_SCALE
-  const opacity = isActive ? 1 : isNeighbor ? NEIGHBOR_OPACITY : FAR_OPACITY
   const projectNumber = formatProjectNumber(project.id)
 
   return (
@@ -139,15 +125,11 @@ const ProjectCard: React.FC<{ project: Project; index: number; activeIndex: numb
           setHasFocus(false)
         }
       }}
-      animate={{ y: isFillActive ? -4 : 0, scale, opacity }}
-      transition={CARD_STATE_TRANSITION}
+      animate={{ y: isFillActive ? -4 : 0 }}
+      transition={CARD_HOVER_TRANSITION}
       data-testid="project-card"
       data-fill-active={isFillActive}
-      data-card-state={cardState}
-      data-card-scale={scale}
-      data-card-opacity={opacity}
       className="pcard shrink-0"
-      style={{ transformOrigin: 'center center' }}
     >
       <div className="pcard-bg" aria-hidden="true" />
 


### PR DESCRIPTION
## Purpose

Remove scroll-distance scale and opacity suppression from project cards so the carousel matches the reference geometry with only hover/focus interactions changing card state.

## What it does

Project cards no longer derive active/neighbor/far depth from scroll position. Cards render at reference scale and opacity at all times; the header progress counter still tracks scroll position.

## Changes made

- `ProjectsSection.tsx` — removed neighbor/far scale-opacity constants, distance-based card state, and `data-card-state` / `data-card-scale` / `data-card-opacity` attributes; hover/focus fill behavior unchanged
- `ProjectsSection.test.tsx` — replaced neighbor-model assertions with tests that scroll position does not add scale/opacity state attributes

## Additional notes

- `activeIndex` remains for the header progress counter only
- Hover lift (`y: -4`) and diagonal fill/readability transitions are preserved

Closes #218

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Projects cards now respond to hover and focus instead of scroll-based positioning, yielding more predictable interactions.

* **Bug Fix**
  * Fixed horizontal overflow in the Projects carousel so cards no longer cause page scrollbars.

* **Tests**
  * Updated test coverage to verify default visual states across scroll positions and hover activation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->