### PR TITLE
Fix Timeline active panel progression and typewriter persistence

### DIFF
--- a/src/animations/useTypewriter.test.ts
+++ b/src/animations/useTypewriter.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTypewriter } from './useTypewriter'
+
+describe('useTypewriter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('issue #221 - typewriter persistence', () => {
+    it('holds partial lines when active becomes false', () => {
+      const lines = ['commit abc123', 'Author: Test User']
+      const { result, rerender } = renderHook(
+        ({ active }) => useTypewriter(active, lines, 16),
+        { initialProps: { active: true } },
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(50)
+      })
+
+      const partial = [...result.current]
+      expect(partial[0]?.length).toBeGreaterThan(0)
+
+      rerender({ active: false })
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      expect(result.current).toEqual(partial)
+    })
+
+    it('resumes typing from held position when active becomes true again', () => {
+      const lines = ['Hello world']
+      const { result, rerender } = renderHook(
+        ({ active }) => useTypewriter(active, lines, 16),
+        { initialProps: { active: true } },
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(32)
+      })
+
+      const partialLength = result.current[0]?.length ?? 0
+      expect(partialLength).toBeGreaterThan(0)
+
+      rerender({ active: false })
+      rerender({ active: true })
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(result.current[0]?.length ?? 0).toBeGreaterThan(partialLength)
+    })
+
+    it('keeps completed lines visible after deactivation', () => {
+      const lines = ['Done']
+      const { result, rerender } = renderHook(
+        ({ active }) => useTypewriter(active, lines, 16),
+        { initialProps: { active: true } },
+      )
+
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(result.current[0]).toBe('Done')
+
+      rerender({ active: false })
+
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      expect(result.current[0]).toBe('Done')
+    })
+  })
+})

--- a/src/animations/useTypewriter.test.ts
+++ b/src/animations/useTypewriter.test.ts
@@ -59,6 +59,17 @@ describe('useTypewriter', () => {
       expect(result.current[0]?.length ?? 0).toBeGreaterThan(partialLength)
     })
 
+    it('stays empty when never activated', () => {
+      const lines = ['commit abc123']
+      const { result } = renderHook(() => useTypewriter(false, lines, 16))
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      expect(result.current).toEqual([])
+    })
+
     it('keeps completed lines visible after deactivation', () => {
       const lines = ['Done']
       const { result, rerender } = renderHook(

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -815,21 +815,18 @@ describe('TimelineSection', () => {
           activeIndex: 0,
           progress: 0,
           tx: -2000,
-          visibleHash: 'd4e8f2c',
         },
         {
           active: [false, true, false] as boolean[],
           activeIndex: 1,
           progress: 0.5,
           tx: -1000,
-          visibleHash: 'a3f9d2b',
         },
         {
           active: [false, false, true] as boolean[],
           activeIndex: 2,
           progress: 1,
           tx: 0,
-          visibleHash: 'b7c3e1a',
         },
       ] as const
 
@@ -903,6 +900,46 @@ describe('TimelineSection', () => {
 
       expect(newestPartial.length).toBeGreaterThan(0)
       expect(middlePartial).toBe('')
+    })
+
+    it('resumes typing on a panel when scroll reactivates it', () => {
+      vi.useFakeTimers()
+
+      const { rerender } = render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const partialHash =
+        getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+      expect(partialHash.length).toBeGreaterThan(0)
+
+      vi.mocked(useTimelineScroll).mockReturnValue(
+        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5, tx: -1000 }),
+      )
+      rerender(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      const heldHash =
+        getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+      expect(heldHash).toBe(partialHash)
+
+      vi.mocked(useTimelineScroll).mockReturnValue(
+        mockTimelineScrollState([true, false, false], { activeIndex: 0, progress: 0, tx: -2000 }),
+      )
+      rerender(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      const resumedHash =
+        getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+      expect(resumedHash.length).toBeGreaterThan(partialHash.length)
     })
   })
 })

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -1,7 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
 import TimelineSection from './TimelineSection'
+import { getTimelineTrackTranslate } from './timelineGeometry'
 import { useTimelineScroll } from '../hooks/useTimelineScroll'
+
+const timelineSectionSource = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'TimelineSection.tsx'),
+  'utf8',
+)
+
+const DEFAULT_ACTIVE = [true, false, false] as const
 
 function mockTimelineScrollState(
   active: boolean[],
@@ -15,12 +26,12 @@ function mockTimelineScrollState(
     active,
     activeIndex,
     progress: options.progress ?? (entryCount <= 1 ? 0 : activeIndex / (entryCount - 1)),
-    tx: options.tx ?? 0,
+    tx: options.tx ?? getTimelineTrackTranslate(activeIndex, entryCount, 1000),
   }
 }
 
 vi.mock('../hooks/useTimelineScroll', () => ({
-  useTimelineScroll: vi.fn(() => mockTimelineScrollState([false, false, false])),
+  useTimelineScroll: vi.fn(() => mockTimelineScrollState([...DEFAULT_ACTIVE])),
 }))
 
 function getTimelinePanel(contentIndex: number) {
@@ -30,7 +41,7 @@ function getTimelinePanel(contentIndex: number) {
 describe('TimelineSection', () => {
   afterEach(() => {
     vi.useRealTimers()
-    vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, false]))
+    vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([...DEFAULT_ACTIVE]))
   })
 
   it('each entry uses tl-panel layout class', () => {
@@ -42,7 +53,7 @@ describe('TimelineSection', () => {
     })
   })
 
-  it('entries start empty when no panel is active', () => {
+  it('entries stay empty when scroll state marks every panel inactive', () => {
     vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, false]))
 
     render(<TimelineSection />)
@@ -780,6 +791,118 @@ describe('TimelineSection', () => {
       render(<TimelineSection />)
 
       expect(screen.getByTestId('scroll-hint')).toHaveAttribute('aria-hidden', 'true')
+    })
+  })
+
+  describe('issue #221 - active panel progression and typewriter persistence', () => {
+    it('activates the newest entry by default from useTimelineScroll', () => {
+      render(<TimelineSection />)
+
+      expect(useTimelineScroll).toHaveBeenCalledWith(expect.objectContaining({ current: null }), 3)
+      expect(getTimelinePanel(0).getAttribute('data-content-index')).toBe('0')
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')).toBeNull()
+    })
+
+    it('derives active panels from useTimelineScroll instead of useActivePanel', () => {
+      expect(timelineSectionSource).toContain('useTimelineScroll')
+      expect(timelineSectionSource).not.toContain('useActivePanel')
+    })
+
+    it('maps scroll progression to older content indexes and track translate', () => {
+      const scenarios = [
+        {
+          active: [true, false, false] as boolean[],
+          activeIndex: 0,
+          progress: 0,
+          tx: -2000,
+          visibleHash: 'd4e8f2c',
+        },
+        {
+          active: [false, true, false] as boolean[],
+          activeIndex: 1,
+          progress: 0.5,
+          tx: -1000,
+          visibleHash: 'a3f9d2b',
+        },
+        {
+          active: [false, false, true] as boolean[],
+          activeIndex: 2,
+          progress: 1,
+          tx: 0,
+          visibleHash: 'b7c3e1a',
+        },
+      ] as const
+
+      for (const scenario of scenarios) {
+        vi.mocked(useTimelineScroll).mockReturnValue(
+          mockTimelineScrollState([...scenario.active], {
+            activeIndex: scenario.activeIndex,
+            progress: scenario.progress,
+            tx: scenario.tx,
+          }),
+        )
+
+        const { unmount } = render(<TimelineSection />)
+
+        expect(screen.getByTestId('progress-count')).toHaveTextContent(
+          `${String(scenario.activeIndex + 1).padStart(2, '0')} / 03`,
+        )
+        expect(document.querySelector('[data-timeline-track="true"]')).toHaveStyle({
+          transform: `translateX(${scenario.tx}px)`,
+        })
+
+        const activePanel = document.querySelector(
+          `[data-content-index="${scenario.activeIndex}"]`,
+        )
+        expect(activePanel?.querySelector('[data-testid="commit-hash"]')).toBeNull()
+
+        unmount()
+      }
+    })
+
+    it('keeps typed content visible when the active panel deactivates', () => {
+      vi.useFakeTimers()
+
+      const { rerender } = render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const partialHash =
+        getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+      expect(partialHash.length).toBeGreaterThan(0)
+
+      vi.mocked(useTimelineScroll).mockReturnValue(
+        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5, tx: -1000 }),
+      )
+      rerender(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(5000)
+      })
+
+      const heldHash =
+        getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+      expect(heldHash).toBe(partialHash)
+    })
+
+    it('starts typewriter on the newest panel at section entry', () => {
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const newestPartial =
+        getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+      const middlePartial =
+        getTimelinePanel(1).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
+
+      expect(newestPartial.length).toBeGreaterThan(0)
+      expect(middlePartial).toBe('')
     })
   })
 })

--- a/src/hooks/useTimelineScroll.test.ts
+++ b/src/hooks/useTimelineScroll.test.ts
@@ -101,4 +101,51 @@ describe('useTimelineScroll', () => {
     expect(result.current.progress).toBe(1)
     expect(result.current.tx).toEqual(0)
   })
+
+  describe('issue #221 - active panel progression', () => {
+    it('maps section scroll progress to active index in newest-to-oldest order', () => {
+      setViewport(1000, 800)
+
+      const scenarios = [
+        { top: 0, activeIndex: 0, active: [true, false, false], tx: -2000 },
+        { top: -800, activeIndex: 1, active: [false, true, false], tx: -1000 },
+        { top: -1600, activeIndex: 2, active: [false, false, true], tx: 0 },
+      ] as const
+
+      for (const scenario of scenarios) {
+        const outer = document.createElement('section')
+        outer.getBoundingClientRect = vi.fn(() => createRect(scenario.top, 2400))
+
+        const { result, unmount } = renderHook(() => {
+          const outerRef = useRef<HTMLElement>(outer)
+          return useTimelineScroll(outerRef, 3)
+        })
+
+        act(() => window.dispatchEvent(new Event('scroll')))
+
+        expect(result.current.activeIndex).toBe(scenario.activeIndex)
+        expect(result.current.active).toEqual(scenario.active)
+        expect(result.current.tx).toBe(scenario.tx)
+
+        unmount()
+      }
+    })
+
+    it('derives active state from section geometry rather than panel refs', () => {
+      setViewport(1000, 800)
+
+      const outer = document.createElement('section')
+      outer.getBoundingClientRect = vi.fn(() => createRect(-800, 2400))
+
+      const { result } = renderHook(() => {
+        const outerRef = useRef<HTMLElement>(outer)
+        return useTimelineScroll(outerRef, 3)
+      })
+
+      act(() => window.dispatchEvent(new Event('scroll')))
+
+      expect(result.current.activeIndex).toBe(1)
+      expect(result.current.progress).toBe(0.5)
+    })
+  })
 })


### PR DESCRIPTION
## Purpose

Close the deferred Timeline behavior gap from #220: newest-first panel activation driven by section scroll progress, and typed content that persists when panels deactivate.

## What it does

Builds on `useTimelineScroll` and `timelineGeometry` to verify newest-to-oldest panel progression and typewriter hold/resume behavior. Aligns TimelineSection test defaults with runtime state (newest panel active at section entry).

## Changes made

- Added explicit issue #221 acceptance tests in `TimelineSection.test.tsx` for panel order, scroll-derived active index/translate progression, and typewriter persistence on deactivation
- Extended `useTimelineScroll.test.ts` with newest-to-oldest progression scenarios mapped from section geometry
- Added `useTypewriter.test.ts` hook-level persistence/resume coverage
- Updated TimelineSection test mock defaults to `[true, false, false]` and realistic `tx` via `getTimelineTrackTranslate`

## Additional notes

Runtime wiring (`useTimelineScroll`, reversed track, `useTypewriter` hold-on-deactivate) landed in #220; this PR closes the QA/test gap called out in that merge. Manual browser QA for snap feel and slide direction still recommended against `ideas/Portfolio.html`.

Closes #221

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering typewriter persistence: pausing, resuming, partial-content retention, and never-activated behavior.
  * Added regression tests for timeline scroll: panel activation logic, progress/translation behavior, and typed-content retention across deactivation/reactivation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->