### PR TITLE
Fix navbar active-section tracking and smooth jumps

### DIFF
--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -307,6 +307,26 @@ describe('HeroSection', () => {
     expect(viewResume).toHaveClass('btn-outline')
   })
 
+  it('VIEW_WORK click smooth-scrolls to the projects section', () => {
+    const projects = document.createElement('section')
+    projects.id = 'projects'
+    Object.defineProperty(projects, 'offsetTop', { configurable: true, value: 1200 })
+    document.body.appendChild(projects)
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+
+    try {
+      render(<HeroSection />)
+      advanceToValuePropComplete()
+
+      screen.getByRole('link', { name: /VIEW_WORK →/i }).click()
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ top: 1200, behavior: 'smooth' })
+    } finally {
+      projects.remove()
+      scrollToSpy.mockRestore()
+    }
+  })
+
   it('wraps CTAs in hero-cta after value prop completes', () => {
     render(<HeroSection />)
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -13,6 +13,7 @@ import {
   VALUE_PROP_SPEED,
   cursorVariants,
 } from './HeroSection.constants'
+import { handleSectionLinkClick } from '../utils/smoothScrollTo'
 
 const ctaVariants = {
   hidden: { opacity: 0, y: 8 },
@@ -117,7 +118,11 @@ const HeroSection: React.FC<HeroSectionProps> = ({ introReady = true }) => {
             transition={{ duration: CTA_FADE_DURATION }}
             className="hero-cta"
           >
-            <a href="#projects" className="btn btn-fill">
+            <a
+              href="#projects"
+              className="btn btn-fill"
+              onClick={(event) => handleSectionLinkClick(event, 'projects')}
+            >
               VIEW_WORK <span>→</span>
             </a>
             <a

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from 'framer-motion'
 import { hoverEase } from '../animations/variants'
+import { handleSectionLinkClick } from '../utils/smoothScrollTo'
 
 interface NavLink {
   label: string
@@ -45,7 +46,10 @@ export default function MobileMenu({ isOpen, onClose, links }: MobileMenuProps) 
               <li key={label}>
                 <motion.a
                   href={href}
-                  onClick={onClose}
+                  onClick={(event) => {
+                    handleSectionLinkClick(event, href.slice(1))
+                    onClose()
+                  }}
                   variants={hoverEase}
                   initial="idle"
                   whileHover="hover"

--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -3,7 +3,48 @@ import { render, screen, waitFor, within, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Navbar from './Navbar'
 
+const VIEWPORT_HEIGHT = 800
+
+function rectWithHeight(top: number, height: number): DOMRect {
+  return {
+    top,
+    right: 1000,
+    bottom: top + height,
+    left: 0,
+    width: 1000,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
+function mockMajorSection(id: string, top: number, height: number): HTMLElement {
+  const section = document.createElement(id === 'contact' ? 'footer' : 'section')
+  section.id = id
+  vi.spyOn(section, 'getBoundingClientRect').mockReturnValue(rectWithHeight(top, height))
+  document.body.appendChild(section)
+  return section
+}
+
+function dispatchScrollUpdate() {
+  act(() => {
+    window.dispatchEvent(new Event('scroll'))
+  })
+}
+
 describe('Navbar', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: VIEWPORT_HEIGHT,
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
   it('renders FM_ logo that links to page top', () => {
     render(<Navbar />)
     const logo = screen.getByText('FM_')
@@ -87,35 +128,10 @@ describe('Navbar', () => {
   })
 
   describe('active section highlighting', () => {
-    let section: HTMLElement
-    let observerCallback!: IntersectionObserverCallback
-
-    beforeEach(() => {
-      section = document.createElement('section')
-      section.id = 'skills'
-      document.body.appendChild(section)
-
-      vi.stubGlobal('IntersectionObserver', vi.fn(function (cb: IntersectionObserverCallback) {
-        observerCallback = cb
-        return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() }
-      }))
-    })
-
-    afterEach(() => {
-      vi.unstubAllGlobals()
-      document.body.removeChild(section)
-      document.getElementById('projects')?.remove()
-    })
-
     it('scopes active color and underline to the label span only', () => {
+      mockMajorSection('skills', 0, VIEWPORT_HEIGHT)
       render(<Navbar />)
-
-      act(() => {
-        observerCallback(
-          [{ target: section, isIntersecting: true } as unknown as IntersectionObserverEntry],
-          {} as IntersectionObserver,
-        )
-      })
+      dispatchScrollUpdate()
 
       const skillsLink = screen.getByText('SKILLS').closest('a')
       expect(skillsLink).not.toBeNull()
@@ -130,25 +146,17 @@ describe('Navbar', () => {
     })
 
     it('restores inactive link caret and removes label underline when active section changes', () => {
-      const projectsSection = document.createElement('section')
-      projectsSection.id = 'projects'
-      document.body.appendChild(projectsSection)
+      mockMajorSection('skills', VIEWPORT_HEIGHT, VIEWPORT_HEIGHT)
+      const projectsSection = mockMajorSection('projects', -1600, VIEWPORT_HEIGHT * 6)
 
       render(<Navbar />)
 
-      act(() => {
-        observerCallback(
-          [{ target: section, isIntersecting: true } as unknown as IntersectionObserverEntry],
-          {} as IntersectionObserver,
-        )
-      })
+      dispatchScrollUpdate()
 
-      act(() => {
-        observerCallback(
-          [{ target: projectsSection, isIntersecting: true } as unknown as IntersectionObserverEntry],
-          {} as IntersectionObserver,
-        )
-      })
+      vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(
+        rectWithHeight(-1600, VIEWPORT_HEIGHT * 6),
+      )
+      dispatchScrollUpdate()
 
       const skillsLink = screen.getByText('SKILLS').closest('a')
       const skillsLabel = screen.getByText('SKILLS')
@@ -217,72 +225,28 @@ describe('Navbar', () => {
     })
 
     it('active link applies active class with nav-label underline via CSS not border utilities', () => {
-      const section = document.createElement('section')
-      section.id = 'skills'
-      document.body.appendChild(section)
-      let observerCallback!: IntersectionObserverCallback
+      mockMajorSection('skills', 0, VIEWPORT_HEIGHT)
+      render(<Navbar />)
+      dispatchScrollUpdate()
 
-      vi.stubGlobal('IntersectionObserver', vi.fn(function (cb: IntersectionObserverCallback) {
-        observerCallback = cb
-        return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() }
-      }))
+      const skillsLink = screen.getByText('SKILLS').closest('a')
+      const skillsLabel = screen.getByText('SKILLS')
 
-      try {
-        render(<Navbar />)
-
-        act(() => {
-          observerCallback(
-            [{ target: section, isIntersecting: true } as unknown as IntersectionObserverEntry],
-            {} as IntersectionObserver,
-          )
-        })
-
-        const skillsLink = screen.getByText('SKILLS').closest('a')
-        const skillsLabel = screen.getByText('SKILLS')
-
-        expect(skillsLink).toHaveClass('nav-link', 'active')
-        expect(skillsLabel).toHaveClass('nav-label')
-        expect(skillsLabel.className).not.toContain('border-b-2')
-        expect(skillsLabel.className).not.toContain('border-atomic-tangerine')
-        expect(skillsLabel.className).not.toContain('text-atomic-tangerine')
-        expect(skillsLink!.querySelector('.nav-caret')).not.toBeNull()
-        expect(skillsLink!.querySelector('.nav-caret')).toHaveTextContent('>')
-      } finally {
-        vi.unstubAllGlobals()
-        document.body.removeChild(section)
-      }
+      expect(skillsLink).toHaveClass('nav-link', 'active')
+      expect(skillsLabel).toHaveClass('nav-label')
+      expect(skillsLabel.className).not.toContain('border-b-2')
+      expect(skillsLabel.className).not.toContain('border-atomic-tangerine')
+      expect(skillsLabel.className).not.toContain('text-atomic-tangerine')
+      expect(skillsLink!.querySelector('.nav-caret')).not.toBeNull()
+      expect(skillsLink!.querySelector('.nav-caret')).toHaveTextContent('>')
     })
   })
 
   describe('issue #208 - active link shows caret', () => {
-    let section: HTMLElement
-    let observerCallback!: IntersectionObserverCallback
-
-    beforeEach(() => {
-      section = document.createElement('section')
-      section.id = 'skills'
-      document.body.appendChild(section)
-
-      vi.stubGlobal('IntersectionObserver', vi.fn(function (cb: IntersectionObserverCallback) {
-        observerCallback = cb
-        return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() }
-      }))
-    })
-
-    afterEach(() => {
-      vi.unstubAllGlobals()
-      document.body.removeChild(section)
-    })
-
     it('keeps nav-caret in DOM on active link for CSS visibility', () => {
+      mockMajorSection('skills', 0, VIEWPORT_HEIGHT)
       render(<Navbar />)
-
-      act(() => {
-        observerCallback(
-          [{ target: section, isIntersecting: true } as unknown as IntersectionObserverEntry],
-          {} as IntersectionObserver,
-        )
-      })
+      dispatchScrollUpdate()
 
       const skillsLink = screen.getByRole('link', { name: /skills/i })
       const caret = skillsLink.querySelector('[data-testid="nav-caret"]')
@@ -320,36 +284,94 @@ describe('Navbar', () => {
     })
 
     it('active link keeps the > prefix in DOM for CSS-driven visibility', () => {
-      const section = document.createElement('section')
-      section.id = 'skills'
-      document.body.appendChild(section)
-      let observerCallback!: IntersectionObserverCallback
+      mockMajorSection('skills', 0, VIEWPORT_HEIGHT)
+      render(<Navbar />)
+      dispatchScrollUpdate()
 
-      vi.stubGlobal('IntersectionObserver', vi.fn(function (cb: IntersectionObserverCallback) {
-        observerCallback = cb
-        return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() }
-      }))
+      const skillsLink = screen.getByRole('link', { name: /skills/i })
+      const labelSpan = skillsLink.querySelector('.nav-label')
+      const caretSpan = skillsLink.querySelector('[data-testid="nav-caret"]')
+      expect(labelSpan).toHaveClass('nav-label')
+      expect(caretSpan).not.toBeNull()
+      expect(caretSpan).toHaveTextContent('>')
+    })
+  })
 
-      try {
-        render(<Navbar />)
+  describe('issue #215 - active section tracking and smooth jumps', () => {
+    it('keeps PROJECTS active across the full internal scroll range', () => {
+      mockMajorSection('home', -VIEWPORT_HEIGHT, VIEWPORT_HEIGHT)
+      const projects = mockMajorSection('projects', -VIEWPORT_HEIGHT * 3, VIEWPORT_HEIGHT * 6)
+      mockMajorSection('skills', VIEWPORT_HEIGHT * 4, VIEWPORT_HEIGHT)
 
-        act(() => {
-          observerCallback(
-            [{ target: section, isIntersecting: true } as unknown as IntersectionObserverEntry],
-            {} as IntersectionObserver,
-          )
-        })
+      render(<Navbar />)
 
-        const skillsLink = screen.getByRole('link', { name: /skills/i })
-        const labelSpan = skillsLink.querySelector('.nav-label')
-        const caretSpan = skillsLink.querySelector('[data-testid="nav-caret"]')
-        expect(labelSpan).toHaveClass('nav-label')
-        expect(caretSpan).not.toBeNull()
-        expect(caretSpan).toHaveTextContent('>')
-      } finally {
-        vi.unstubAllGlobals()
-        document.body.removeChild(section)
+      for (const top of [-VIEWPORT_HEIGHT, -VIEWPORT_HEIGHT * 3, -(VIEWPORT_HEIGHT * 6 - VIEWPORT_HEIGHT)]) {
+        vi.spyOn(projects, 'getBoundingClientRect').mockReturnValue(
+          rectWithHeight(top, VIEWPORT_HEIGHT * 6),
+        )
+        dispatchScrollUpdate()
+
+        expect(screen.getByText('PROJECTS').closest('a')).toHaveClass('active')
       }
+    })
+
+    it('keeps TIMELINE active across the full internal scroll range', () => {
+      mockMajorSection('home', -VIEWPORT_HEIGHT * 2, VIEWPORT_HEIGHT)
+      mockMajorSection('projects', -VIEWPORT_HEIGHT * 8, VIEWPORT_HEIGHT * 6)
+      mockMajorSection('skills', -VIEWPORT_HEIGHT, VIEWPORT_HEIGHT)
+      const timeline = mockMajorSection('timeline', -VIEWPORT_HEIGHT * 2, VIEWPORT_HEIGHT * 3)
+      mockMajorSection('contact', VIEWPORT_HEIGHT * 2, VIEWPORT_HEIGHT)
+
+      render(<Navbar />)
+
+      for (const top of [0, -VIEWPORT_HEIGHT, -(VIEWPORT_HEIGHT * 3 - VIEWPORT_HEIGHT)]) {
+        vi.spyOn(timeline, 'getBoundingClientRect').mockReturnValue(
+          rectWithHeight(top, VIEWPORT_HEIGHT * 3),
+        )
+        dispatchScrollUpdate()
+
+        expect(screen.getByText('TIMELINE').closest('a')).toHaveClass('active')
+      }
+    })
+
+    it('desktop nav clicks smooth-scroll to the target section', async () => {
+      const user = userEvent.setup()
+      const projects = mockMajorSection('projects', 0, VIEWPORT_HEIGHT)
+      Object.defineProperty(projects, 'offsetTop', { configurable: true, value: 900 })
+      const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+
+      render(<Navbar />)
+
+      await user.click(screen.getByRole('link', { name: /projects/i }))
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ top: 900, behavior: 'smooth' })
+    })
+
+    it('logo click smooth-scrolls to home', async () => {
+      const user = userEvent.setup()
+      const home = mockMajorSection('home', 0, VIEWPORT_HEIGHT)
+      Object.defineProperty(home, 'offsetTop', { configurable: true, value: 0 })
+      const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+
+      render(<Navbar />)
+
+      await user.click(screen.getByText('FM_'))
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
+    })
+
+    it('mobile menu nav clicks smooth-scroll to the target section', async () => {
+      const user = userEvent.setup()
+      const timeline = mockMajorSection('timeline', 0, VIEWPORT_HEIGHT)
+      Object.defineProperty(timeline, 'offsetTop', { configurable: true, value: 2400 })
+      const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+
+      render(<Navbar />)
+
+      await user.click(screen.getByRole('button', { name: /open menu/i }))
+      await user.click(within(screen.getByRole('dialog')).getByRole('link', { name: 'TIMELINE' }))
+
+      expect(scrollToSpy).toHaveBeenCalledWith({ top: 2400, behavior: 'smooth' })
     })
   })
 })

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,8 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { hoverEase } from '../animations/variants'
+import { useActiveMajorSection } from '../hooks/useActiveMajorSection'
+import { handleSectionLinkClick, smoothScrollToSection } from '../utils/smoothScrollTo'
 import MobileMenu from './MobileMenu'
 
 const NAV_LINKS = [
@@ -12,40 +14,33 @@ const NAV_LINKS = [
 ]
 
 export default function Navbar() {
-  const [activeSection, setActiveSection] = useState<string>('')
+  const activeSection = useActiveMajorSection()
   const [menuOpen, setMenuOpen] = useState(false)
-
-  useEffect(() => {
-    const sections = document.querySelectorAll('section[id]')
-    const observer = new IntersectionObserver(
-      (entries) => {
-        for (const entry of entries) {
-          if (entry.isIntersecting) {
-            setActiveSection(entry.target.id)
-          }
-        }
-      },
-      { threshold: 0.5 }
-    )
-    sections.forEach((section) => observer.observe(section))
-    return () => observer.disconnect()
-  }, [])
 
   return (
     <>
       <nav className="nav">
-        <a href="#" className="nav-logo">
+        <a
+          href="#"
+          className="nav-logo"
+          onClick={(event) => {
+            event.preventDefault()
+            smoothScrollToSection('home')
+          }}
+        >
           FM_
         </a>
 
         <ul className="nav-list hidden md:flex">
           {NAV_LINKS.map(({ label, href }) => {
-            const isActive = activeSection === href.slice(1)
+            const sectionId = href.slice(1)
+            const isActive = activeSection === sectionId
             return (
               <li key={label}>
                 <a
                   href={href}
                   className={`nav-link${isActive ? ' active' : ''}`}
+                  onClick={(event) => handleSectionLinkClick(event, sectionId)}
                 >
                   <span className="nav-caret" data-testid="nav-caret">
                     &gt;

--- a/src/hooks/useActiveMajorSection.test.ts
+++ b/src/hooks/useActiveMajorSection.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  ACTIVE_SECTION_SAMPLE_RATIO,
+  MAJOR_SECTION_IDS,
+  computeActiveMajorSection,
+  useActiveMajorSection,
+} from './useActiveMajorSection'
+
+function rectWithHeight(top: number, height: number): DOMRect {
+  return {
+    top,
+    right: 1000,
+    bottom: top + height,
+    left: 0,
+    width: 1000,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
+function mockSection(id: string, top: number, height: number): HTMLElement {
+  const section = document.createElement('section')
+  section.id = id
+  vi.spyOn(section, 'getBoundingClientRect').mockReturnValue(rectWithHeight(top, height))
+  document.body.appendChild(section)
+  return section
+}
+
+describe('computeActiveMajorSection', () => {
+  const viewportHeight = 800
+  const probeY = viewportHeight * ACTIVE_SECTION_SAMPLE_RATIO
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('samples at 40% of viewport height', () => {
+    expect(probeY).toBe(320)
+  })
+
+  it('returns the first section when probe is above all sections', () => {
+    const sections = {
+      home: mockSection('home', 0, viewportHeight),
+      projects: mockSection('projects', viewportHeight, viewportHeight * 6),
+    }
+
+    expect(
+      computeActiveMajorSection(
+        MAJOR_SECTION_IDS,
+        (id) => sections[id as keyof typeof sections] ?? null,
+        viewportHeight,
+      ),
+    ).toBe('home')
+  })
+
+  it('keeps projects active across the full internal scroll range', () => {
+    const projectCount = 6
+    const projectsHeight = viewportHeight * projectCount
+    mockSection('home', -viewportHeight, viewportHeight)
+    const projects = mockSection('projects', -projectsHeight / 2, projectsHeight)
+    mockSection('skills', projectsHeight / 2, viewportHeight)
+
+    const scrollTops = [
+      0,
+      -viewportHeight,
+      -projectsHeight / 2,
+      -(projectsHeight - viewportHeight - 1),
+      -(projectsHeight - viewportHeight),
+    ]
+
+    for (const top of scrollTops) {
+      vi.spyOn(projects, 'getBoundingClientRect').mockReturnValue(
+        rectWithHeight(top, projectsHeight),
+      )
+
+      expect(
+        computeActiveMajorSection(MAJOR_SECTION_IDS, (id) => document.getElementById(id), viewportHeight),
+      ).toBe('projects')
+    }
+  })
+
+  it('keeps timeline active across the full internal scroll range', () => {
+    const entryCount = 3
+    const timelineHeight = viewportHeight * entryCount
+    mockSection('home', -viewportHeight * 2, viewportHeight)
+    mockSection('projects', -viewportHeight * 8, viewportHeight * 6)
+    mockSection('skills', -viewportHeight, viewportHeight)
+    const timeline = mockSection('timeline', -timelineHeight / 2, timelineHeight)
+    mockSection('contact', timelineHeight / 2, viewportHeight)
+
+    const scrollTops = [
+      0,
+      -viewportHeight,
+      -timelineHeight / 2,
+      -(timelineHeight - viewportHeight - 1),
+      -(timelineHeight - viewportHeight),
+    ]
+
+    for (const top of scrollTops) {
+      vi.spyOn(timeline, 'getBoundingClientRect').mockReturnValue(
+        rectWithHeight(top, timelineHeight),
+      )
+
+      expect(
+        computeActiveMajorSection(MAJOR_SECTION_IDS, (id) => document.getElementById(id), viewportHeight),
+      ).toBe('timeline')
+    }
+  })
+
+  it('does not switch active section based on internal snap anchors or panels', () => {
+    const projectsHeight = viewportHeight * 4
+    const projects = mockSection('projects', -viewportHeight, projectsHeight)
+
+    const snapAnchor = document.createElement('div')
+    snapAnchor.className = 'snap-anchor'
+    vi.spyOn(snapAnchor, 'getBoundingClientRect').mockReturnValue(rectWithHeight(100, 1))
+    projects.appendChild(snapAnchor)
+
+    const panel = document.createElement('div')
+    panel.dataset.timelineTrack = 'true'
+    vi.spyOn(panel, 'getBoundingClientRect').mockReturnValue(rectWithHeight(-200, viewportHeight))
+    projects.appendChild(panel)
+
+    expect(
+      computeActiveMajorSection(MAJOR_SECTION_IDS, (id) => document.getElementById(id), viewportHeight),
+    ).toBe('projects')
+  })
+})
+
+describe('useActiveMajorSection', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 800,
+    })
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('updates active section on scroll using major-section geometry', () => {
+    mockSection('home', 0, 800)
+    mockSection('projects', 5000, 4800)
+    mockSection('skills', 12000, 800)
+
+    const { result } = renderHook(() => useActiveMajorSection())
+
+    expect(result.current).toBe('home')
+
+    act(() => {
+      const projects = document.getElementById('projects') as HTMLElement
+      vi.spyOn(projects, 'getBoundingClientRect').mockReturnValue(rectWithHeight(-1600, 4800))
+      window.dispatchEvent(new Event('scroll'))
+    })
+
+    expect(result.current).toBe('projects')
+  })
+
+  it('cleans up scroll and resize listeners on unmount', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener')
+    const removeSpy = vi.spyOn(window, 'removeEventListener')
+
+    const { unmount } = renderHook(() => useActiveMajorSection())
+
+    const scrollHandler = addSpy.mock.calls.find(([event]) => event === 'scroll')?.[1]
+    const resizeHandler = addSpy.mock.calls.find(([event]) => event === 'resize')?.[1]
+
+    unmount()
+
+    expect(removeSpy).toHaveBeenCalledWith('scroll', scrollHandler)
+    expect(removeSpy).toHaveBeenCalledWith('resize', resizeHandler)
+  })
+})

--- a/src/hooks/useActiveMajorSection.test.ts
+++ b/src/hooks/useActiveMajorSection.test.ts
@@ -111,6 +111,33 @@ describe('computeActiveMajorSection', () => {
     }
   })
 
+  it('detects contact when the probe is inside the footer element', () => {
+    mockSection('home', -4000, viewportHeight)
+    mockSection('projects', -3000, viewportHeight * 6)
+    mockSection('skills', -800, viewportHeight)
+    mockSection('timeline', -400, viewportHeight * 3)
+    const contact = document.createElement('footer')
+    contact.id = 'contact'
+    vi.spyOn(contact, 'getBoundingClientRect').mockReturnValue(rectWithHeight(0, viewportHeight))
+    document.body.appendChild(contact)
+
+    expect(
+      computeActiveMajorSection(MAJOR_SECTION_IDS, (id) => document.getElementById(id), viewportHeight),
+    ).toBe('contact')
+  })
+
+  it('falls back to the first section when the probe is below all sections', () => {
+    mockSection('home', -1000, 200)
+    mockSection('projects', -800, 400)
+    mockSection('skills', -400, 400)
+    mockSection('timeline', -100, 80)
+    mockSection('contact', -50, 40)
+
+    expect(
+      computeActiveMajorSection(MAJOR_SECTION_IDS, (id) => document.getElementById(id), viewportHeight),
+    ).toBe('home')
+  })
+
   it('does not switch active section based on internal snap anchors or panels', () => {
     const projectsHeight = viewportHeight * 4
     const projects = mockSection('projects', -viewportHeight, projectsHeight)
@@ -160,6 +187,25 @@ describe('useActiveMajorSection', () => {
     })
 
     expect(result.current).toBe('projects')
+  })
+
+  it('updates active section on resize when viewport height changes', () => {
+    mockSection('home', 0, 500)
+    mockSection('skills', 250, 800)
+
+    const { result } = renderHook(() => useActiveMajorSection())
+
+    expect(result.current).toBe('skills')
+
+    act(() => {
+      Object.defineProperty(window, 'innerHeight', {
+        configurable: true,
+        value: 600,
+      })
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    expect(result.current).toBe('home')
   })
 
   it('cleans up scroll and resize listeners on unmount', () => {

--- a/src/hooks/useActiveMajorSection.ts
+++ b/src/hooks/useActiveMajorSection.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+
+export const MAJOR_SECTION_IDS = ['home', 'projects', 'skills', 'timeline', 'contact'] as const
+
+export const ACTIVE_SECTION_SAMPLE_RATIO = 0.4
+
+export function computeActiveMajorSection(
+  sectionIds: readonly string[],
+  getElement: (id: string) => HTMLElement | null,
+  viewportHeight: number,
+): string {
+  const probeY = viewportHeight * ACTIVE_SECTION_SAMPLE_RATIO
+  let current = sectionIds[0] ?? ''
+
+  for (const id of sectionIds) {
+    const element = getElement(id)
+    if (!element) continue
+
+    const rect = element.getBoundingClientRect()
+    if (rect.top <= probeY && rect.bottom > probeY) {
+      current = id
+    }
+  }
+
+  return current
+}
+
+export function useActiveMajorSection(): string {
+  const [activeSection, setActiveSection] = useState('')
+
+  useEffect(() => {
+    const updateActiveSection = () => {
+      setActiveSection(
+        computeActiveMajorSection(
+          MAJOR_SECTION_IDS,
+          (id) => document.getElementById(id),
+          window.innerHeight,
+        ),
+      )
+    }
+
+    updateActiveSection()
+    window.addEventListener('scroll', updateActiveSection, { passive: true })
+    window.addEventListener('resize', updateActiveSection)
+
+    return () => {
+      window.removeEventListener('scroll', updateActiveSection)
+      window.removeEventListener('resize', updateActiveSection)
+    }
+  }, [])
+
+  return activeSection
+}
+
+export default useActiveMajorSection

--- a/src/hooks/useActiveMajorSection.ts
+++ b/src/hooks/useActiveMajorSection.ts
@@ -26,7 +26,7 @@ export function computeActiveMajorSection(
 }
 
 export function useActiveMajorSection(): string {
-  const [activeSection, setActiveSection] = useState('')
+  const [activeSection, setActiveSection] = useState<string>(MAJOR_SECTION_IDS[0])
 
   useEffect(() => {
     const updateActiveSection = () => {

--- a/src/utils/smoothScrollTo.test.ts
+++ b/src/utils/smoothScrollTo.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { smoothScrollToSection } from './smoothScrollTo'
+
+describe('smoothScrollToSection', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('scrolls to the target section top with smooth behavior', () => {
+    const section = document.createElement('section')
+    section.id = 'projects'
+    Object.defineProperty(section, 'offsetTop', { configurable: true, value: 1200 })
+    document.body.appendChild(section)
+
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+
+    smoothScrollToSection('projects')
+
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 1200, behavior: 'smooth' })
+  })
+
+  it('no-ops when the section is missing', () => {
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+
+    smoothScrollToSection('missing')
+
+    expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/smoothScrollTo.test.ts
+++ b/src/utils/smoothScrollTo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { smoothScrollToSection } from './smoothScrollTo'
+import { handleSectionLinkClick, smoothScrollToSection } from './smoothScrollTo'
 
 describe('smoothScrollToSection', () => {
   afterEach(() => {
@@ -26,5 +26,28 @@ describe('smoothScrollToSection', () => {
     smoothScrollToSection('missing')
 
     expect(scrollToSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleSectionLinkClick', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('prevents default navigation and smooth-scrolls to the section', () => {
+    const section = document.createElement('section')
+    section.id = 'skills'
+    Object.defineProperty(section, 'offsetTop', { configurable: true, value: 1800 })
+    document.body.appendChild(section)
+
+    const scrollToSpy = vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+    const preventDefault = vi.fn()
+    const event = { preventDefault } as unknown as Parameters<typeof handleSectionLinkClick>[0]
+
+    handleSectionLinkClick(event, 'skills')
+
+    expect(preventDefault).toHaveBeenCalled()
+    expect(scrollToSpy).toHaveBeenCalledWith({ top: 1800, behavior: 'smooth' })
   })
 })

--- a/src/utils/smoothScrollTo.ts
+++ b/src/utils/smoothScrollTo.ts
@@ -1,0 +1,16 @@
+import type { MouseEvent } from 'react'
+
+export function smoothScrollToSection(sectionId: string): void {
+  const element = document.getElementById(sectionId)
+  if (!element) return
+
+  window.scrollTo({ top: element.offsetTop, behavior: 'smooth' })
+}
+
+export function handleSectionLinkClick(
+  event: MouseEvent<HTMLAnchorElement>,
+  sectionId: string,
+): void {
+  event.preventDefault()
+  smoothScrollToSection(sectionId)
+}


### PR DESCRIPTION
## Purpose
Restore reference scroll-model navbar behavior so active nav reflects major-section ownership and explicit navigation uses smooth jumps without affecting manual scrolling.

## What it does
Replaces IntersectionObserver-based active tracking with 40% viewport-height geometry sampling (matching `ideas/Portfolio.html`). Navbar, mobile menu, and VIEW_WORK CTA call `window.scrollTo({ behavior: 'smooth' })` on click; global CSS keeps native scroll behavior for wheel/trackpad.

## Changes made
- `useActiveMajorSection` hook with pure `computeActiveMajorSection` helper
- `smoothScrollTo` utility for section jumps
- `Navbar`, `MobileMenu`, and `HeroSection` wired to smooth explicit navigation
- Tests for Projects/Timeline full-range active state and smooth-scroll clicks

## Additional notes
- Active nav stays on Projects/Timeline for their entire tall section height, unaffected by internal snap anchors or panels
- `html` scroll-behavior remains unset (auto); smooth behavior is opt-in per click only

Closes #215

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smooth in-page navigation for section links and improved click handling for menu and hero CTAs
  * Background tracking that highlights the active major section as you scroll

* **Tests**
  * Expanded test coverage validating smooth-scroll behavior, active-section detection, and related navigation interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nemesis-12/portfolio/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->