### PR TITLE
Remove Projects card suppression states

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -747,7 +747,7 @@ describe('ProjectsSection', () => {
     })
   })
 
-  describe('issue #218 - no scroll-driven card scale or opacity state', () => {
+  describe('issue #233 - no active/neighbor/far card suppression state', () => {
     const threeProjects = [
       ...mockProjects,
       {

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -10,9 +10,27 @@ const portfolioCss = readFileSync(join(srcDir, 'portfolio.css'), 'utf8')
 const indexCss = readFileSync(join(srcDir, 'index.css'), 'utf8')
 
 function blockFor(selector: string) {
-  const match = portfolioCss.match(new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{([^}]*)\\}`))
-  expect(match).not.toBeNull()
-  return match?.[1] ?? ''
+  const selectorIndex = portfolioCss.indexOf(selector)
+  expect(selectorIndex).toBeGreaterThanOrEqual(0)
+
+  const blockStart = portfolioCss.indexOf('{', selectorIndex)
+  expect(blockStart).toBeGreaterThanOrEqual(0)
+
+  let depth = 0
+  for (let index = blockStart; index < portfolioCss.length; index += 1) {
+    const char = portfolioCss[index]
+    if (char === '{') {
+      depth += 1
+    }
+    if (char === '}') {
+      depth -= 1
+      if (depth === 0) {
+        return portfolioCss.slice(blockStart + 1, index)
+      }
+    }
+  }
+
+  throw new Error(`Missing closing brace for ${selector}`)
 }
 
 const REFERENCE_COMPONENT_CLASSES = [

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -9,6 +9,12 @@ const srcDir = dirname(fileURLToPath(import.meta.url))
 const portfolioCss = readFileSync(join(srcDir, 'portfolio.css'), 'utf8')
 const indexCss = readFileSync(join(srcDir, 'index.css'), 'utf8')
 
+function blockFor(selector: string) {
+  const match = portfolioCss.match(new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{([^}]*)\\}`))
+  expect(match).not.toBeNull()
+  return match?.[1] ?? ''
+}
+
 const REFERENCE_COMPONENT_CLASSES = [
   'ls-inner',
   'nav',
@@ -64,6 +70,15 @@ describe('portfolio.css CSS anchor', () => {
     expect(portfolioCss).toContain("[data-fill-active='true']")
     expect(portfolioCss).toContain('.pcard:hover .pcard-fill')
     expect(portfolioCss).toContain('.ptag-inverted')
+  })
+
+  it('does not prepare project cards for active/neighbor/far scale or opacity suppression', () => {
+    const projectCardRule = blockFor('.pcard')
+
+    expect(portfolioCss).not.toMatch(/data-card-state|card-state|neighbor|far/)
+    expect(projectCardRule).not.toMatch(/\bscale\(/)
+    expect(projectCardRule).not.toMatch(/transition:[^;}]*opacity/)
+    expect(projectCardRule).not.toMatch(/will-change:[^;}]*opacity/)
   })
 
   it('defines the shared easing token for transitions', () => {

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -83,7 +83,7 @@
   .proj-track{gap:56px}
   .proj-edge{flex-shrink:0;width:calc(50vw - min(280px, 39vw))}
   .pcard{--notch:22px;flex-shrink:0;width:min(560px,78vw);height:min(640px,76vh);position:relative;cursor:pointer;
-    transition:transform .35s var(--ease),opacity .35s var(--ease);will-change:transform,opacity}
+    transition:transform .35s var(--ease);will-change:transform}
   .pcard-bg{position:absolute;inset:0;background:var(--color-platinum);
     clip-path:polygon(var(--notch) 0, 100% 0, 100% calc(100% - var(--notch)), calc(100% - var(--notch)) 100%, 0 100%, 0 var(--notch));
     transition:transform .35s var(--ease)}


### PR DESCRIPTION
## Purpose
Remove the remaining Projects card opacity suppression preparation so cards retain reference visual weight while the horizontal track scrolls.

## What it does
Keeps Projects cards at their reference scale and opacity by removing base-card opacity transition/will-change preparation while preserving transform support for hover/focus motion and the existing diagonal fill behavior.

## Changes made
- Removed opacity from the `.pcard` transition and `will-change` CSS declarations.
- Added CSS regression coverage asserting Projects cards do not prepare active/neighbor/far scale or opacity suppression.
- Renamed the existing Projects scroll-state test group to issue #233 acceptance language.

## Additional notes
No parent PRD was referenced by the issue. `npm run typecheck` and `npm run test` both pass.

Closes #233

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized card transition animations to focus on transform properties.

* **Tests**
  * Updated test assertions to verify card styling behavior and transition properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->