### PR TITLE
Restore Projects sticky scroll shell

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -416,12 +416,12 @@ describe('ProjectsSection', () => {
     expect(scrollHint).toHaveClass('hscroll-hint')
   })
 
-  it('outer container does not introduce horizontal overflow', () => {
+  it('outer container clips horizontal overflow without creating a sticky-breaking scroll container', () => {
     setViewport(1000, 800)
     render(<ProjectsSection projects={mockProjects} />)
 
     const projectsSection = document.getElementById('projects')
-    expect(projectsSection).toHaveStyle({ overflowX: 'hidden' })
+    expect(projectsSection).toHaveStyle({ overflowX: 'clip' })
   })
 
   it('outer container does not participate in global card-deck stack depth', () => {
@@ -862,12 +862,12 @@ describe('ProjectsSection', () => {
       expect(fill).toHaveAttribute('data-active', 'true')
     })
 
-    it('outer container does not introduce horizontal page overflow from carousel cards', () => {
+    it('outer container clips horizontal page overflow from carousel cards without breaking sticky', () => {
       setViewport(1440, 900)
       render(<ProjectsSection projects={threeProjects} />)
 
       const projectsSection = document.getElementById('projects')
-      expect(projectsSection).toHaveStyle({ overflowX: 'hidden' })
+      expect(projectsSection).toHaveStyle({ overflowX: 'clip' })
     })
   })
 })

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -402,6 +402,20 @@ describe('ProjectsSection', () => {
     expect(carouselTrack?.closest('[data-sticky-viewport="true"]')).toBeInTheDocument()
   })
 
+  it('restores the reference sticky viewport shell with direct header, track, and scroll hint children', () => {
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const stickyViewport = document.querySelector('[data-sticky-viewport="true"]')
+    const header = document.querySelector('.hscroll-head')
+    const carouselTrack = document.querySelector('[data-carousel-track="true"]')
+    const scrollHint = screen.getByTestId('scroll-hint')
+
+    expect(header?.parentElement).toBe(stickyViewport)
+    expect(carouselTrack?.parentElement).toBe(stickyViewport)
+    expect(scrollHint.parentElement).toBe(stickyViewport)
+    expect(scrollHint).toHaveClass('hscroll-hint')
+  })
+
   it('outer container does not introduce horizontal overflow', () => {
     setViewport(1000, 800)
     render(<ProjectsSection projects={mockProjects} />)

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -48,38 +48,36 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
         />
       ))}
 
-      <div data-sticky-viewport="true" className="flex flex-col justify-center py-14 hscroll-sticky">
-        <div className="w-full">
-          <div className="hscroll-head">
-            <span className="hscroll-no">// 01</span>
-            <span className="hscroll-name">PROJECTS</span>
-            <div className="hscroll-rule" />
-            <div data-testid="progress-indicator" className="hscroll-progress">
-              <span data-testid="progress-count">
-                {String(activeIndex + 1).padStart(2, '0')} / {String(projects.length).padStart(2, '0')}
-              </span>
-              <div className="hscroll-progress-track">
-                <div
-                  data-testid="progress-fill"
-                  className="hscroll-progress-fill"
-                  style={{ width: `${progress * 100}%` }}
-                />
-              </div>
+      <div data-sticky-viewport="true" className="hscroll-sticky flex flex-col">
+        <div className="hscroll-head">
+          <span className="hscroll-no">// 01</span>
+          <span className="hscroll-name">PROJECTS</span>
+          <div className="hscroll-rule" />
+          <div data-testid="progress-indicator" className="hscroll-progress">
+            <span data-testid="progress-count">
+              {String(activeIndex + 1).padStart(2, '0')} / {String(projects.length).padStart(2, '0')}
+            </span>
+            <div className="hscroll-progress-track">
+              <div
+                data-testid="progress-fill"
+                className="hscroll-progress-fill"
+                style={{ width: `${progress * 100}%` }}
+              />
             </div>
           </div>
+        </div>
 
-          <div
-            ref={innerRef as React.RefObject<HTMLDivElement>}
-            data-carousel-track="true"
-            className="hscroll-track proj-track pb-4"
-            style={{ transform: `translateX(${tx}px)` }}
-          >
-            <div className="proj-edge" aria-hidden="true" />
-            {projects.map((project) => (
-              <ProjectCard key={project.id} project={project} />
-            ))}
-            <div className="proj-edge" aria-hidden="true" />
-          </div>
+        <div
+          ref={innerRef as React.RefObject<HTMLDivElement>}
+          data-carousel-track="true"
+          className="hscroll-track proj-track pb-4"
+          style={{ transform: `translateX(${tx}px)` }}
+        >
+          <div className="proj-edge" aria-hidden="true" />
+          {projects.map((project) => (
+            <ProjectCard key={project.id} project={project} />
+          ))}
+          <div className="proj-edge" aria-hidden="true" />
         </div>
 
         <motion.div
@@ -88,8 +86,7 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
           aria-hidden="true"
           animate={{ opacity: progress === 0 ? 0.85 : 0 }}
           transition={{ duration: 0.3 }}
-          className="absolute font-body text-periwinkle flex items-center gap-3 pointer-events-none"
-          style={{ fontSize: '14px', letterSpacing: '3px', left: '50%', bottom: '28px', transform: 'translateX(-50%)' }}
+          className="hscroll-hint pointer-events-none"
         >
           SCROLL{' '}
           <motion.span

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -36,7 +36,7 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
       id="projects"
       data-sticky-scroll-host="true"
       className="relative hscroll min-h-screen px-8 bg-graphite-light"
-      style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'hidden' }}
+      style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'clip' }}
     >
       {projects.map((_, index) => (
         <div


### PR DESCRIPTION
## Purpose
Restore Projects to the reference sticky horizontal scroll shell required by issue #234.

## What it does
Makes the Projects sticky viewport own the header, horizontal track, progress indicator, edge spacers, snap anchors, and scroll hint in the expected shell structure.

## Changes made
- Updated `ProjectsSection` so the `hscroll-head`, `hscroll-track`, and `hscroll-hint` are direct children of the sticky viewport.
- Reused the shared `hscroll-hint` styling for the Projects scroll hint while preserving progress-driven visibility.
- Added a focused ProjectsSection test that asserts the restored reference shell structure.

## Additional notes
- No parent PRD was referenced in issue #234.
- Verified with `npm run typecheck` and `npm run test`.

Closes #234

Made with [Cursor](https://cursor.com)