### PR TITLE
Restore Timeline sticky scroll shell

### DIFF
--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -713,6 +713,18 @@ describe('TimelineSection', () => {
     })
   })
 
+  describe('issue #235 - restore timeline sticky scroll shell', () => {
+    it('outer timeline scroll host uses the shared hscroll shell class', () => {
+      render(<TimelineSection />)
+
+      const timeline = document.getElementById('timeline')
+      const stickyViewport = timeline?.querySelector('[data-sticky-viewport="true"]')
+
+      expect(timeline).toHaveClass('hscroll')
+      expect(stickyViewport).toHaveClass('hscroll-sticky')
+    })
+  })
+
   describe('issue #206 - timeline section chrome', () => {
     it('renders // 03 TIMELINE header with hscroll classes', () => {
       render(<TimelineSection />)

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -157,7 +157,7 @@ const TimelineSection: React.FC = () => {
       ref={outerRef}
       id="timeline"
       data-sticky-scroll-host="true"
-      className="relative min-h-screen bg-graphite-light"
+      className="relative hscroll min-h-screen bg-graphite-light"
       style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'hidden' }}
     >
       {timelineEntries.map((entry, index) => (


### PR DESCRIPTION
## Purpose
Restore the Timeline sticky scroll shell so it matches the issue #235 one-section internal sticky viewport contract.

## What it does
Adds the shared `hscroll` shell class to the Timeline scroll host while preserving the existing internal sticky viewport, horizontal track, progress indicator, scroll hint, full-width panels, and snap anchors.

## Changes made
- Updated `TimelineSection` to mark the outer Timeline scroll host with the shared `hscroll` shell class.
- Added issue #235 regression coverage asserting the outer shell class and internal sticky viewport contract.

## Additional notes
Issue #235 has no PRD reference. The implementation intentionally leaves the existing Timeline geometry, track translation, typewriter behavior, progress indicator, scroll hint, and snap-anchor wiring unchanged.

Closes #235

Made with [Cursor](https://cursor.com)