### PR TITLE
Restore Timeline newest-to-oldest slide direction

### DIFF
--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
-import TimelineSection, { timelineEntries } from './TimelineSection'
+import TimelineSection from './TimelineSection'
 import { useTimelineScroll } from '../hooks/useTimelineScroll'
 
 function mockTimelineScrollState(
@@ -703,16 +703,25 @@ describe('TimelineSection', () => {
   })
 
   describe('issue #237 - newest-to-oldest slide direction', () => {
-    it('keeps timeline content semantics newest-first while rendering the track reversed', () => {
+    it('renders the track oldest-to-newest while preserving newest-first content semantics', () => {
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, true, true]))
+      vi.useFakeTimers()
+
       render(<TimelineSection />)
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
 
-      const semanticHashes = timelineEntries.map((entry) => entry.hash)
-      const renderedContentIndexes = Array.from(
-        document.querySelectorAll('[data-testid="timeline-panel"]'),
-      ).map((panel) => panel.getAttribute('data-content-index'))
+      const renderedPanels = Array.from(document.querySelectorAll('[data-testid="timeline-panel"]'))
+      const renderedContentIndexes = renderedPanels.map((panel) =>
+        panel.getAttribute('data-content-index'),
+      )
+      const renderedHashes = renderedPanels.map(
+        (panel) => panel.querySelector('[data-testid="commit-hash"]')?.textContent,
+      )
 
-      expect(semanticHashes).toEqual(['d4e8f2c', 'a3f9d2b', 'b7c3e1a'])
       expect(renderedContentIndexes).toEqual(['2', '1', '0'])
+      expect(renderedHashes).toEqual(['commit b7c3e1a', 'commit a3f9d2b', 'commit d4e8f2c'])
     })
 
     it.each([

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
-import TimelineSection from './TimelineSection'
+import TimelineSection, { timelineEntries } from './TimelineSection'
 import { useTimelineScroll } from '../hooks/useTimelineScroll'
 
 function mockTimelineScrollState(
@@ -700,6 +700,69 @@ describe('TimelineSection', () => {
       expect(contentIndexes).toEqual(['2', '1', '0'])
       expect(panels[2]?.getAttribute('data-content-index')).toBe('0')
     })
+  })
+
+  describe('issue #237 - newest-to-oldest slide direction', () => {
+    it('keeps timeline content semantics newest-first while rendering the track reversed', () => {
+      render(<TimelineSection />)
+
+      const semanticHashes = timelineEntries.map((entry) => entry.hash)
+      const renderedContentIndexes = Array.from(
+        document.querySelectorAll('[data-testid="timeline-panel"]'),
+      ).map((panel) => panel.getAttribute('data-content-index'))
+
+      expect(semanticHashes).toEqual(['d4e8f2c', 'a3f9d2b', 'b7c3e1a'])
+      expect(renderedContentIndexes).toEqual(['2', '1', '0'])
+    })
+
+    it.each([
+      {
+        active: [true, false, false],
+        activeIndex: 0,
+        expectedHash: 'commit d4e8f2c',
+        expectedCount: '01 / 03',
+        expectedTx: 'translateX(-2000px)',
+      },
+      {
+        active: [false, true, false],
+        activeIndex: 1,
+        expectedHash: 'commit a3f9d2b',
+        expectedCount: '02 / 03',
+        expectedTx: 'translateX(-1000px)',
+      },
+      {
+        active: [false, false, true],
+        activeIndex: 2,
+        expectedHash: 'commit b7c3e1a',
+        expectedCount: '03 / 03',
+        expectedTx: 'translateX(0px)',
+      },
+    ])(
+      'centers panel $activeIndex with the matching counter and track translation',
+      ({ active, activeIndex, expectedHash, expectedCount, expectedTx }) => {
+        vi.mocked(useTimelineScroll).mockReturnValue(
+          mockTimelineScrollState(active, {
+            activeIndex,
+            tx: activeIndex === 0 ? -2000 : activeIndex === 1 ? -1000 : 0,
+          }),
+        )
+        vi.useFakeTimers()
+
+        render(<TimelineSection />)
+        act(() => {
+          vi.advanceTimersByTime(15000)
+        })
+
+        const activePanel = getTimelinePanel(activeIndex)
+        const track = document.querySelector('[data-timeline-track="true"]') as HTMLElement
+
+        expect(activePanel.querySelector('[data-testid="commit-hash"]')).toHaveTextContent(
+          expectedHash,
+        )
+        expect(screen.getByTestId('progress-count')).toHaveTextContent(expectedCount)
+        expect(track.style.transform).toContain(expectedTx)
+      },
+    )
   })
 
   describe('issue #206 - timeline section chrome', () => {


### PR DESCRIPTION
## Purpose
Restore and lock down the Timeline's newest-to-oldest slide direction so the newest content remains the first user-facing panel.

## What it does
Adds focused regression coverage for the existing reversed Timeline track order, quantized newest/middle/oldest panel positions, progress counter values, and horizontal track translations.

## Changes made
- Import `timelineEntries` in `TimelineSection.test.tsx` to assert semantic newest-first content order.
- Add issue #237 tests for reversed rendered panel order (`2`, `1`, `0`).
- Add table-driven assertions for newest, intermediate, and oldest panels, including commit hash, counter text, and `translateX` direction.

## Additional notes
- The existing Timeline implementation already satisfied the issue behavior; this PR preserves it and adds explicit coverage to prevent regressions.
- `npm run typecheck` and `npm run test` pass.

Closes #237

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for timeline slide direction functionality, verifying correct panel ordering and progression tracking across different active panel states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->