### PR TITLE
Prevent horizontal document overflow

### DIFF
--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -639,6 +639,15 @@ describe('TimelineSection', () => {
       expect(stickyViewport).toHaveClass('hscroll-sticky')
     })
 
+    it('clips timeline host overflow without creating an overflow container around sticky content', () => {
+      render(<TimelineSection />)
+
+      const timeline = document.getElementById('timeline')
+
+      expect(timeline).toHaveStyle({ overflowX: 'clip' })
+      expect(timeline).not.toHaveStyle({ overflowX: 'hidden' })
+    })
+
     it('timeline track translateX is independent from the outer section transform', () => {
       vi.mocked(useTimelineScroll).mockReturnValue({
         active: [false, true, false],

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -129,7 +129,7 @@ function TimelinePanel({
     <div
       data-testid="timeline-panel"
       data-content-index={contentIndex}
-      className="relative shrink-0"
+      className="tl-panel-shell"
     >
       <div
         data-testid="section-label"

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -158,7 +158,7 @@ const TimelineSection: React.FC = () => {
       id="timeline"
       data-sticky-scroll-host="true"
       className="relative hscroll min-h-screen bg-graphite-light"
-      style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'hidden' }}
+      style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'clip' }}
     >
       {timelineEntries.map((entry, index) => (
         <div

--- a/src/index-css.test.ts
+++ b/src/index-css.test.ts
@@ -42,8 +42,9 @@ describe('global CSS brand chrome', () => {
     expect(blockFor('@theme')).toContain("--font-body: 'Space Mono', monospace;")
   })
 
-  it('clips horizontal overflow on the document body', () => {
-    expect(blockFor('body')).toContain('overflow-x: hidden;')
+  it('clips horizontal overflow on the full document', () => {
+    expect(blockFor('html')).toContain('overflow-x: clip;')
+    expect(blockFor('body')).toContain('overflow-x: clip;')
   })
 
   it('uses proximity vertical scroll snap on html', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,7 @@
 html {
   scroll-snap-type: y proximity;
   scroll-padding-top: 56px;
+  overflow-x: clip;
 }
 
 ::-webkit-scrollbar {
@@ -47,7 +48,7 @@ body {
   font-family: var(--font-body);
   background-color: var(--color-graphite);
   color: var(--color-periwinkle);
-  overflow-x: hidden;
+  overflow-x: clip;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -139,7 +139,7 @@ describe('portfolio.css CSS anchor', () => {
   })
 
   it('anchors timeline panel typography and terminal caret', () => {
-    expect(portfolioCss).toContain('.tl-panel{flex-shrink:0;width:100vw')
+    expect(portfolioCss).toContain('.tl-panel{height:calc(100vh - 160px)')
     expect(portfolioCss).toContain('.tl-commit{font-size:14px;color:var(--color-atomic-tangerine)')
     expect(portfolioCss).toContain('.caret{display:inline-block')
     expect(portfolioCss).toContain('@keyframes blink-cursor{50%{opacity:0}}')
@@ -165,5 +165,21 @@ describe('portfolio.css CSS anchor', () => {
       /\[data-sticky-section="true"\]:not\(\[data-sticky-scroll-host="true"\]\)\{[^}]*position:sticky/,
     )
     expect(portfolioCss).toContain('[data-sticky-viewport="true"]')
+  })
+
+  it('avoids scrollbar-induced document overflow from full-width surfaces', () => {
+    expect(blockFor('#hero{')).toContain('width:100%')
+    expect(blockFor('.hscroll')).toContain('width:100%')
+    expect(blockFor('#skills{')).toContain('width:100%')
+    expect(blockFor('footer')).toContain('width:100%')
+    expect(portfolioCss).not.toMatch(/width:100vw/)
+  })
+
+  it('clips internal horizontal tracks inside sticky viewports', () => {
+    const stickyViewportRule = blockFor('.hscroll-sticky,[data-sticky-viewport="true"]')
+
+    expect(stickyViewportRule).toContain('width:100%')
+    expect(stickyViewportRule).toContain('max-width:100%')
+    expect(stickyViewportRule).toContain('overflow:hidden')
   })
 })

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -46,7 +46,7 @@
   .nav-link.active .nav-label{color:var(--color-atomic-tangerine)}
 
   /* ─── HERO ──── */
-  #hero{width:100vw;min-height:100vh;display:flex;flex-direction:column;justify-content:center;padding:0 5vw;position:relative;overflow:hidden}
+  #hero{width:100%;min-height:100vh;display:flex;flex-direction:column;justify-content:center;padding:0 5vw;position:relative;overflow:hidden}
   .hero-grid{position:absolute;inset:0;background-image:linear-gradient(var(--color-graphite-light) 1px,transparent 1px),linear-gradient(90deg,var(--color-graphite-light) 1px,transparent 1px);background-size:80px 80px;opacity:.35;mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%);-webkit-mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%)}
   .hero-inner{position:relative;z-index:1;width:100%;padding:0 5vw}
   .hero-init{font-size:11px;color:var(--color-atomic-tangerine);letter-spacing:4px;margin-bottom:18px}
@@ -65,8 +65,8 @@
   .btn-outline:hover{box-shadow:inset 0 0 0 1px var(--color-atomic-tangerine);color:var(--color-atomic-tangerine)}
 
   /* ─── HORIZONTAL SCROLL SCAFFOLD ──── */
-  .hscroll{position:relative;width:100vw;height:100%}
-  .hscroll-sticky,[data-sticky-viewport="true"]{position:sticky;top:0;height:100vh;width:100vw;overflow:hidden;display:flex;flex-direction:column}
+  .hscroll{position:relative;width:100%;height:100%}
+  .hscroll-sticky,[data-sticky-viewport="true"]{position:sticky;top:0;height:100vh;width:100%;max-width:100%;overflow:hidden;display:flex;flex-direction:column}
   .hscroll-head{padding:74px 5vw 18px;display:flex;align-items:center;gap:18px;flex-shrink:0}
   .hscroll-no{font-size:14px;color:var(--color-atomic-tangerine);letter-spacing:3px}
   .hscroll-name{font-family:var(--font-display);font-size:18px;color:var(--color-platinum);letter-spacing:3px}
@@ -186,7 +186,7 @@
   @keyframes fade-up{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
 
   /* ─── SKILLS ──── */
-  #skills{width:100vw;padding:120px 5vw 140px;position:relative}
+  #skills{width:100%;padding:120px 5vw 140px;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:80px}
   .bento{display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:170px 150px 110px 90px;gap:12px;
     grid-template-areas:
@@ -217,7 +217,8 @@
   .c-yellow{background:var(--color-golden-pollen);color:var(--color-graphite)}
 
   /* ─── TIMELINE ──── */
-  .tl-panel{flex-shrink:0;width:100vw;height:calc(100vh - 160px);padding:0 8vw;display:flex;flex-direction:column;justify-content:center;position:relative;transition:opacity .35s var(--ease)}
+  .tl-panel-shell{flex:0 0 100%;width:100%;position:relative}
+  .tl-panel{height:calc(100vh - 160px);padding:0 8vw;display:flex;flex-direction:column;justify-content:center;position:relative;transition:opacity .35s var(--ease)}
   .tl-commit{font-size:14px;color:var(--color-atomic-tangerine);letter-spacing:1px;margin-bottom:8px;min-height:1.5em}
   .tl-meta{font-size:14px;color:var(--color-periwinkle);letter-spacing:1px;line-height:1.9;min-height:1.5em}
   .tl-sep{height:48px}
@@ -237,7 +238,7 @@
   .caret{display:inline-block;width:.55ch;height:.9em;background:currentColor;vertical-align:-.13em;margin-left:4px;animation:blink-cursor 1.05s steps(1) infinite}
 
   /* ─── FOOTER ──── */
-  footer{width:100vw;min-height:100vh;display:flex;flex-direction:column;padding:0}
+  footer{width:100%;min-height:100vh;display:flex;flex-direction:column;padding:0}
   .footer-cta{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:80px 5vw;gap:48px;text-align:center}
   .footer-big{font-family:var(--font-display);font-size:clamp(40px,8vw,120px);color:var(--color-platinum);line-height:1.1;letter-spacing:-1px}
   .footer-big-line{display:block}


### PR DESCRIPTION
## Purpose
Prevent wide internal scroll tracks from creating document-level horizontal overflow while preserving the existing reference layout.

## What it does
Clips horizontal overflow at the document root and keeps Projects/Timeline horizontal tracks contained inside their sticky viewport shells.

## Changes made
- Added document-level horizontal clipping on `html` and `body`.
- Replaced top-level `100vw` section/sticky widths with `100%` to avoid scrollbar-gutter overflow.
- Added a full-width Timeline panel shell so horizontal track panels retain viewport-sized layout without `100vw`.
- Added CSS regression coverage for document clipping, sticky viewport clipping, and absence of `width:100vw` surfaces.

## Additional notes
`npm run typecheck` and `npm run test` pass. Issue #241 listed #234 and #235 as blockers; both are already present in `origin/main`.

Closes #241

Made with [Cursor](https://cursor.com)