### PR TITLE
Fix Projects track progress math

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -304,6 +304,43 @@ describe('ProjectsSection', () => {
     expect(carouselTrack.style.transform).toBe(`translateX(${-0.5 * (trackWidth - 1000)}px)`)
   })
 
+  it('uses the Projects runway instead of raw section height for progress math', () => {
+    const fourProjects = [
+      ...mockProjects,
+      {
+        id: '3',
+        title: 'Project Three',
+        description: 'Description for project three',
+        tags: ['Vue', 'Python'],
+        links: [{ label: 'Site', url: 'https://project3.com' }],
+      },
+      {
+        id: '4',
+        title: 'Project Four',
+        description: 'Description for project four',
+        tags: ['Go', 'Postgres'],
+        links: [{ label: 'Repo', url: 'https://github.com/project4' }],
+      },
+    ]
+
+    setViewport(1200, 900)
+    render(<ProjectsSection projects={fourProjects} />)
+
+    const projectsSection = document.getElementById('projects') as HTMLElement
+    const carouselTrack = document.querySelector('[data-carousel-track="true"]') as HTMLElement
+
+    vi.spyOn(projectsSection, 'getBoundingClientRect').mockReturnValue(createRect(-1350, 9999))
+    Object.defineProperty(carouselTrack, 'scrollWidth', {
+      configurable: true,
+      value: 3200,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(carouselTrack.style.transform).toBe('translateX(-1000px)')
+    expect(screen.getByTestId('progress-fill')).toHaveStyle({ width: '50%' })
+  })
+
   it('section header uses hscroll classes with orange slash and pixel font name', () => {
     render(<ProjectsSection projects={mockProjects} />)
 

--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -587,6 +587,11 @@ describe('ProjectsSection', () => {
       expect(screen.getByTestId('progress-count')).toHaveTextContent('01 / 01')
     })
 
+    it('progress count shows 00 / 00 for an empty project list', () => {
+      render(<ProjectsSection projects={[]} />)
+      expect(screen.getByTestId('progress-count')).toHaveTextContent('00 / 00')
+    })
+
     it('progress count advances to last card index at full scroll', () => {
       setViewport(1000, 800)
       render(<ProjectsSection projects={mockProjects} />)

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -36,6 +36,7 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
   const activeIndex = projects.length > 1
     ? clampIndex(Math.round(progress * (projects.length - 1)), projects.length)
     : 0
+  const visibleProjectIndex = projects.length === 0 ? 0 : activeIndex + 1
 
   return (
     <section
@@ -62,7 +63,7 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
           <div className="hscroll-rule" />
           <div data-testid="progress-indicator" className="hscroll-progress">
             <span data-testid="progress-count">
-              {String(activeIndex + 1).padStart(2, '0')} / {String(projects.length).padStart(2, '0')}
+              {String(visibleProjectIndex).padStart(2, '0')} / {String(projects.length).padStart(2, '0')}
             </span>
             <div className="hscroll-progress-track">
               <div

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,8 +1,8 @@
-import { useRef, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
 import { useHorizontalScroll } from '../hooks/useHorizontalScroll'
 import type { Project } from '../data/projects'
-import { formatProjectNumber, getScrollRangeVh } from './projectsGeometry'
+import { formatProjectNumber, getProjectsScrollRunwayPx, getScrollRangeVh } from './projectsGeometry'
 
 interface Props {
   projects: Project[]
@@ -23,8 +23,15 @@ function clampIndex(index: number, projectCount: number) {
 const ProjectsSection: React.FC<Props> = ({ projects }) => {
   const outerRef = useRef<HTMLElement>(null)
   const innerRef = useRef<HTMLDivElement>(null)
-  const { tx, progress } = useHorizontalScroll(outerRef as React.RefObject<HTMLElement>, innerRef as React.RefObject<HTMLElement>)
   const scrollRangeVh = getScrollRangeVh(projects.length)
+  const scrollOptions = useMemo(() => ({
+    getScrollRangePx: ({ viewportHeight }: { viewportHeight: number }) => getProjectsScrollRunwayPx(projects.length, viewportHeight),
+  }), [projects.length])
+  const { tx, progress } = useHorizontalScroll(
+    outerRef as React.RefObject<HTMLElement>,
+    innerRef as React.RefObject<HTMLElement>,
+    scrollOptions,
+  )
 
   const activeIndex = projects.length > 1
     ? clampIndex(Math.round(progress * (projects.length - 1)), projects.length)

--- a/src/components/projectsGeometry.test.ts
+++ b/src/components/projectsGeometry.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   formatProjectNumber,
+  getProjectsScrollProgress,
+  getProjectsTrackState,
+  getProjectsTrackTranslate,
   getEdgeSpacerWidth,
   getScrollRangeVh,
   PROJECT_CARD_GAP,
@@ -49,6 +52,46 @@ describe('projectsGeometry', () => {
     it('matches calc(50vw - min(280px, 39vw)) for desktop card width', () => {
       expect(getEdgeSpacerWidth(1440)).toBe(440)
       expect(getEdgeSpacerWidth(1000)).toBe(220)
+    })
+  })
+
+  describe('Projects track progress math', () => {
+    it('starts with zero progress and the first card centered', () => {
+      expect(getProjectsTrackState(0, 4, 900, 3200, 1200)).toEqual({
+        progress: 0,
+        tx: 0,
+      })
+    })
+
+    it('maps the middle of the vertical runway to the middle of the horizontal overflow', () => {
+      expect(getProjectsTrackState(-1350, 4, 900, 3200, 1200)).toEqual({
+        progress: 0.5,
+        tx: -1000,
+      })
+    })
+
+    it('ends at full progress with the last card centered', () => {
+      expect(getProjectsTrackState(-2700, 4, 900, 3200, 1200)).toEqual({
+        progress: 1,
+        tx: -2000,
+      })
+    })
+
+    it('recomputes progress from the current viewport height after resize', () => {
+      expect(getProjectsScrollProgress(-1350, 4, 900)).toBe(0.5)
+      expect(getProjectsScrollProgress(-1350, 4, 600)).toBe(0.75)
+    })
+
+    it('recomputes translation from the current viewport width after resize', () => {
+      expect(getProjectsTrackTranslate(0.5, 2600, 1000)).toBe(-800)
+      expect(getProjectsTrackTranslate(0.5, 2600, 1200)).toBe(-700)
+    })
+
+    it('keeps progress while suppressing translation when the track does not overflow', () => {
+      expect(getProjectsTrackState(-1350, 4, 900, 1000, 1200)).toEqual({
+        progress: 0.5,
+        tx: 0,
+      })
     })
   })
 })

--- a/src/components/projectsGeometry.ts
+++ b/src/components/projectsGeometry.ts
@@ -30,6 +30,55 @@ export function getScrollRangeVh(projectCount: number) {
   return Math.max(projectCount, 1)
 }
 
+function clamp01(value: number) {
+  return Math.min(Math.max(value, 0), 1)
+}
+
+/** Returns the vertical Projects scroll runway in pixels. */
+export function getProjectsScrollRunwayPx(projectCount: number, viewportHeight: number) {
+  return Math.max(getScrollRangeVh(projectCount) - 1, 0) * viewportHeight
+}
+
+/** Returns Projects vertical scroll progress from section top and runway geometry. */
+export function getProjectsScrollProgress(
+  sectionTop: number,
+  projectCount: number,
+  viewportHeight: number,
+) {
+  const scrollRunway = getProjectsScrollRunwayPx(projectCount, viewportHeight)
+  if (scrollRunway === 0) {
+    return 0
+  }
+
+  return clamp01(-sectionTop / scrollRunway)
+}
+
+/** Returns Projects track translation for the actual horizontal overflow. */
+export function getProjectsTrackTranslate(progress: number, trackWidth: number, viewportWidth: number) {
+  const horizontalDistance = Math.max(trackWidth - viewportWidth, 0)
+  if (horizontalDistance === 0 || progress === 0) {
+    return 0
+  }
+
+  return -(clamp01(progress) * horizontalDistance)
+}
+
+/** Maps Projects section scroll geometry to track progress and translation. */
+export function getProjectsTrackState(
+  sectionTop: number,
+  projectCount: number,
+  viewportHeight: number,
+  trackWidth: number,
+  viewportWidth: number,
+) {
+  const progress = getProjectsScrollProgress(sectionTop, projectCount, viewportHeight)
+
+  return {
+    progress,
+    tx: getProjectsTrackTranslate(progress, trackWidth, viewportWidth),
+  }
+}
+
 /** Formats a project id as the v4 card number prefix (e.g. "1" → "_01"). */
 export function formatProjectNumber(id: string) {
   return `_${id.padStart(2, '0')}`

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -5,6 +5,16 @@ interface HorizontalScrollState {
   progress: number
 }
 
+interface HorizontalScrollOptions {
+  getScrollRangePx?: (geometry: {
+    sectionTop: number
+    sectionHeight: number
+    viewportHeight: number
+  }) => number
+}
+
+const DEFAULT_HORIZONTAL_SCROLL_OPTIONS: HorizontalScrollOptions = {}
+
 export function clamp01(value: number) {
   return Math.min(Math.max(value, 0), 1)
 }
@@ -12,6 +22,7 @@ export function clamp01(value: number) {
 function getHorizontalScrollState(
   outer: HTMLElement | null,
   inner: HTMLElement | null,
+  options: HorizontalScrollOptions = DEFAULT_HORIZONTAL_SCROLL_OPTIONS,
 ): HorizontalScrollState {
   if (!outer || !inner) {
     return { tx: 0, progress: 0 }
@@ -20,7 +31,14 @@ function getHorizontalScrollState(
   const rect = outer.getBoundingClientRect()
   const viewportWidth = window.innerWidth
   const viewportHeight = window.innerHeight
-  const scrollRange = Math.max(rect.height - viewportHeight, 0)
+  const defaultScrollRange = Math.max(rect.height - viewportHeight, 0)
+  const scrollRange = options.getScrollRangePx
+    ? Math.max(options.getScrollRangePx({
+      sectionTop: rect.top,
+      sectionHeight: rect.height,
+      viewportHeight,
+    }), 0)
+    : defaultScrollRange
   const progress = scrollRange === 0 ? 0 : clamp01(-rect.top / scrollRange)
   const trackWidth = Math.max(inner.scrollWidth - viewportWidth, 0)
   const tx = progress === 0 || trackWidth === 0 ? 0 : -(progress * trackWidth)
@@ -34,12 +52,13 @@ function getHorizontalScrollState(
 export function useHorizontalScroll(
   outerRef: RefObject<HTMLElement>,
   innerRef: RefObject<HTMLElement>,
+  options: HorizontalScrollOptions = DEFAULT_HORIZONTAL_SCROLL_OPTIONS,
 ): HorizontalScrollState {
   const [state, setState] = useState<HorizontalScrollState>({ tx: 0, progress: 0 })
 
   useEffect(() => {
     const update = () => {
-      setState(getHorizontalScrollState(outerRef.current, innerRef.current))
+      setState(getHorizontalScrollState(outerRef.current, innerRef.current, options))
     }
 
     update()
@@ -51,7 +70,7 @@ export function useHorizontalScroll(
       window.removeEventListener('scroll', update)
       window.removeEventListener('resize', update)
     }
-  }, [outerRef, innerRef])
+  }, [outerRef, innerRef, options])
 
   return state
 }


### PR DESCRIPTION
## Purpose
Fix Projects horizontal track progress so vertical section scroll maps directly from the first centered card to the last centered card.

## What it does
Computes Projects progress from the project-count scroll runway and viewport height, then translates the track by the actual horizontal overflow between track width and viewport width.

## Changes made
- Added Projects geometry helpers for runway progress, overflow-based translation, and combined track state.
- Wired ProjectsSection to pass its project runway into the shared horizontal scroll hook.
- Added regression coverage for start, middle, end, resize, no-overflow, and rendered Projects integration behavior.

## Additional notes
Issue #236 listed #234 as blocked; #234 is already merged on main. Validation passed with `npm run typecheck` and `npm run test`.

Closes #236

Made with [Cursor](https://cursor.com)