### PR TITLE
Align Timeline typewriter with HTML reference

### DIFF
--- a/src/animations/useTypewriter.ts
+++ b/src/animations/useTypewriter.ts
@@ -1,11 +1,18 @@
 import { useState, useEffect, useRef } from 'react'
 
+interface UseTypewriterOptions {
+  mode?: 'character' | 'line'
+  restartOnActivate?: boolean
+}
+
 export function useTypewriter(
   active: boolean,
   lines: string[],
   speed = 25,
-  onDone?: () => void
+  onDone?: () => void,
+  options: UseTypewriterOptions = {},
 ) {
+  const { mode = 'character', restartOnActivate = false } = options
   const [displayedLines, setDisplayedLines] = useState<string[]>([])
   const stateRef = useRef({ lineIndex: 0, charIndex: 0, done: false })
   const timerRef = useRef<number | null>(null)
@@ -13,6 +20,7 @@ export function useTypewriter(
   const linesRef = useRef(lines)
   const linesKey = JSON.stringify(lines)
   const prevLinesKeyRef = useRef(linesKey)
+  const prevActiveRef = useRef(active)
 
   linesRef.current = lines
 
@@ -22,9 +30,14 @@ export function useTypewriter(
 
   useEffect(() => {
     const linesChanged = linesKey !== prevLinesKeyRef.current
+    const activated = active && !prevActiveRef.current
+    prevActiveRef.current = active
 
     if (linesChanged) {
       prevLinesKeyRef.current = linesKey
+      stateRef.current = { lineIndex: 0, charIndex: 0, done: false }
+      setDisplayedLines([])
+    } else if (activated && restartOnActivate) {
       stateRef.current = { lineIndex: 0, charIndex: 0, done: false }
       setDisplayedLines([])
     }
@@ -60,6 +73,25 @@ export function useTypewriter(
       }
 
       const currentLine = lines[lineIndex]
+
+      if (mode === 'line') {
+        setDisplayedLines(prev => {
+          const newLines = [...prev]
+          newLines[lineIndex] = currentLine
+          return newLines
+        })
+
+        stateRef.current.lineIndex = lineIndex + 1
+        stateRef.current.charIndex = 0
+
+        if (stateRef.current.lineIndex < linesRef.current.length) {
+          timerRef.current = window.setTimeout(typeNextChar, speed)
+        } else {
+          stateRef.current.done = true
+          onDoneRef.current?.()
+        }
+        return
+      }
 
       if (charIndex < currentLine.length) {
         setDisplayedLines(prev => {
@@ -97,7 +129,7 @@ export function useTypewriter(
         timerRef.current = null
       }
     }
-  }, [active, linesKey, speed])
+  }, [active, linesKey, mode, restartOnActivate, speed])
 
   useEffect(() => {
     return () => {

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -225,7 +225,7 @@ describe('TimelineSection', () => {
       expect(heldText).toBe(partialText)
     })
 
-    it('Typewriter resumes from held position when panel becomes active again', () => {
+    it('Typewriter restarts from the first line when panel becomes active again', () => {
       vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
@@ -245,11 +245,12 @@ describe('TimelineSection', () => {
       vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       rerender(<TimelineSection />)
       act(() => {
-        vi.advanceTimersByTime(500)
+        vi.advanceTimersByTime(100)
       })
 
-      const resumedText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
-      expect(resumedText.length).toBeGreaterThan(partialText.length)
+      const restartedText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
+      expect(restartedText).toBe(partialText)
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')).toBeNull()
     })
 
     it('issue #98 - longest bullet completes within 2.5s', () => {
@@ -300,7 +301,7 @@ describe('TimelineSection', () => {
       expect(panel2Lines.length).toBeGreaterThan(0)
     })
 
-    it('reactivate does not blank partial text before resuming', () => {
+    it('deactivation keeps partial text visible before a later restart', () => {
       vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       vi.useFakeTimers()
 
@@ -316,11 +317,22 @@ describe('TimelineSection', () => {
       vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, false]))
       rerender(<TimelineSection />)
 
+      act(() => {
+        vi.advanceTimersByTime(1000)
+      })
+
+      const inactiveText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
+      expect(inactiveText).toBe(partialText)
+
       vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       rerender(<TimelineSection />)
 
-      const immediateText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
-      expect(immediateText).toBe(partialText)
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const restartedText = document.querySelector('[data-typewriter-line]')?.textContent ?? ''
+      expect(restartedText).toBe(partialText)
     })
 
     it('each panel retains independent partial progress when switching panels', () => {
@@ -355,12 +367,16 @@ describe('TimelineSection', () => {
       vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
       rerender(<TimelineSection />)
 
-      const panel1Immediate =
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      const panel1Restarted =
         getTimelinePanel(0).querySelector('[data-typewriter-line]')?.textContent ?? ''
       const panel2Held =
         getTimelinePanel(1).querySelector('[data-typewriter-line]')?.textContent ?? ''
 
-      expect(panel1Immediate).toBe(panel1Partial)
+      expect(panel1Restarted).toBe(panel1Partial)
       expect(panel2Held).toBe(panel2Partial)
     })
 
@@ -794,6 +810,58 @@ describe('TimelineSection', () => {
     )
   })
 
+  describe('issue #238 - HTML-reference typewriter pacing', () => {
+    it('preserves inactive text but restarts from the first line when reactivated', () => {
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
+      vi.useFakeTimers()
+
+      const { rerender } = render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')).toHaveTextContent(
+        'commit d4e8f2c',
+      )
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')).toHaveTextContent(
+        'NETAPP INC.',
+      )
+
+      vi.mocked(useTimelineScroll).mockReturnValue(
+        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5, tx: -1000 }),
+      )
+      rerender(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(500)
+      })
+
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')).toHaveTextContent(
+        'commit d4e8f2c',
+      )
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')).toHaveTextContent(
+        'NETAPP INC.',
+      )
+
+      vi.mocked(useTimelineScroll).mockReturnValue(
+        mockTimelineScrollState([true, false, false], { activeIndex: 0, progress: 0, tx: -2000 }),
+      )
+      rerender(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')).toHaveTextContent(
+        'commit d4e8f2c',
+      )
+      expect(
+        getTimelinePanel(0).querySelector('[data-testid="commit-institution"]'),
+      ).not.toBeInTheDocument()
+    })
+  })
+
   describe('issue #235 - restore timeline sticky scroll shell', () => {
     it('outer timeline scroll host uses the shared hscroll shell class', () => {
       render(<TimelineSection />)
@@ -995,7 +1063,7 @@ describe('TimelineSection', () => {
       expect(middlePartial).toBe('')
     })
 
-    it('resumes typing on a panel when scroll reactivates it', () => {
+    it('restarts typing on a panel when scroll reactivates it', () => {
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -1032,7 +1100,8 @@ describe('TimelineSection', () => {
 
       const resumedHash =
         getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')?.textContent ?? ''
-      expect(resumedHash.length).toBeGreaterThan(partialHash.length)
+      expect(resumedHash).toBe(partialHash)
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')).toBeNull()
     })
   })
 })

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -59,7 +59,10 @@ function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean 
     [entry],
   )
 
-  const displayedLines = useTypewriter(active, lines, 16)
+  const displayedLines = useTypewriter(active, lines, 80, undefined, {
+    mode: 'line',
+    restartOnActivate: true,
+  })
 
   const institutionLine = displayedLines[METADATA_LINE_COUNT]
   const roleLine = displayedLines[METADATA_LINE_COUNT + 1]


### PR DESCRIPTION
## Purpose
Align the Timeline typewriter behavior with the Portfolio v4 reference so panel text prints quickly, remains visible while inactive, and replays when a panel is revisited.

## What it does
Adds opt-in line-paced typewriter playback with restart-on-activation behavior, then applies it to Timeline panels without changing the default character-by-character typewriter behavior elsewhere.

## Changes made
- Added `mode: 'line'` and `restartOnActivate` options to `useTypewriter`.
- Updated `TimelineSection` to use fast per-line playback and replay typing on panel reactivation.
- Updated Timeline regression tests for inactive text preservation, horizontal transition preservation, and restart-on-reactivation behavior.

## Additional notes
- `npm run typecheck` and `npm run test` pass.
- The referenced `ideas/DESIGN.md`, `ideas/Portfolio v4.html`, `ideas/timeline.png`, and `ideas/timeline 2.png` files were not present in the isolated worktree, so implementation used the checked-in Portfolio v4 PRD and existing Timeline tests as the available reference.

Closes #238

Made with [Cursor](https://cursor.com)