### PR TITLE
Preserve internal snap ownership

### DIFF
--- a/src/components/ProjectsSection.test.tsx
+++ b/src/components/ProjectsSection.test.tsx
@@ -394,10 +394,12 @@ describe('ProjectsSection', () => {
   it('renders one snap-anchor per project at expected vertical landing points', () => {
     render(<ProjectsSection projects={mockProjects} />)
 
+    const projectsSection = document.getElementById('projects')
     const anchors = document.querySelectorAll('.snap-anchor')
     expect(anchors).toHaveLength(mockProjects.length)
 
     anchors.forEach((anchor, index) => {
+      expect(anchor.parentElement).toBe(projectsSection)
       expect(anchor).toHaveStyle({ top: `${index * 100}vh` })
     })
   })

--- a/src/components/TimelineSection.test.tsx
+++ b/src/components/TimelineSection.test.tsx
@@ -692,6 +692,9 @@ describe('TimelineSection', () => {
       const anchors = timeline?.querySelectorAll('.snap-anchor')
 
       expect(anchors).toHaveLength(3)
+      anchors?.forEach((anchor) => {
+        expect(anchor.parentElement).toBe(timeline)
+      })
       expect(anchors?.[0]).toHaveStyle({ top: '0vh' })
       expect(anchors?.[1]).toHaveStyle({ top: '100vh' })
       expect(anchors?.[2]).toHaveStyle({ top: '200vh' })

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -124,6 +124,14 @@ describe('portfolio.css CSS anchor', () => {
     expect(portfolioCss).toContain('scroll-margin-top: 56px')
   })
 
+  it('scopes snap anchor ownership to internal sticky scroll hosts', () => {
+    const internalSnapAnchorRule = blockFor('[data-sticky-scroll-host="true"] > .snap-anchor')
+
+    expect(internalSnapAnchorRule).toContain('scroll-snap-align: start')
+    expect(internalSnapAnchorRule).toContain('scroll-snap-stop: always')
+    expect(portfolioCss).not.toMatch(/(^|\})\s*\.snap-anchor\s*\{[^}]*scroll-snap-align/)
+  })
+
   it('anchors navbar floating terminal bar chrome from the reference', () => {
     expect(portfolioCss).toMatch(/\.nav\{[^}]*position:fixed/)
     expect(portfolioCss).toMatch(/\.nav\{[^}]*z-index:100/)

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -12,7 +12,7 @@
     scroll-snap-align: start;
   }
 
-  .snap-anchor {
+  [data-sticky-scroll-host="true"] > .snap-anchor {
     position: absolute;
     left: 0;
     width: 100%;


### PR DESCRIPTION
## Purpose
Preserve proximity-based page scroll while Projects and Timeline retain ownership of their internal snap landing points.

## What it does
Scopes snap-anchor scroll snapping to direct children of internal sticky scroll hosts so Projects and Timeline card/panel anchors settle without making arbitrary `.snap-anchor` elements global snap stops.

## Changes made
- Updated `src/portfolio.css` to target `[data-sticky-scroll-host="true"] > .snap-anchor` for internal snap behavior.
- Added regression coverage in `src/portfolio-css.test.ts` that verifies snap-anchor ownership is scoped to internal sticky scroll hosts and not a bare global `.snap-anchor` rule.

## Additional notes
- Global `html` scroll snap remains `y proximity`, and explicit smooth navigation remains unchanged.
- `npm run typecheck` and `npm run test` pass.

Closes #239

Made with [Cursor](https://cursor.com)