### PR TITLE
Keep navbar highlight on owning section

### DIFF
--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -171,6 +171,32 @@ describe('Navbar', () => {
       expect(projectsLink!.querySelector('[data-testid="nav-caret"]')).toHaveTextContent('>')
       expect(projectsLabel).toHaveClass('nav-label')
     })
+
+    it('keeps PROJECTS active for its owning scroll runway when no internal panel owns the sample line', () => {
+      mockMajorSection('home', -VIEWPORT_HEIGHT, VIEWPORT_HEIGHT)
+      mockMajorSection('projects', -(VIEWPORT_HEIGHT * 6 + 24), VIEWPORT_HEIGHT * 6)
+      mockMajorSection('skills', VIEWPORT_HEIGHT * 0.4 + 120, VIEWPORT_HEIGHT)
+
+      render(<Navbar />)
+      dispatchScrollUpdate()
+
+      expect(screen.getByText('PROJECTS').closest('a')).toHaveClass('active')
+      expect(screen.getByText('SKILLS').closest('a')).not.toHaveClass('active')
+    })
+
+    it('keeps TIMELINE active for its owning scroll runway when no internal panel owns the sample line', () => {
+      mockMajorSection('home', -VIEWPORT_HEIGHT * 4, VIEWPORT_HEIGHT)
+      mockMajorSection('projects', -VIEWPORT_HEIGHT * 3, VIEWPORT_HEIGHT)
+      mockMajorSection('skills', -VIEWPORT_HEIGHT * 2, VIEWPORT_HEIGHT)
+      mockMajorSection('timeline', -(VIEWPORT_HEIGHT * 3 + 24), VIEWPORT_HEIGHT * 3)
+      mockMajorSection('contact', VIEWPORT_HEIGHT * 0.4 + 120, VIEWPORT_HEIGHT)
+
+      render(<Navbar />)
+      dispatchScrollUpdate()
+
+      expect(screen.getByText('TIMELINE').closest('a')).toHaveClass('active')
+      expect(screen.getByText('CONTACT').closest('a')).not.toHaveClass('active')
+    })
   })
 
   describe('issue #38 - logo size and container alignment', () => {

--- a/src/hooks/useActiveMajorSection.test.ts
+++ b/src/hooks/useActiveMajorSection.test.ts
@@ -83,6 +83,18 @@ describe('computeActiveMajorSection', () => {
     }
   })
 
+  it('keeps projects active when the probe is in the Projects-owned runway gap', () => {
+    const projectCount = 6
+    const projectsHeight = viewportHeight * projectCount
+    mockSection('home', -viewportHeight, viewportHeight)
+    mockSection('projects', -(projectsHeight + 24), projectsHeight)
+    mockSection('skills', probeY + 120, viewportHeight)
+
+    expect(
+      computeActiveMajorSection(MAJOR_SECTION_IDS, (id) => document.getElementById(id), viewportHeight),
+    ).toBe('projects')
+  })
+
   it('keeps timeline active across the full internal scroll range', () => {
     const entryCount = 3
     const timelineHeight = viewportHeight * entryCount
@@ -111,6 +123,20 @@ describe('computeActiveMajorSection', () => {
     }
   })
 
+  it('keeps timeline active when the probe is in the Timeline-owned runway gap', () => {
+    const entryCount = 3
+    const timelineHeight = viewportHeight * entryCount
+    mockSection('home', -viewportHeight * 4, viewportHeight)
+    mockSection('projects', -viewportHeight * 3, viewportHeight)
+    mockSection('skills', -viewportHeight * 2, viewportHeight)
+    mockSection('timeline', -(timelineHeight + 24), timelineHeight)
+    mockSection('contact', probeY + 120, viewportHeight)
+
+    expect(
+      computeActiveMajorSection(MAJOR_SECTION_IDS, (id) => document.getElementById(id), viewportHeight),
+    ).toBe('timeline')
+  })
+
   it('detects contact when the probe is inside the footer element', () => {
     mockSection('home', -4000, viewportHeight)
     mockSection('projects', -3000, viewportHeight * 6)
@@ -126,7 +152,7 @@ describe('computeActiveMajorSection', () => {
     ).toBe('contact')
   })
 
-  it('falls back to the first section when the probe is below all sections', () => {
+  it('keeps the nearest entered major section when the probe is below all sections', () => {
     mockSection('home', -1000, 200)
     mockSection('projects', -800, 400)
     mockSection('skills', -400, 400)
@@ -135,7 +161,7 @@ describe('computeActiveMajorSection', () => {
 
     expect(
       computeActiveMajorSection(MAJOR_SECTION_IDS, (id) => document.getElementById(id), viewportHeight),
-    ).toBe('home')
+    ).toBe('contact')
   })
 
   it('does not switch active section based on internal snap anchors or panels', () => {

--- a/src/hooks/useActiveMajorSection.ts
+++ b/src/hooks/useActiveMajorSection.ts
@@ -10,7 +10,8 @@ export function computeActiveMajorSection(
   viewportHeight: number,
 ): string {
   const probeY = viewportHeight * ACTIVE_SECTION_SAMPLE_RATIO
-  let current = sectionIds[0] ?? ''
+  let containingSection: string | null = null
+  let latestEnteredSection = sectionIds[0] ?? ''
 
   for (const id of sectionIds) {
     const element = getElement(id)
@@ -18,11 +19,15 @@ export function computeActiveMajorSection(
 
     const rect = element.getBoundingClientRect()
     if (rect.top <= probeY && rect.bottom > probeY) {
-      current = id
+      containingSection = id
+    }
+
+    if (rect.top <= probeY) {
+      latestEnteredSection = id
     }
   }
 
-  return current
+  return containingSection ?? latestEnteredSection
 }
 
 export function useActiveMajorSection(): string {


### PR DESCRIPTION
## Purpose
Keep the navbar highlight on the major section that owns the current scroll runway so internal Projects and Timeline scrolling does not prematurely switch nav state.

## What it does
Active-section detection still samples major section geometry first, then falls back to the latest major section whose top has crossed the sample line when the sample is between section rects.

## Changes made
- Updated `useActiveMajorSection` to retain the latest entered major section when no major section contains the sample point.
- Added hook regression coverage for Projects and Timeline runway gaps.
- Added Navbar regression coverage for rendered active nav state across Projects and Timeline owning scroll ranges.

## Additional notes
- No parent PRD was referenced by issue #240.
- `ideas/DESIGN.md`, `ideas/Portfolio v4.html`, and checked-in screenshots were absent from this worktree, so implementation used the existing checked-in source and tests.
- Verified with `npm run typecheck` and `npm run test`.

Closes #240

Made with [Cursor](https://cursor.com)