### PR TITLE
Introduce canonical section registry for nav and active section behavior

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -6,15 +6,10 @@ import {
   FADE_OUT_DURATION,
 } from './components/LoadingScreen.constants'
 import { FIRST_NAME, NAME_SPEED } from './components/HeroSection.constants'
+import { SECTIONS, type SectionId } from './data/sections'
 
-const sections = ['home', 'projects', 'skills', 'timeline', 'contact'] as const
-const sectionIds = [
-  'home',
-  'projects',
-  'skills',
-  'timeline',
-  'contact',
-] as const
+const sectionIds = SECTIONS.map((section) => section.id)
+const sections = sectionIds satisfies readonly SectionId[]
 const shellConstraintClasses = ['container', 'max-w-7xl', 'mx-auto'] as const
 
 function expectNoShellConstraint(element: Element) {
@@ -245,7 +240,7 @@ describe('App shell', () => {
   })
 
   describe('issue #214 - global scroll shell regression', () => {
-    const majorSectionIds = ['home', 'projects', 'skills', 'timeline', 'contact'] as const
+    const majorSectionIds = sectionIds
 
     it('does not mount a global sticky section stack', () => {
       render(<App />)

--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, within, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { SECTIONS } from '../data/sections'
 import Navbar from './Navbar'
+
+const expectedNavHrefs = SECTIONS.map((section) => `#${section.id}`)
+const expectedNavLabels = SECTIONS.map((section) => section.navLabel)
 
 const VIEWPORT_HEIGHT = 800
 
@@ -52,21 +56,19 @@ describe('Navbar', () => {
     expect(logo.closest('a')).toHaveAttribute('href', '#')
   })
 
-  it('renders all five nav links in the desktop nav', () => {
+  it('renders all registry nav links in the desktop nav', () => {
     render(<Navbar />)
     const nav = screen.getByRole('navigation')
     const links = within(nav).getAllByRole('link')
     const hrefs = links.map((l) => l.getAttribute('href'))
-    expect(hrefs).toContain('#home')
-    expect(hrefs).toContain('#projects')
-    expect(hrefs).toContain('#skills')
-    expect(hrefs).toContain('#timeline')
-    expect(hrefs).toContain('#contact')
+    for (const href of expectedNavHrefs) {
+      expect(hrefs).toContain(href)
+    }
   })
 
-  it('shows label text for all five nav links', () => {
+  it('shows label text for all registry nav links', () => {
     render(<Navbar />)
-    for (const label of ['HOME', 'PROJECTS', 'SKILLS', 'TIMELINE', 'CONTACT']) {
+    for (const label of expectedNavLabels) {
       expect(screen.getByText(label)).toBeInTheDocument()
     }
   })

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,17 +1,15 @@
 import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { hoverEase } from '../animations/variants'
+import { SECTIONS } from '../data/sections'
 import { useActiveMajorSection } from '../hooks/useActiveMajorSection'
 import { handleSectionLinkClick, smoothScrollToSection } from '../utils/smoothScrollTo'
 import MobileMenu from './MobileMenu'
 
-const NAV_LINKS = [
-  { label: 'HOME', href: '#home' },
-  { label: 'PROJECTS', href: '#projects' },
-  { label: 'SKILLS', href: '#skills' },
-  { label: 'TIMELINE', href: '#timeline' },
-  { label: 'CONTACT', href: '#contact' },
-]
+const NAV_LINKS = SECTIONS.map(({ id, navLabel }) => ({
+  label: navLabel,
+  href: `#${id}`,
+}))
 
 export default function Navbar() {
   const activeSection = useActiveMajorSection()

--- a/src/data/sections.test.ts
+++ b/src/data/sections.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { SECTIONS } from './sections'
+import { MAJOR_SECTION_IDS } from '../hooks/useActiveMajorSection'
+
+describe('sections registry', () => {
+  it('keeps MAJOR_SECTION_IDS derived from SECTIONS', () => {
+    expect(MAJOR_SECTION_IDS).toEqual(SECTIONS.map((section) => section.id))
+  })
+
+  it('defines unique section ids in scroll order', () => {
+    const ids = SECTIONS.map((section) => section.id)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(ids.length).toBeGreaterThan(0)
+  })
+
+  it('defines nav labels and hash hrefs for every section', () => {
+    for (const { id, navLabel } of SECTIONS) {
+      expect(navLabel.length).toBeGreaterThan(0)
+      expect(`#${id}`).toMatch(/^#[a-z]+$/)
+    }
+  })
+})

--- a/src/data/sections.ts
+++ b/src/data/sections.ts
@@ -1,0 +1,11 @@
+export const SECTIONS = [
+  { id: 'home', navLabel: 'HOME' },
+  { id: 'projects', navLabel: 'PROJECTS' },
+  { id: 'skills', navLabel: 'SKILLS' },
+  { id: 'timeline', navLabel: 'TIMELINE' },
+  { id: 'contact', navLabel: 'CONTACT' },
+] as const
+
+export type SectionId = (typeof SECTIONS)[number]['id']
+
+export type Section = (typeof SECTIONS)[number]

--- a/src/hooks/useActiveMajorSection.ts
+++ b/src/hooks/useActiveMajorSection.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
+import { SECTIONS, type SectionId } from '../data/sections'
 
-export const MAJOR_SECTION_IDS = ['home', 'projects', 'skills', 'timeline', 'contact'] as const
+export const MAJOR_SECTION_IDS: readonly SectionId[] = SECTIONS.map((section) => section.id)
 
 export const ACTIVE_SECTION_SAMPLE_RATIO = 0.4
 

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -116,7 +116,7 @@ describe('portfolio.css CSS anchor', () => {
   })
 
   it('anchors scroll snap targets and snap anchors', () => {
-    expect(portfolioCss).toContain('#hero')
+    expect(portfolioCss).toContain('#home')
     expect(portfolioCss).toContain('#skills')
     expect(portfolioCss).toContain('#contact')
     expect(portfolioCss).toContain('scroll-snap-align: start')
@@ -176,7 +176,7 @@ describe('portfolio.css CSS anchor', () => {
   })
 
   it('avoids scrollbar-induced document overflow from full-width surfaces', () => {
-    expect(blockFor('#hero{')).toContain('width:100%')
+    expect(blockFor('#home{')).toContain('width:100%')
     expect(blockFor('.hscroll')).toContain('width:100%')
     expect(blockFor('#skills{')).toContain('width:100%')
     expect(blockFor('footer')).toContain('width:100%')

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -6,7 +6,7 @@
     --ease: cubic-bezier(0.4, 0, 0.2, 1);
   }
 
-  #hero,
+  #home,
   #skills,
   #contact {
     scroll-snap-align: start;
@@ -46,7 +46,7 @@
   .nav-link.active .nav-label{color:var(--color-atomic-tangerine)}
 
   /* ─── HERO ──── */
-  #hero{width:100%;min-height:100vh;display:flex;flex-direction:column;justify-content:center;padding:0 5vw;position:relative;overflow:hidden}
+  #home{width:100%;min-height:100vh;display:flex;flex-direction:column;justify-content:center;padding:0 5vw;position:relative;overflow:hidden}
   .hero-grid{position:absolute;inset:0;background-image:linear-gradient(var(--color-graphite-light) 1px,transparent 1px),linear-gradient(90deg,var(--color-graphite-light) 1px,transparent 1px);background-size:80px 80px;opacity:.35;mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%);-webkit-mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%)}
   .hero-inner{position:relative;z-index:1;width:100%;padding:0 5vw}
   .hero-init{font-size:11px;color:var(--color-atomic-tangerine);letter-spacing:4px;margin-bottom:18px}


### PR DESCRIPTION
## Purpose

Provide a single source of truth for major portfolio section ids and nav labels so navbar links, active-section tracking, and tests stay in sync.

## What it does

Adds `src/data/sections.ts` with `SECTIONS` and `SectionId`, derives `MAJOR_SECTION_IDS` and `NAV_LINKS` from that registry, and fixes the `#hero` / `#home` CSS selector mismatch so scroll snap and hero layout apply to the actual home section element.

## Changes made

- Add `src/data/sections.ts` with canonical `SECTIONS` array and `SectionId` type
- Derive `MAJOR_SECTION_IDS` from `SECTIONS` in `useActiveMajorSection.ts`
- Derive `NAV_LINKS` from `SECTIONS` in `Navbar.tsx`
- Rename `#hero` selectors to `#home` in `portfolio.css` and update `portfolio-css.test.ts`
- Replace hard-coded section id lists in `App.test.tsx` with imports from `SECTIONS`

## Additional notes

Nav label text and section order remain unchanged. `npm run typecheck` and `npm run test` pass (441 tests).

Closes #255

Made with [Cursor](https://cursor.com)