### PR TITLE
Move timeline domain model to data layer and wire UI to it

### DIFF
--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useRef } from 'react'
 import { useTypewriter } from '../animations/useTypewriter'
+import type { TimelineEntry } from '../data/timeline'
+import { timelineEntries } from '../data/timeline'
 import { useTimelineScroll } from '../hooks/useTimelineScroll'
 import { getTimelineScrollRangeVh, getTimelineSnapAnchorTopVh } from './timelineGeometry'
 
@@ -8,41 +10,6 @@ const TIMELINE_SECTION_NO = '// 03'
 function formatPanelCount(index: number, total: number): string {
   return `${String(index + 1).padStart(2, '0')} / ${String(total).padStart(2, '0')}`
 }
-
-const timelineEntries: TimelineEntry[] = [
-  {
-    hash: 'd4e8f2c',
-    dateRange: 'AUG 2024 – PRESENT',
-    institution: 'NETAPP INC.',
-    role: 'SOFTWARE_ENGINEER_IN_TEST',
-    bullets: [
-      'Built automated analysis pipeline processing storage telemetry across distributed RAID systems (FC, SAS, NVMe/RoCE), handling terabytes of performance data.',
-      'Designed Python automation framework reducing manual configuration tasks by 30% across Linux, Windows, and VMware infrastructure.',
-      'Implemented Ansible-based deployment orchestration for 300+ system configurations, streamlining infrastructure provisioning workflows.',
-      'Developed interactive visualization dashboard for system performance metrics using Python, analyzing 1M+ database entries for engineering insights.',
-    ],
-    category: 'experience',
-  },
-  {
-    hash: 'a3f9d2b',
-    dateRange: 'JAN 2026 – DEC 2027 (EXPECTED)',
-    institution: 'WICHITA STATE UNIVERSITY',
-    role: 'ACCELERATED_M.S._COMPUTER_SCIENCE',
-    bullets: [],
-    category: 'education',
-  },
-  {
-    hash: 'b7c3e1a',
-    dateRange: 'JAN 2022 – DEC 2025',
-    institution: 'WICHITA STATE UNIVERSITY',
-    role: 'B.S._COMPUTER_SCIENCE',
-    bullets: [
-      "Dean's List: Spring 2022 – Fall 2025",
-      'Relevant Coursework: Machine Learning, Artificial Intelligence, Fundamentals of AI Agents, Data Science',
-    ],
-    category: 'education',
-  },
-]
 
 const METADATA_LINE_COUNT = 3
 
@@ -226,14 +193,3 @@ const TimelineSection: React.FC = () => {
 }
 
 export default TimelineSection
-
-export interface TimelineEntry {
-  hash: string
-  dateRange: string
-  institution: string
-  role: string
-  bullets: string[]
-  category: 'experience' | 'education'
-}
-
-export { timelineEntries }

--- a/src/data/resume-audit.test.ts
+++ b/src/data/resume-audit.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { projects } from './projects'
 import { FIRST_NAME, LAST_NAME } from '../components/HeroSection.constants'
-import { timelineEntries } from '../components/TimelineSection'
+import { timelineEntries } from './timeline'
 
 // Resume source-of-truth constants (from public/resume.pdf)
 const RESUME_FULL_NAME = 'Farhan Mohammed'

--- a/src/data/timeline.ts
+++ b/src/data/timeline.ts
@@ -1,0 +1,43 @@
+export interface TimelineEntry {
+  hash: string
+  dateRange: string
+  institution: string
+  role: string
+  bullets: string[]
+  category: 'experience' | 'education'
+}
+
+export const timelineEntries: TimelineEntry[] = [
+  {
+    hash: 'd4e8f2c',
+    dateRange: 'AUG 2024 – PRESENT',
+    institution: 'NETAPP INC.',
+    role: 'SOFTWARE_ENGINEER_IN_TEST',
+    bullets: [
+      'Built automated analysis pipeline processing storage telemetry across distributed RAID systems (FC, SAS, NVMe/RoCE), handling terabytes of performance data.',
+      'Designed Python automation framework reducing manual configuration tasks by 30% across Linux, Windows, and VMware infrastructure.',
+      'Implemented Ansible-based deployment orchestration for 300+ system configurations, streamlining infrastructure provisioning workflows.',
+      'Developed interactive visualization dashboard for system performance metrics using Python, analyzing 1M+ database entries for engineering insights.',
+    ],
+    category: 'experience',
+  },
+  {
+    hash: 'a3f9d2b',
+    dateRange: 'JAN 2026 – DEC 2027 (EXPECTED)',
+    institution: 'WICHITA STATE UNIVERSITY',
+    role: 'ACCELERATED_M.S._COMPUTER_SCIENCE',
+    bullets: [],
+    category: 'education',
+  },
+  {
+    hash: 'b7c3e1a',
+    dateRange: 'JAN 2022 – DEC 2025',
+    institution: 'WICHITA STATE UNIVERSITY',
+    role: 'B.S._COMPUTER_SCIENCE',
+    bullets: [
+      "Dean's List: Spring 2022 – Fall 2025",
+      'Relevant Coursework: Machine Learning, Artificial Intelligence, Fundamentals of AI Agents, Data Science',
+    ],
+    category: 'education',
+  },
+]


### PR DESCRIPTION
## Purpose

Separate canonical timeline resume data from the TimelineSection UI component so data changes and presentation changes can evolve independently.

## What it does

Moves `TimelineEntry` and `timelineEntries` into `src/data/timeline.ts`, updates `TimelineSection` to consume the data layer, and redirects `resume-audit.test.ts` to import from the new module. This satisfies the architecture boundary test from #252.

## Changes made

- Added `src/data/timeline.ts` exporting `TimelineEntry` and `timelineEntries`
- Updated `src/components/TimelineSection.tsx` to import from `../data/timeline` and removed re-exports
- Updated `src/data/resume-audit.test.ts` import path from `../components/TimelineSection` to `./timeline`

## Additional notes

- Branch is based on `gpt-5-5/issue-252-establish-architecture-boundaries-for-data-vs-ui` because `architecture.test.ts` lives there and #253 is blocked by #252; merge #252 first or rebase once it lands on main.
- `METADATA_LINE_COUNT` remains in the component as a render/typewriter concern, not domain data.
- All 445 tests pass (`npm run typecheck`, `npm run test`).

Closes #253

Made with [Cursor](https://cursor.com)