### PR TITLE
Extract shared scroll frame primitive and migrate one production flow

### DIFF
--- a/src/components/projectsGeometry.ts
+++ b/src/components/projectsGeometry.ts
@@ -1,3 +1,5 @@
+import { clamp01 } from '../utils/math'
+
 /**
  * Layout token contract — CSS values that MUST stay in sync with these constants:
  *
@@ -45,10 +47,6 @@ export function getCarouselTrackWidth(
 /** Returns the Projects section height multiplier in viewport-height units (one viewport per project). */
 export function getScrollRangeVh(projectCount: number) {
   return Math.max(projectCount, 1)
-}
-
-function clamp01(value: number) {
-  return Math.min(Math.max(value, 0), 1)
 }
 
 /** Returns the vertical Projects scroll runway in pixels. */

--- a/src/components/timelineGeometry.ts
+++ b/src/components/timelineGeometry.ts
@@ -1,4 +1,4 @@
-import { clamp01 } from '../hooks/useHorizontalScroll'
+import { clamp01 } from '../utils/math'
 
 /** Returns the Timeline section height multiplier in viewport-height units. */
 export function getTimelineScrollRangeVh(entryCount: number) {

--- a/src/hooks/useHorizontalScroll.test.tsx
+++ b/src/hooks/useHorizontalScroll.test.tsx
@@ -2,7 +2,7 @@ import { renderHook, act } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { useRef } from 'react'
 import { getEdgeSpacerWidth, PROJECT_CARD_GAP } from '../components/projectsGeometry'
-import { useHorizontalScroll, clamp01 } from './useHorizontalScroll'
+import { useHorizontalScroll } from './useHorizontalScroll'
 
 function setViewport(width: number, height: number) {
   Object.defineProperty(window, 'innerWidth', {
@@ -227,23 +227,5 @@ describe('useHorizontalScroll', () => {
 
     expect(result.current.progress).toBe(1)
     expect(cardCenterX(result.current.tx, 1, cardWidth, cardGap, edgeWidth)).toBe(1000 / 2)
-  })
-})
-
-describe('clamp01', () => {
-  it('returns 0 for negative values', () => {
-    expect(clamp01(-0.5)).toBe(0)
-    expect(clamp01(-10)).toBe(0)
-  })
-
-  it('returns 1 for values above 1', () => {
-    expect(clamp01(1.5)).toBe(1)
-    expect(clamp01(10)).toBe(1)
-  })
-
-  it('passes through values between 0 and 1', () => {
-    expect(clamp01(0)).toBe(0)
-    expect(clamp01(0.5)).toBe(0.5)
-    expect(clamp01(1)).toBe(1)
   })
 })

--- a/src/hooks/useHorizontalScroll.ts
+++ b/src/hooks/useHorizontalScroll.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState, type RefObject } from 'react'
+import { useMemo, type RefObject } from 'react'
+import { useScrollProgress } from './useScrollProgress'
 
 interface HorizontalScrollState {
   tx: number
@@ -15,38 +16,17 @@ interface HorizontalScrollOptions {
 
 const DEFAULT_HORIZONTAL_SCROLL_OPTIONS: HorizontalScrollOptions = {}
 
-export function clamp01(value: number) {
-  return Math.min(Math.max(value, 0), 1)
-}
-
-function getHorizontalScrollState(
-  outer: HTMLElement | null,
+function getHorizontalTranslate(
   inner: HTMLElement | null,
-  options: HorizontalScrollOptions = DEFAULT_HORIZONTAL_SCROLL_OPTIONS,
-): HorizontalScrollState {
-  if (!outer || !inner) {
-    return { tx: 0, progress: 0 }
+  progress: number,
+  viewportWidth: number,
+): number {
+  if (!inner) {
+    return 0
   }
 
-  const rect = outer.getBoundingClientRect()
-  const viewportWidth = window.innerWidth
-  const viewportHeight = window.innerHeight
-  const defaultScrollRange = Math.max(rect.height - viewportHeight, 0)
-  const scrollRange = options.getScrollRangePx
-    ? Math.max(options.getScrollRangePx({
-      sectionTop: rect.top,
-      sectionHeight: rect.height,
-      viewportHeight,
-    }), 0)
-    : defaultScrollRange
-  const progress = scrollRange === 0 ? 0 : clamp01(-rect.top / scrollRange)
   const trackWidth = Math.max(inner.scrollWidth - viewportWidth, 0)
-  const tx = progress === 0 || trackWidth === 0 ? 0 : -(progress * trackWidth)
-
-  return {
-    progress,
-    tx,
-  }
+  return progress === 0 || trackWidth === 0 ? 0 : -(progress * trackWidth)
 }
 
 export function useHorizontalScroll(
@@ -54,23 +34,12 @@ export function useHorizontalScroll(
   innerRef: RefObject<HTMLElement>,
   options: HorizontalScrollOptions = DEFAULT_HORIZONTAL_SCROLL_OPTIONS,
 ): HorizontalScrollState {
-  const [state, setState] = useState<HorizontalScrollState>({ tx: 0, progress: 0 })
+  const { progress, viewportWidth } = useScrollProgress(outerRef, options)
 
-  useEffect(() => {
-    const update = () => {
-      setState(getHorizontalScrollState(outerRef.current, innerRef.current, options))
-    }
+  const tx = useMemo(
+    () => getHorizontalTranslate(innerRef.current, progress, viewportWidth),
+    [innerRef, progress, viewportWidth],
+  )
 
-    update()
-
-    window.addEventListener('scroll', update, { passive: true })
-    window.addEventListener('resize', update)
-
-    return () => {
-      window.removeEventListener('scroll', update)
-      window.removeEventListener('resize', update)
-    }
-  }, [outerRef, innerRef, options])
-
-  return state
+  return { progress, tx }
 }

--- a/src/hooks/useScrollProgress.test.tsx
+++ b/src/hooks/useScrollProgress.test.tsx
@@ -1,0 +1,127 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useRef } from 'react'
+import { useScrollProgress } from './useScrollProgress'
+
+function setViewport(width: number, height: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value: height,
+  })
+}
+
+function createRect(top: number, height: number): DOMRect {
+  return {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: window.innerWidth,
+    width: window.innerWidth,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
+function renderScrollProgressHook({
+  outerTop,
+  outerHeight,
+  getScrollRangePx,
+}: {
+  outerTop: number | (() => number)
+  outerHeight: number
+  getScrollRangePx?: (geometry: {
+    sectionTop: number
+    sectionHeight: number
+    viewportHeight: number
+  }) => number
+}) {
+  const outer = document.createElement('section')
+  const getOuterTop = typeof outerTop === 'function' ? outerTop : () => outerTop
+
+  outer.getBoundingClientRect = vi.fn(() => createRect(getOuterTop(), outerHeight))
+
+  return renderHook(() => {
+    const outerRef = useRef<HTMLElement>(outer)
+    return useScrollProgress(outerRef, getScrollRangePx ? { getScrollRangePx } : undefined)
+  })
+}
+
+describe('useScrollProgress', () => {
+  it('returns 0 progress at section entry', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderScrollProgressHook({
+      outerTop: 0,
+      outerHeight: 1600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current.progress).toBe(0)
+  })
+
+  it('returns 0.5 progress midway through the section', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderScrollProgressHook({
+      outerTop: -400,
+      outerHeight: 1600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current.progress).toBe(0.5)
+  })
+
+  it('returns 1 progress after the section scrolls fully past', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderScrollProgressHook({
+      outerTop: -800,
+      outerHeight: 1600,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current.progress).toBe(1)
+  })
+
+  it('removes scroll and resize listeners on unmount', () => {
+    setViewport(1000, 800)
+    const removeScrollSpy = vi.spyOn(window, 'removeEventListener')
+
+    const { unmount } = renderScrollProgressHook({
+      outerTop: 0,
+      outerHeight: 1600,
+    })
+
+    unmount()
+
+    expect(removeScrollSpy).toHaveBeenCalledWith('scroll', expect.any(Function))
+    expect(removeScrollSpy).toHaveBeenCalledWith('resize', expect.any(Function))
+
+    removeScrollSpy.mockRestore()
+  })
+
+  it('uses a custom scroll range callback when provided', () => {
+    setViewport(1000, 800)
+
+    const { result } = renderScrollProgressHook({
+      outerTop: -400,
+      outerHeight: 1600,
+      getScrollRangePx: () => 800,
+    })
+
+    act(() => window.dispatchEvent(new Event('scroll')))
+
+    expect(result.current.progress).toBe(0.5)
+  })
+})

--- a/src/hooks/useScrollProgress.ts
+++ b/src/hooks/useScrollProgress.ts
@@ -1,0 +1,75 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+import { clamp01 } from '../utils/math'
+
+export interface ScrollProgressGeometry {
+  sectionTop: number
+  sectionHeight: number
+  viewportHeight: number
+}
+
+export interface ScrollProgressOptions {
+  getScrollRangePx?: (geometry: ScrollProgressGeometry) => number
+}
+
+const DEFAULT_SCROLL_PROGRESS_OPTIONS: ScrollProgressOptions = {}
+
+export interface ScrollProgressState {
+  progress: number
+  viewportWidth: number
+  viewportHeight: number
+}
+
+export function computeScrollProgress(
+  outer: HTMLElement | null,
+  options: ScrollProgressOptions = DEFAULT_SCROLL_PROGRESS_OPTIONS,
+): ScrollProgressState {
+  const viewportWidth = window.innerWidth
+  const viewportHeight = window.innerHeight
+
+  if (!outer) {
+    return { progress: 0, viewportWidth, viewportHeight }
+  }
+
+  const rect = outer.getBoundingClientRect()
+  const defaultScrollRange = Math.max(rect.height - viewportHeight, 0)
+  const scrollRange = options.getScrollRangePx
+    ? Math.max(options.getScrollRangePx({
+      sectionTop: rect.top,
+      sectionHeight: rect.height,
+      viewportHeight,
+    }), 0)
+    : defaultScrollRange
+  const progress = scrollRange === 0 ? 0 : clamp01(-rect.top / scrollRange)
+
+  return { progress, viewportWidth, viewportHeight }
+}
+
+export function useScrollProgress(
+  outerRef: RefObject<HTMLElement | null>,
+  options: ScrollProgressOptions = DEFAULT_SCROLL_PROGRESS_OPTIONS,
+): ScrollProgressState {
+  const optionsRef = useRef(options)
+  optionsRef.current = options
+
+  const [state, setState] = useState<ScrollProgressState>(() =>
+    computeScrollProgress(outerRef.current, optionsRef.current),
+  )
+
+  useEffect(() => {
+    const update = () => {
+      setState(computeScrollProgress(outerRef.current, optionsRef.current))
+    }
+
+    update()
+
+    window.addEventListener('scroll', update, { passive: true })
+    window.addEventListener('resize', update)
+
+    return () => {
+      window.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+    }
+  }, [outerRef])
+
+  return state
+}

--- a/src/utils/math.test.ts
+++ b/src/utils/math.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { clamp01 } from './math'
+
+describe('clamp01', () => {
+  it('returns 0 for negative values', () => {
+    expect(clamp01(-0.5)).toBe(0)
+    expect(clamp01(-10)).toBe(0)
+  })
+
+  it('returns 1 for values above 1', () => {
+    expect(clamp01(1.5)).toBe(1)
+    expect(clamp01(10)).toBe(1)
+  })
+
+  it('passes through values between 0 and 1', () => {
+    expect(clamp01(0)).toBe(0)
+    expect(clamp01(0.5)).toBe(0.5)
+    expect(clamp01(1)).toBe(1)
+  })
+})

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -1,0 +1,3 @@
+export function clamp01(value: number) {
+  return Math.min(Math.max(value, 0), 1)
+}


### PR DESCRIPTION
## Purpose

Eliminate duplicated scroll listener, resize handling, and progress normalization logic between horizontal scroll hooks by extracting a shared primitive and proving it on the projects carousel flow.

## What it does

Introduces `useScrollProgress` as the shared scroll-frame primitive (window scroll/resize listeners, progress normalization via optional `getScrollRangePx`) and refactors `useHorizontalScroll` to compose it while keeping the public `{ tx, progress }` API unchanged. Moves `clamp01` into `src/utils/math.ts` so geometry modules no longer import from hooks.

## Changes made

- Added `src/utils/math.ts` with shared `clamp01` (+ unit tests)
- Added `src/hooks/useScrollProgress.ts` with scroll/resize lifecycle and progress sampling (+ unit tests for 0, 0.5, 1.0, and unmount cleanup)
- Refactored `src/hooks/useHorizontalScroll.ts` to delegate progress to `useScrollProgress` and derive `tx` from viewport width
- Updated `timelineGeometry.ts` and `projectsGeometry.ts` to import `clamp01` from `src/utils/math`
- Moved `clamp01` tests out of `useHorizontalScroll.test.tsx` into `math.test.ts`

## Additional notes

- `useScrollProgress` stores options in a ref so callers are not forced to memoize option objects (avoids listener re-subscription loops).
- `useTimelineScroll` migration is intentionally deferred to #257.
- Full suite: 465/467 tests pass; 2 pre-existing `architecture.test.ts` failures (#252) unrelated to this change.

Closes #256

Made with [Cursor](https://cursor.com)