### PR TITLE
Rework resume audit checks to validate domain facts not presentation format

### DIFF
--- a/src/data/resume-audit.test.ts
+++ b/src/data/resume-audit.test.ts
@@ -1,24 +1,62 @@
 import { describe, expect, it } from 'vitest'
 import { projects } from './projects'
+import { timelineEntries, type TimelineEntry } from './timeline'
 import { FIRST_NAME, LAST_NAME } from '../components/HeroSection.constants'
-import { timelineEntries } from './timeline'
 
 // Resume source-of-truth constants (from public/resume.pdf)
 const RESUME_FULL_NAME = 'Farhan Mohammed'
 const RESUME_EMAIL = 'famohammed@shockers.wichita.edu'
 
+const RESUME_TIMELINE = {
+  netapp: {
+    institution: 'NetApp Inc.',
+    role: 'Software Engineer in Test',
+    dateRange: 'Aug 2024 – Present',
+    category: 'experience' as const,
+  },
+  ms: {
+    institution: 'Wichita State University',
+    role: 'Accelerated M.S. Computer Science',
+    dateRange: 'Jan 2026 – Dec 2027 (Expected)',
+    category: 'education' as const,
+  },
+  bs: {
+    institution: 'Wichita State University',
+    role: 'B.S. Computer Science',
+    dateRange: 'Jan 2022 – Dec 2025',
+    category: 'education' as const,
+  },
+}
+
+/** Normalizes labels for factual comparison across resume PDF and site data. */
+function normalizeResumeText(value: string): string {
+  return value
+    .replace(/_/g, ' ')
+    .replace(/\./g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase()
+}
+
+function findEntry(predicate: (entry: TimelineEntry) => boolean): TimelineEntry {
+  const entry = timelineEntries.find(predicate)
+  if (!entry) {
+    throw new Error('Expected timeline entry not found')
+  }
+  return entry
+}
+
 describe('resume source-of-truth audit', () => {
   describe('name', () => {
-    it('hero name constants combine to match resume full name', () => {
+    it('hero name matches resume full name', () => {
       const displayName = `${FIRST_NAME} ${LAST_NAME}`
-      expect(displayName).toBe(RESUME_FULL_NAME.toUpperCase())
+      expect(normalizeResumeText(displayName)).toBe(normalizeResumeText(RESUME_FULL_NAME))
     })
   })
 
   describe('contact', () => {
-    it('email constant matches resume', () => {
-      const mailtoHref = `mailto:${RESUME_EMAIL}`
-      expect(mailtoHref).toBe('mailto:famohammed@shockers.wichita.edu')
+    it('site email matches resume', () => {
+      expect(RESUME_EMAIL).toBe('famohammed@shockers.wichita.edu')
     })
   })
 
@@ -69,36 +107,98 @@ describe('resume source-of-truth audit', () => {
       expect(timelineEntries.filter((e) => e.category === 'education')).toHaveLength(2)
     })
 
+    it('NetApp institution matches resume', () => {
+      const netapp = findEntry((e) => e.category === 'experience')
+      expect(normalizeResumeText(netapp.institution)).toBe(
+        normalizeResumeText(RESUME_TIMELINE.netapp.institution),
+      )
+    })
+
+    it('NetApp role matches resume', () => {
+      const netapp = findEntry((e) => e.category === 'experience')
+      expect(normalizeResumeText(netapp.role)).toBe(normalizeResumeText(RESUME_TIMELINE.netapp.role))
+    })
+
     it('NetApp date range matches resume', () => {
-      const netapp = timelineEntries.find((e) => e.hash === 'd4e8f2c')
-      expect(netapp?.dateRange).toBe('AUG 2024 – PRESENT')
+      const netapp = findEntry((e) => e.category === 'experience')
+      expect(normalizeResumeText(netapp.dateRange)).toBe(
+        normalizeResumeText(RESUME_TIMELINE.netapp.dateRange),
+      )
     })
 
     it('NetApp bullets match resume content', () => {
-      const netapp = timelineEntries.find((e) => e.hash === 'd4e8f2c')
-      expect(netapp?.bullets).toHaveLength(4)
-      expect(netapp?.bullets?.[0]).toContain('automated analysis pipeline')
-      expect(netapp?.bullets?.[1]).toContain('30%')
+      const netapp = findEntry((e) => e.category === 'experience')
+      expect(netapp.bullets).toHaveLength(4)
+      expect(netapp.bullets[0]).toContain('automated analysis pipeline')
+      expect(netapp.bullets[1]).toContain('30%')
+    })
+
+    it('M.S. institution matches resume', () => {
+      const ms = findEntry(
+        (e) =>
+          e.category === 'education' &&
+          normalizeResumeText(e.role).includes('accelerated ms computer science'),
+      )
+      expect(normalizeResumeText(ms.institution)).toBe(
+        normalizeResumeText(RESUME_TIMELINE.ms.institution),
+      )
+    })
+
+    it('M.S. role matches resume', () => {
+      const ms = findEntry(
+        (e) =>
+          e.category === 'education' &&
+          normalizeResumeText(e.role).includes('accelerated ms computer science'),
+      )
+      expect(normalizeResumeText(ms.role)).toBe(normalizeResumeText(RESUME_TIMELINE.ms.role))
+    })
+
+    it('M.S. date range matches resume', () => {
+      const ms = findEntry(
+        (e) =>
+          e.category === 'education' &&
+          normalizeResumeText(e.role).includes('accelerated ms computer science'),
+      )
+      expect(normalizeResumeText(ms.dateRange)).toBe(normalizeResumeText(RESUME_TIMELINE.ms.dateRange))
+    })
+
+    it('B.S. institution matches resume', () => {
+      const bs = findEntry(
+        (e) =>
+          e.category === 'education' &&
+          normalizeResumeText(e.role).includes('bs computer science'),
+      )
+      expect(normalizeResumeText(bs.institution)).toBe(
+        normalizeResumeText(RESUME_TIMELINE.bs.institution),
+      )
+    })
+
+    it('B.S. role matches resume', () => {
+      const bs = findEntry(
+        (e) =>
+          e.category === 'education' &&
+          normalizeResumeText(e.role).includes('bs computer science'),
+      )
+      expect(normalizeResumeText(bs.role)).toBe(normalizeResumeText(RESUME_TIMELINE.bs.role))
+    })
+
+    it('B.S. date range matches resume', () => {
+      const bs = findEntry(
+        (e) =>
+          e.category === 'education' &&
+          normalizeResumeText(e.role).includes('bs computer science'),
+      )
+      expect(normalizeResumeText(bs.dateRange)).toBe(normalizeResumeText(RESUME_TIMELINE.bs.dateRange))
     })
 
     it('B.S. education bullets match resume', () => {
-      const bs = timelineEntries.find((e) => e.hash === 'b7c3e1a')
-      expect(bs?.bullets?.[0]).toContain("Dean's List")
-      expect(bs?.bullets?.[1]).toContain('Relevant Coursework')
-    })
-
-    it('documents resume formatting differences for role titles', () => {
-      const netapp = timelineEntries.find((e) => e.hash === 'd4e8f2c')
-      // Resume uses title case; timeline uses stylized uppercase with underscores.
-      expect(netapp?.role).toBe('SOFTWARE_ENGINEER_IN_TEST')
-      expect(netapp?.role).not.toBe('Software Engineer in Test')
-    })
-
-    it('documents resume content gap for B.S. GPA honors line', () => {
-      const bs = timelineEntries.find((e) => e.hash === 'b7c3e1a')
-      // Resume includes "GPA: 3.66/4.0, Magna Cum Laude" in the degree line.
-      expect(bs?.role).toBe('B.S._COMPUTER_SCIENCE')
-      expect(bs?.role).not.toContain('GPA')
+      const bs = findEntry(
+        (e) =>
+          e.category === 'education' &&
+          normalizeResumeText(e.role).includes('bs computer science'),
+      )
+      expect(bs.bullets[0]).toContain("Dean's List")
+      expect(bs.bullets[1]).toContain('Relevant Coursework')
     })
   })
 })


### PR DESCRIPTION
## Purpose

Prevent resume audit tests from failing when timeline display formatting changes, while still validating that site data matches the resume PDF.

## What it does

Reworks `resume-audit.test.ts` to assert domain facts (names, institutions, roles, dates, bullets) using normalized text comparison instead of stylized strings, hash lookups, or uppercase transforms.

## Changes made

- Added `RESUME_TIMELINE` constants and `normalizeResumeText()` helper for format-agnostic comparisons
- Replaced hash-based entry lookups with category/role predicates
- Removed format-assumption tests (stylized role strings, GPA gap documentation)
- Added explicit institution/role/date-range checks for NetApp, M.S., and B.S. entries
- Renamed tests to describe factual claims (e.g. "hero name matches resume full name")

## Additional notes

- Format/presentation assertions were removed rather than relocated; `TimelineSection.test.tsx` already covers display formatting via issue #160 tests (#259 owns further TimelineSection test refactors)
- `timelineEntries` already imports from `./timeline` (post-#253)
- All 473 tests pass; typecheck clean

Closes #254

Made with [Cursor](https://cursor.com)