### PR TITLE
Add maintainability smoke path for navigation and scroll progression

### DIFF
--- a/src/integration.smoke.test.ts
+++ b/src/integration.smoke.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Maintainability smoke path — first check for cross-module regressions.
+ *
+ * Verifies the refactored contracts work together end-to-end: the SECTIONS
+ * registry drives nav rendering and active-section detection, and the shared
+ * useScrollProgress primitive reports correct progression through a sticky host.
+ * Issue #261.
+ */
+
+import { createElement, useRef } from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, within, renderHook, act } from '@testing-library/react'
+import { SECTIONS } from './data/sections'
+import Navbar from './components/Navbar'
+import {
+  ACTIVE_SECTION_SAMPLE_RATIO,
+  computeActiveMajorSection,
+} from './hooks/useActiveMajorSection'
+import { useScrollProgress } from './hooks/useScrollProgress'
+
+const VIEWPORT_HEIGHT = 800
+const SECTION_IDS = SECTIONS.map((section) => section.id)
+const PROGRESS_TOLERANCE = 0.01
+
+function rectWithHeight(top: number, height: number): DOMRect {
+  return {
+    top,
+    right: 1000,
+    bottom: top + height,
+    left: 0,
+    width: 1000,
+    height,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
+function setViewport(height: number) {
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value: height,
+  })
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: 1000,
+  })
+}
+
+function mockSectionElement(id: string, top: number, height: number): HTMLElement {
+  const tag = id === 'contact' ? 'footer' : 'section'
+  const element = document.createElement(tag)
+  element.id = id
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue(rectWithHeight(top, height))
+  document.body.appendChild(element)
+  return element
+}
+
+function setupActiveSectionGeometry(targetId: string): (id: string) => HTMLElement | null {
+  const elements = new Map<string, HTMLElement>()
+  const targetIndex = SECTIONS.findIndex((section) => section.id === targetId)
+
+  for (const [index, section] of SECTIONS.entries()) {
+    let top: number
+    const height = VIEWPORT_HEIGHT
+
+    if (section.id === targetId) {
+      top = 0
+    } else if (index < targetIndex) {
+      top = -5000 - index * 1000
+    } else {
+      top = 5000 + index * 1000
+    }
+
+    elements.set(section.id, mockSectionElement(section.id, top, height))
+  }
+
+  return (id) => elements.get(id) ?? null
+}
+
+describe('maintainability smoke path (issue #261)', () => {
+  beforeEach(() => {
+    setViewport(VIEWPORT_HEIGHT)
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('wires section registry, navigation, active-section, and scroll progression', () => {
+    // Contract 1 — Section registry → nav rendering
+    render(createElement(Navbar))
+    const nav = screen.getByRole('navigation')
+    const links = within(nav).getAllByRole('link')
+
+    for (const section of SECTIONS) {
+      const link = links.find((candidate) => candidate.getAttribute('href') === `#${section.id}`)
+      expect(link, `nav link for ${section.id}`).toBeDefined()
+      expect(within(link!).getByText(section.navLabel)).toBeInTheDocument()
+    }
+
+    const sectionLinks = links.filter((link) =>
+      SECTIONS.some((section) => link.getAttribute('href') === `#${section.id}`),
+    )
+    expect(sectionLinks).toHaveLength(SECTIONS.length)
+
+    // Contract 2 — Section registry → active-section
+    expect(VIEWPORT_HEIGHT * ACTIVE_SECTION_SAMPLE_RATIO).toBe(320)
+
+    for (const targetSection of SECTIONS) {
+      document.body.innerHTML = ''
+      vi.restoreAllMocks()
+
+      const getElement = setupActiveSectionGeometry(targetSection.id)
+
+      expect(
+        computeActiveMajorSection(SECTION_IDS, getElement, VIEWPORT_HEIGHT),
+        `active section for ${targetSection.id}`,
+      ).toBe(targetSection.id)
+    }
+
+    // Contract 3 — Scroll primitive → progression
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+
+    const outer = document.createElement('section')
+    const outerHeight = 1600
+    outer.getBoundingClientRect = vi.fn(() => rectWithHeight(-400, outerHeight))
+
+    const { result } = renderHook(() => {
+      const outerRef = useRef<HTMLElement>(outer)
+      return useScrollProgress(outerRef)
+    })
+
+    act(() => {
+      window.dispatchEvent(new Event('scroll'))
+    })
+
+    expect(result.current.progress).toBeGreaterThanOrEqual(0.5 - PROGRESS_TOLERANCE)
+    expect(result.current.progress).toBeLessThanOrEqual(0.5 + PROGRESS_TOLERANCE)
+  })
+
+  it('propagates SECTIONS registry changes to rendered nav without Navbar changes', async () => {
+    vi.resetModules()
+    vi.doMock('./data/sections', () => ({
+      SECTIONS: [
+        { id: 'home', navLabel: 'HOME' },
+        { id: 'about', navLabel: 'ABOUT US' },
+      ] as const,
+    }))
+
+    const { default: NavbarWithRegistry } = await import('./components/Navbar')
+
+    render(createElement(NavbarWithRegistry))
+
+    const nav = screen.getByRole('navigation')
+    const links = within(nav).getAllByRole('link')
+
+    expect(screen.getByText('ABOUT US')).toBeInTheDocument()
+    expect(links.some((link) => link.getAttribute('href') === '#about')).toBe(true)
+    expect(links.filter((link) => link.getAttribute('href') === '#home')).toHaveLength(1)
+
+    vi.doUnmock('./data/sections')
+    vi.resetModules()
+  })
+})

--- a/src/integration.smoke.test.ts
+++ b/src/integration.smoke.test.ts
@@ -9,11 +9,11 @@
 
 import { createElement, useRef } from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, within, renderHook, act } from '@testing-library/react'
+import { render, screen, within, renderHook, act, cleanup } from '@testing-library/react'
 import { SECTIONS } from './data/sections'
 import Navbar from './components/Navbar'
 import {
-  ACTIVE_SECTION_SAMPLE_RATIO,
+  MAJOR_SECTION_IDS,
   computeActiveMajorSection,
 } from './hooks/useActiveMajorSection'
 import { useScrollProgress } from './hooks/useScrollProgress'
@@ -86,6 +86,7 @@ describe('maintainability smoke path (issue #261)', () => {
   })
 
   afterEach(() => {
+    cleanup()
     document.body.innerHTML = ''
     vi.restoreAllMocks()
   })
@@ -108,7 +109,7 @@ describe('maintainability smoke path (issue #261)', () => {
     expect(sectionLinks).toHaveLength(SECTIONS.length)
 
     // Contract 2 — Section registry → active-section
-    expect(VIEWPORT_HEIGHT * ACTIVE_SECTION_SAMPLE_RATIO).toBe(320)
+    expect(SECTION_IDS).toEqual(MAJOR_SECTION_IDS)
 
     for (const targetSection of SECTIONS) {
       document.body.innerHTML = ''
@@ -152,18 +153,27 @@ describe('maintainability smoke path (issue #261)', () => {
       ] as const,
     }))
 
-    const { default: NavbarWithRegistry } = await import('./components/Navbar')
+    try {
+      const { default: NavbarWithRegistry } = await import('./components/Navbar')
 
-    render(createElement(NavbarWithRegistry))
+      render(createElement(NavbarWithRegistry))
 
-    const nav = screen.getByRole('navigation')
-    const links = within(nav).getAllByRole('link')
+      const nav = screen.getByRole('navigation')
+      const links = within(nav).getAllByRole('link')
+      const sectionLinks = links.filter((link) => {
+        const href = link.getAttribute('href') ?? ''
+        return href.startsWith('#') && href !== '#'
+      })
 
-    expect(screen.getByText('ABOUT US')).toBeInTheDocument()
-    expect(links.some((link) => link.getAttribute('href') === '#about')).toBe(true)
-    expect(links.filter((link) => link.getAttribute('href') === '#home')).toHaveLength(1)
-
-    vi.doUnmock('./data/sections')
-    vi.resetModules()
+      expect(sectionLinks).toHaveLength(2)
+      expect(screen.getByText('ABOUT US')).toBeInTheDocument()
+      expect(links.some((link) => link.getAttribute('href') === '#about')).toBe(true)
+      expect(links.filter((link) => link.getAttribute('href') === '#home')).toHaveLength(1)
+      expect(screen.queryByText('PROJECTS')).not.toBeInTheDocument()
+      expect(screen.queryByText('TIMELINE')).not.toBeInTheDocument()
+    } finally {
+      vi.doUnmock('./data/sections')
+      vi.resetModules()
+    }
   })
 })


### PR DESCRIPTION
## Purpose

Add a high-signal integration smoke test that verifies the refactored cross-module contracts still work together after the architecture migrations (#255, #257, #258). This is the CI guard that fails if registry, navigation, active-section, or scroll-progress wiring breaks.

## What it does

Runs one integration scenario (plus a registry-propagation check) asserting three contracts:

1. **Section registry → nav rendering** — `Navbar` renders all `SECTIONS` labels as links with correct `#id` hrefs; changing the registry via mock propagates to nav without touching `Navbar` internals.
2. **Section registry → active-section** — `computeActiveMajorSection` returns the expected section for each registry ID given mock intersection geometry.
3. **Scroll primitive → progression** — `useScrollProgress` reports ~0.5 progress at 50% of a section's scroll range.

## Changes made

- Added `src/integration.smoke.test.ts` with a file-header comment documenting it as the first check for cross-module regressions.

## Additional notes

- Uses existing vitest + Testing Library patterns; no production code changes.
- `npm run typecheck` and `npm run test` (456 tests) pass locally.

Closes #261

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests to validate navigation rendering, scroll progress tracking, and dynamic section registry updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->