### PR TITLE
mochi: clip project card hover fill inside card boundary

### DIFF
--- a/src/components/ProjectsSection.cards.test.tsx
+++ b/src/components/ProjectsSection.cards.test.tsx
@@ -44,9 +44,10 @@ describe('ProjectsSection cards', () => {
     const card = screen.getByRole('heading', { name: 'Project One' }).closest('[data-testid="project-card"]')
     expect(card).not.toBeNull()
 
+    const clip = card!.querySelector('.pcard-clip')
     const fill = card!.querySelector('[data-testid="project-card-fill"]')
+    expect(clip).toHaveAttribute('aria-hidden', 'true')
     expect(fill).toBeInTheDocument()
-    expect(fill).toHaveAttribute('aria-hidden', 'true')
     expect(fill).toHaveAttribute('data-active', 'false')
 
     await user.hover(card!)
@@ -219,6 +220,45 @@ describe('ProjectsSection cards', () => {
         expect(card.querySelector('.pcard-notch.tl')).toBeInTheDocument()
         expect(card.querySelector('.pcard-notch.br')).toBeInTheDocument()
       })
+    })
+
+    it('nests fill layer inside pcard-clip while notches stay outside', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const card = document.querySelector('[data-testid="project-card"]')
+      expect(card).not.toBeNull()
+
+      const clip = card!.querySelector('.pcard-clip')
+      expect(clip).toBeInTheDocument()
+
+      const fill = card!.querySelector('[data-testid="project-card-fill"]')
+      expect(fill).toBeInTheDocument()
+      expect(clip!.contains(fill)).toBe(true)
+
+      const notches = card!.querySelectorAll('.pcard-notch')
+      expect(notches).toHaveLength(2)
+      notches.forEach((notch) => {
+        expect(clip!.contains(notch)).toBe(false)
+      })
+    })
+
+    it('toggles data-fill-active on card for mask-position fill reveal', async () => {
+      const user = userEvent.setup()
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const card = screen.getByRole('heading', { name: 'Project One' }).closest('[data-testid="project-card"]')
+      expect(card).not.toBeNull()
+
+      const fill = card!.querySelector('[data-testid="project-card-fill"]')
+      expect(card).toHaveAttribute('data-fill-active', 'false')
+
+      await user.hover(card!)
+      expect(card).toHaveAttribute('data-fill-active', 'true')
+      expect(fill).toHaveAttribute('data-active', 'true')
+
+      await user.unhover(card!)
+      expect(card).toHaveAttribute('data-fill-active', 'false')
+      expect(fill).toHaveAttribute('data-active', 'false')
     })
 
     it('renders card hierarchy for a single-project carousel', () => {

--- a/src/components/ProjectsSection.cards.test.tsx
+++ b/src/components/ProjectsSection.cards.test.tsx
@@ -212,17 +212,17 @@ describe('ProjectsSection cards', () => {
       expect(PROJECT_CARD_WIDTH).toBe(560)
     })
 
-    it('renders notched corner accent markers on each card', () => {
+    it('renders only the bottom-right notched corner accent on each card', () => {
       render(<ProjectsSection projects={mockProjects} />)
 
       const cards = document.querySelectorAll('[data-testid="project-card"]')
       cards.forEach((card) => {
-        expect(card.querySelector('.pcard-notch.tl')).toBeInTheDocument()
+        expect(card.querySelector('.pcard-notch.tl')).not.toBeInTheDocument()
         expect(card.querySelector('.pcard-notch.br')).toBeInTheDocument()
       })
     })
 
-    it('nests fill layer inside pcard-clip while notches stay outside', () => {
+    it('nests fill layer inside pcard-clip while the remaining notch stays outside', () => {
       render(<ProjectsSection projects={mockProjects} />)
 
       const card = document.querySelector('[data-testid="project-card"]')
@@ -239,9 +239,24 @@ describe('ProjectsSection cards', () => {
       expect(clip!.contains(fill)).toBe(true)
 
       const notches = card!.querySelectorAll('.pcard-notch')
-      expect(notches).toHaveLength(2)
+      expect(notches).toHaveLength(1)
       notches.forEach((notch) => {
         expect(clip!.contains(notch)).toBe(false)
+      })
+    })
+
+    it('does not render a left-edge rising highlight strip', () => {
+      render(<ProjectsSection projects={mockProjects} />)
+
+      const cards = document.querySelectorAll('[data-testid="project-card"]')
+      const leftStripClasses = ['left-0', 'top-0', 'bottom-0', 'w-[3px]', 'bg-atomic-tangerine']
+
+      cards.forEach((card) => {
+        const leftStrip = Array.from(card.querySelectorAll('*')).find((element) =>
+          leftStripClasses.every((className) => element.classList.contains(className)),
+        )
+
+        expect(leftStrip).toBeUndefined()
       })
     })
 

--- a/src/components/ProjectsSection.cards.test.tsx
+++ b/src/components/ProjectsSection.cards.test.tsx
@@ -27,7 +27,7 @@ describe('ProjectsSection cards', () => {
     expect(title).not.toHaveClass('text-platinum')
   })
 
-  it('renders fill as a static layer driven by CSS mask-position (not Framer clip-path)', () => {
+  it('renders fill as a static clipped opacity layer (not Framer clip-path)', () => {
     render(<ProjectsSection projects={mockProjects} />)
 
     const fill = document.querySelector('[data-testid="project-card-fill"]')
@@ -37,7 +37,7 @@ describe('ProjectsSection cards', () => {
     expect(fill?.getAttribute('style') ?? '').not.toMatch(/clip-path/i)
   })
 
-  it('activates a diagonal orange fill layer when a project card is hovered', async () => {
+  it('activates the orange fill layer when a project card is hovered', async () => {
     const user = userEvent.setup()
     render(<ProjectsSection projects={mockProjects} />)
 
@@ -57,7 +57,7 @@ describe('ProjectsSection cards', () => {
     expect(fill).toHaveAttribute('data-active', 'false')
   })
 
-  it('activates the diagonal orange fill while a project card link has focus', async () => {
+  it('activates the orange fill while a project card link has focus', async () => {
     const user = userEvent.setup()
     render(<ProjectsSection projects={mockProjects} />)
 
@@ -245,7 +245,7 @@ describe('ProjectsSection cards', () => {
       })
     })
 
-    it('toggles data-fill-active on card for mask-position fill reveal', async () => {
+    it('toggles data-fill-active on card for opacity fill reveal', async () => {
       const user = userEvent.setup()
       render(<ProjectsSection projects={mockProjects} />)
 

--- a/src/components/ProjectsSection.cards.test.tsx
+++ b/src/components/ProjectsSection.cards.test.tsx
@@ -231,8 +231,11 @@ describe('ProjectsSection cards', () => {
       const clip = card!.querySelector('.pcard-clip')
       expect(clip).toBeInTheDocument()
 
+      const bg = card!.querySelector('.pcard-bg')
       const fill = card!.querySelector('[data-testid="project-card-fill"]')
+      expect(bg).toBeInTheDocument()
       expect(fill).toBeInTheDocument()
+      expect(clip!.contains(bg)).toBe(true)
       expect(clip!.contains(fill)).toBe(true)
 
       const notches = card!.querySelectorAll('.pcard-notch')

--- a/src/components/ProjectsSection.cards.test.tsx
+++ b/src/components/ProjectsSection.cards.test.tsx
@@ -27,7 +27,7 @@ describe('ProjectsSection cards', () => {
     expect(title).not.toHaveClass('text-platinum')
   })
 
-  it('renders fill as a static clipped opacity layer (not Framer clip-path)', () => {
+  it('renders fill as a static layer driven by CSS mask-position (not Framer clip-path)', () => {
     render(<ProjectsSection projects={mockProjects} />)
 
     const fill = document.querySelector('[data-testid="project-card-fill"]')
@@ -37,7 +37,7 @@ describe('ProjectsSection cards', () => {
     expect(fill?.getAttribute('style') ?? '').not.toMatch(/clip-path/i)
   })
 
-  it('activates the orange fill layer when a project card is hovered', async () => {
+  it('activates a diagonal orange fill layer when a project card is hovered', async () => {
     const user = userEvent.setup()
     render(<ProjectsSection projects={mockProjects} />)
 
@@ -57,7 +57,7 @@ describe('ProjectsSection cards', () => {
     expect(fill).toHaveAttribute('data-active', 'false')
   })
 
-  it('activates the orange fill while a project card link has focus', async () => {
+  it('activates the diagonal orange fill while a project card link has focus', async () => {
     const user = userEvent.setup()
     render(<ProjectsSection projects={mockProjects} />)
 
@@ -150,6 +150,43 @@ describe('ProjectsSection cards', () => {
     expect(fill).toHaveAttribute('data-active', 'false')
   })
 
+  it('keeps fill active via lingering keyboard focus after the pointer leaves a hovered card', async () => {
+    const user = userEvent.setup()
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const githubLink = screen.getByRole('link', { name: '// GitHub ↗' })
+    const card = githubLink.closest('[data-testid="project-card"]')!
+    const fill = card.querySelector('[data-testid="project-card-fill"]')!
+
+    await user.hover(card)
+    await user.tab()
+    expect(githubLink).toHaveFocus()
+    expect(fill).toHaveAttribute('data-active', 'true')
+
+    await user.unhover(card)
+    expect(fill).toHaveAttribute('data-active', 'true')
+  })
+
+  it('survives rapid hover/unhover toggling without leaving stale fill state', async () => {
+    const user = userEvent.setup()
+    render(<ProjectsSection projects={mockProjects} />)
+
+    const card = screen.getByRole('heading', { name: 'Project One' }).closest('[data-testid="project-card"]')!
+    const fill = card.querySelector('[data-testid="project-card-fill"]')!
+
+    for (let i = 0; i < 5; i += 1) {
+      await user.hover(card)
+      await user.unhover(card)
+    }
+
+    expect(card).toHaveAttribute('data-fill-active', 'false')
+    expect(fill).toHaveAttribute('data-active', 'false')
+
+    await user.hover(card)
+    expect(card).toHaveAttribute('data-fill-active', 'true')
+    expect(fill).toHaveAttribute('data-active', 'true')
+  })
+
   describe('v4 notched card hierarchy', () => {
     it('each card exposes number, ghost number, title, description, tags, and links', () => {
       render(<ProjectsSection projects={mockProjects} />)
@@ -212,17 +249,17 @@ describe('ProjectsSection cards', () => {
       expect(PROJECT_CARD_WIDTH).toBe(560)
     })
 
-    it('renders only the bottom-right notched corner accent on each card', () => {
+    it('renders notched corner accent markers on each card', () => {
       render(<ProjectsSection projects={mockProjects} />)
 
       const cards = document.querySelectorAll('[data-testid="project-card"]')
       cards.forEach((card) => {
-        expect(card.querySelector('.pcard-notch.tl')).not.toBeInTheDocument()
+        expect(card.querySelector('.pcard-notch.tl')).toBeInTheDocument()
         expect(card.querySelector('.pcard-notch.br')).toBeInTheDocument()
       })
     })
 
-    it('nests fill layer inside pcard-clip while the remaining notch stays outside', () => {
+    it('nests fill layer inside pcard-clip while notches stay outside', () => {
       render(<ProjectsSection projects={mockProjects} />)
 
       const card = document.querySelector('[data-testid="project-card"]')
@@ -239,28 +276,30 @@ describe('ProjectsSection cards', () => {
       expect(clip!.contains(fill)).toBe(true)
 
       const notches = card!.querySelectorAll('.pcard-notch')
-      expect(notches).toHaveLength(1)
+      expect(notches).toHaveLength(2)
       notches.forEach((notch) => {
         expect(clip!.contains(notch)).toBe(false)
       })
     })
 
-    it('does not render a left-edge rising highlight strip', () => {
+    it('renders a left-edge rising highlight strip outside the pcard-clip wrapper', () => {
       render(<ProjectsSection projects={mockProjects} />)
 
       const cards = document.querySelectorAll('[data-testid="project-card"]')
       const leftStripClasses = ['left-0', 'top-0', 'bottom-0', 'w-[3px]', 'bg-atomic-tangerine']
 
       cards.forEach((card) => {
+        const clip = card.querySelector('.pcard-clip')
         const leftStrip = Array.from(card.querySelectorAll('*')).find((element) =>
           leftStripClasses.every((className) => element.classList.contains(className)),
         )
 
-        expect(leftStrip).toBeUndefined()
+        expect(leftStrip).toBeDefined()
+        expect(clip!.contains(leftStrip!)).toBe(false)
       })
     })
 
-    it('toggles data-fill-active on card for opacity fill reveal', async () => {
+    it('toggles data-fill-active on card for mask-position fill reveal', async () => {
       const user = userEvent.setup()
       render(<ProjectsSection projects={mockProjects} />)
 

--- a/src/components/ProjectsSection.cards.test.tsx
+++ b/src/components/ProjectsSection.cards.test.tsx
@@ -282,23 +282,6 @@ describe('ProjectsSection cards', () => {
       })
     })
 
-    it('renders a left-edge rising highlight strip outside the pcard-clip wrapper', () => {
-      render(<ProjectsSection projects={mockProjects} />)
-
-      const cards = document.querySelectorAll('[data-testid="project-card"]')
-      const leftStripClasses = ['left-0', 'top-0', 'bottom-0', 'w-[3px]', 'bg-atomic-tangerine']
-
-      cards.forEach((card) => {
-        const clip = card.querySelector('.pcard-clip')
-        const leftStrip = Array.from(card.querySelectorAll('*')).find((element) =>
-          leftStripClasses.every((className) => element.classList.contains(className)),
-        )
-
-        expect(leftStrip).toBeDefined()
-        expect(clip!.contains(leftStrip!)).toBe(false)
-      })
-    })
-
     it('toggles data-fill-active on card for mask-position fill reveal', async () => {
       const user = userEvent.setup()
       render(<ProjectsSection projects={mockProjects} />)

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -136,14 +136,14 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
       data-fill-active={isFillActive}
       className="pcard shrink-0"
     >
-      <div className="pcard-bg" aria-hidden="true" />
-
-      <div
-        data-testid="project-card-fill"
-        aria-hidden="true"
-        data-active={isFillActive}
-        className="pcard-fill"
-      />
+      <div className="pcard-clip" aria-hidden="true">
+        <div className="pcard-bg" />
+        <div
+          data-testid="project-card-fill"
+          data-active={isFillActive}
+          className="pcard-fill"
+        />
+      </div>
 
       <span className="pcard-notch tl" aria-hidden="true" />
       <span className="pcard-notch br" aria-hidden="true" />

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -145,7 +145,6 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
         />
       </div>
 
-      <span className="pcard-notch tl" aria-hidden="true" />
       <span className="pcard-notch br" aria-hidden="true" />
 
       <div className="pcard-body">
@@ -187,14 +186,6 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
           ))}
         </div>
       </div>
-
-      <motion.div
-        className="absolute left-0 top-0 bottom-0 w-[3px] bg-atomic-tangerine"
-        initial={{ scaleY: 0, opacity: 0 }}
-        animate={{ scaleY: isFillActive ? 1 : 0, opacity: isFillActive ? 1 : 0 }}
-        style={{ transformOrigin: 'bottom' }}
-        transition={{ duration: 0.25, ease: 'easeOut' }}
-      />
     </motion.article>
   )
 }

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -187,14 +187,6 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
           ))}
         </div>
       </div>
-
-      <motion.div
-        className="absolute left-0 top-0 bottom-0 w-[3px] bg-atomic-tangerine"
-        initial={{ scaleY: 0, opacity: 0 }}
-        animate={{ scaleY: isFillActive ? 1 : 0, opacity: isFillActive ? 1 : 0 }}
-        style={{ transformOrigin: 'bottom' }}
-        transition={{ duration: 0.25, ease: 'easeOut' }}
-      />
     </motion.article>
   )
 }

--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -145,6 +145,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
         />
       </div>
 
+      <span className="pcard-notch tl" aria-hidden="true" />
       <span className="pcard-notch br" aria-hidden="true" />
 
       <div className="pcard-body">
@@ -186,6 +187,14 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
           ))}
         </div>
       </div>
+
+      <motion.div
+        className="absolute left-0 top-0 bottom-0 w-[3px] bg-atomic-tangerine"
+        initial={{ scaleY: 0, opacity: 0 }}
+        animate={{ scaleY: isFillActive ? 1 : 0, opacity: isFillActive ? 1 : 0 }}
+        style={{ transformOrigin: 'bottom' }}
+        transition={{ duration: 0.25, ease: 'easeOut' }}
+      />
     </motion.article>
   )
 }

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -104,10 +104,17 @@ describe('portfolio.css CSS anchor', () => {
     expect(portfolioCss).toContain('--ease: cubic-bezier(0.4, 0, 0.2, 1)')
   })
 
-  it('uses mask-position diagonal reveal on pcard-fill from the reference', () => {
-    expect(portfolioCss).toContain('mask-image:linear-gradient(135deg')
-    expect(portfolioCss).toContain('mask-size:300% 300%')
-    expect(portfolioCss).toContain('mask-position:100% 100%')
+  it('keeps pcard-fill as a clipped opacity fill without a left-side mask reveal', () => {
+    const fillRule = blockFor('.pcard-fill')
+    const hoverRule = blockFor('.pcard:hover .pcard-fill')
+    const activeRule = blockFor(".pcard[data-fill-active='true'] .pcard-fill")
+
+    expect(fillRule).toContain('opacity:0')
+    expect(fillRule).toContain('transition:opacity .35s var(--ease)')
+    expect(fillRule).not.toMatch(/mask-(image|size|position)/)
+    expect(hoverRule).toContain('opacity:1')
+    expect(activeRule).toContain('opacity: 1')
+    expect(portfolioCss).not.toContain('mask-position:100% 100%')
   })
 
   it('clips pcard fill inside card silhouette via pcard-clip wrapper', () => {

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -109,6 +109,11 @@ describe('portfolio.css CSS anchor', () => {
     const hoverRule = blockFor('.pcard:hover .pcard-fill')
     const activeRule = blockFor(".pcard[data-fill-active='true'] .pcard-fill")
 
+    expect(fillRule).not.toContain('inset:0')
+    expect(fillRule).toContain('top:1px')
+    expect(fillRule).toContain('right:1px')
+    expect(fillRule).toContain('bottom:1px')
+    expect(fillRule).toContain('left:1px')
     expect(fillRule).toContain('opacity:0')
     expect(fillRule).toContain('transition:opacity .35s var(--ease)')
     expect(fillRule).not.toMatch(/mask-(image|size|position)/)
@@ -130,6 +135,12 @@ describe('portfolio.css CSS anchor', () => {
     expect(cardRule).not.toContain('overflow:hidden')
     expect(bgRule).not.toContain('clip-path')
     expect(fillRule).not.toContain('clip-path')
+    expect(fillRule).not.toContain('inset:0')
+  })
+
+  it('does not define a top-left project-card corner accent', () => {
+    expect(portfolioCss).not.toContain('.pcard-notch.tl')
+    expect(portfolioCss).toContain('.pcard-notch.br{bottom:-6px;right:-6px}')
   })
 
   it('anchors loading screen boot sequence from the reference', () => {

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -112,11 +112,17 @@ describe('portfolio.css CSS anchor', () => {
 
   it('clips pcard fill inside card silhouette via pcard-clip wrapper', () => {
     const clipRule = blockFor('.pcard-clip')
+    const cardRule = blockFor('.pcard')
+    const bgRule = blockFor('.pcard-bg')
+    const fillRule = blockFor('.pcard-fill')
 
     expect(clipRule).toContain('overflow:hidden')
     expect(clipRule).toContain('clip-path:polygon(var(--notch) 0')
     expect(clipRule).toContain('position:absolute')
     expect(clipRule).toContain('inset:0')
+    expect(cardRule).not.toContain('overflow:hidden')
+    expect(bgRule).not.toContain('clip-path')
+    expect(fillRule).not.toContain('clip-path')
   })
 
   it('anchors loading screen boot sequence from the reference', () => {

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -110,6 +110,15 @@ describe('portfolio.css CSS anchor', () => {
     expect(portfolioCss).toContain('mask-position:100% 100%')
   })
 
+  it('clips pcard fill inside card silhouette via pcard-clip wrapper', () => {
+    const clipRule = blockFor('.pcard-clip')
+
+    expect(clipRule).toContain('overflow:hidden')
+    expect(clipRule).toContain('clip-path:polygon(var(--notch) 0')
+    expect(clipRule).toContain('position:absolute')
+    expect(clipRule).toContain('inset:0')
+  })
+
   it('anchors loading screen boot sequence from the reference', () => {
     expect(portfolioCss).toMatch(/#ls\{[^}]*background:var\(--color-graphite\)/)
     expect(portfolioCss).toContain('.ls-fill{height:1px;background:var(--color-atomic-tangerine)')

--- a/src/portfolio-css.test.ts
+++ b/src/portfolio-css.test.ts
@@ -104,22 +104,16 @@ describe('portfolio.css CSS anchor', () => {
     expect(portfolioCss).toContain('--ease: cubic-bezier(0.4, 0, 0.2, 1)')
   })
 
-  it('keeps pcard-fill as a clipped opacity fill without a left-side mask reveal', () => {
+  it('uses mask-position diagonal reveal on pcard-fill from the reference', () => {
     const fillRule = blockFor('.pcard-fill')
     const hoverRule = blockFor('.pcard:hover .pcard-fill')
     const activeRule = blockFor(".pcard[data-fill-active='true'] .pcard-fill")
 
-    expect(fillRule).not.toContain('inset:0')
-    expect(fillRule).toContain('top:1px')
-    expect(fillRule).toContain('right:1px')
-    expect(fillRule).toContain('bottom:1px')
-    expect(fillRule).toContain('left:1px')
-    expect(fillRule).toContain('opacity:0')
-    expect(fillRule).toContain('transition:opacity .35s var(--ease)')
-    expect(fillRule).not.toMatch(/mask-(image|size|position)/)
-    expect(hoverRule).toContain('opacity:1')
-    expect(activeRule).toContain('opacity: 1')
-    expect(portfolioCss).not.toContain('mask-position:100% 100%')
+    expect(fillRule).toContain('mask-image:linear-gradient(135deg')
+    expect(fillRule).toContain('mask-size:300% 300%')
+    expect(fillRule).toContain('mask-position:100% 100%')
+    expect(hoverRule).toContain('mask-position:0% 0%')
+    expect(activeRule).toContain('mask-position: 0% 0%')
   })
 
   it('clips pcard fill inside card silhouette via pcard-clip wrapper', () => {
@@ -129,17 +123,24 @@ describe('portfolio.css CSS anchor', () => {
     const fillRule = blockFor('.pcard-fill')
 
     expect(clipRule).toContain('overflow:hidden')
-    expect(clipRule).toContain('clip-path:polygon(var(--notch) 0')
+    expect(clipRule).toContain(
+      'clip-path:polygon(var(--notch) 0, 100% 0, 100% calc(100% - var(--notch)), calc(100% - var(--notch)) 100%, 0 100%, 0 var(--notch))',
+    )
     expect(clipRule).toContain('position:absolute')
     expect(clipRule).toContain('inset:0')
     expect(cardRule).not.toContain('overflow:hidden')
     expect(bgRule).not.toContain('clip-path')
     expect(fillRule).not.toContain('clip-path')
-    expect(fillRule).not.toContain('inset:0')
+
+    // Exactly one clip-path polygon should exist for the card silhouette — on the
+    // wrapper only. If .pcard-bg or .pcard-fill ever re-grow their own clip-path,
+    // the mask animation can again paint outside the notched card boundary.
+    const polygonMatches = portfolioCss.match(/clip-path:polygon\(var\(--notch\)/g) ?? []
+    expect(polygonMatches).toHaveLength(1)
   })
 
-  it('does not define a top-left project-card corner accent', () => {
-    expect(portfolioCss).not.toContain('.pcard-notch.tl')
+  it('defines both top-left and bottom-right project-card corner accents', () => {
+    expect(portfolioCss).toContain('.pcard-notch.tl{top:-6px;left:-6px}')
     expect(portfolioCss).toContain('.pcard-notch.br{bottom:-6px;right:-6px}')
   })
 

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -88,14 +88,13 @@
     clip-path:polygon(var(--notch) 0, 100% 0, 100% calc(100% - var(--notch)), calc(100% - var(--notch)) 100%, 0 100%, 0 var(--notch))}
   .pcard-bg{position:absolute;inset:0;background:var(--color-platinum);
     transition:transform .35s var(--ease)}
-  /* clipped orange fill without the left-edge diagonal reveal */
-  .pcard-fill{position:absolute;inset:0;background:var(--color-atomic-tangerine);
+  /* clipped orange fill without painting the antialiased card silhouette edge */
+  .pcard-fill{position:absolute;top:1px;right:1px;bottom:1px;left:1px;background:var(--color-atomic-tangerine);
     opacity:0;transition:opacity .35s var(--ease)}
   .pcard:hover .pcard-fill{opacity:1}
-  /* notch corner accents — sit outside */
+  /* bottom-right notch corner accent */
   .pcard-notch{position:absolute;width:calc(var(--notch) * 1.8);height:calc(var(--notch) * 1.8);pointer-events:none}
   .pcard-notch::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,transparent calc(50% - 1px),var(--color-atomic-tangerine) calc(50% - 1px),var(--color-atomic-tangerine) calc(50% + 1px),transparent calc(50% + 1px))}
-  .pcard-notch.tl{top:-6px;left:-6px}
   .pcard-notch.br{bottom:-6px;right:-6px}
   .pcard-body{position:relative;height:100%;padding:36px 36px 32px;display:flex;flex-direction:column;color:var(--color-graphite);z-index:1}
   .pcard-ghost{position:absolute;font-family:var(--font-display);font-size:clamp(110px,15vw,200px);color:var(--color-graphite);opacity:.07;top:18px;left:24px;line-height:1;letter-spacing:-4px;pointer-events:none;transition:color .35s var(--ease),opacity .35s var(--ease)}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -88,13 +88,18 @@
     clip-path:polygon(var(--notch) 0, 100% 0, 100% calc(100% - var(--notch)), calc(100% - var(--notch)) 100%, 0 100%, 0 var(--notch))}
   .pcard-bg{position:absolute;inset:0;background:var(--color-platinum);
     transition:transform .35s var(--ease)}
-  /* clipped orange fill without painting the antialiased card silhouette edge */
-  .pcard-fill{position:absolute;top:1px;right:1px;bottom:1px;left:1px;background:var(--color-atomic-tangerine);
-    opacity:0;transition:opacity .35s var(--ease)}
-  .pcard:hover .pcard-fill{opacity:1}
-  /* bottom-right notch corner accent */
+  /* diagonal orange fill that slides in from top-left; clip-path lives on .pcard-clip wrapper */
+  .pcard-fill{position:absolute;inset:0;background:var(--color-atomic-tangerine);
+    -webkit-mask-image:linear-gradient(135deg,#000 0%,#000 50%,transparent 50%,transparent 100%);
+    mask-image:linear-gradient(135deg,#000 0%,#000 50%,transparent 50%,transparent 100%);
+    -webkit-mask-size:300% 300%;mask-size:300% 300%;
+    -webkit-mask-position:100% 100%;mask-position:100% 100%;
+    transition:mask-position .55s var(--ease),-webkit-mask-position .55s var(--ease)}
+  .pcard:hover .pcard-fill{-webkit-mask-position:0% 0%;mask-position:0% 0%}
+  /* notch corner accents — sit outside the clip wrapper */
   .pcard-notch{position:absolute;width:calc(var(--notch) * 1.8);height:calc(var(--notch) * 1.8);pointer-events:none}
   .pcard-notch::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,transparent calc(50% - 1px),var(--color-atomic-tangerine) calc(50% - 1px),var(--color-atomic-tangerine) calc(50% + 1px),transparent calc(50% + 1px))}
+  .pcard-notch.tl{top:-6px;left:-6px}
   .pcard-notch.br{bottom:-6px;right:-6px}
   .pcard-body{position:relative;height:100%;padding:36px 36px 32px;display:flex;flex-direction:column;color:var(--color-graphite);z-index:1}
   .pcard-ghost{position:absolute;font-family:var(--font-display);font-size:clamp(110px,15vw,200px);color:var(--color-graphite);opacity:.07;top:18px;left:24px;line-height:1;letter-spacing:-4px;pointer-events:none;transition:color .35s var(--ease),opacity .35s var(--ease)}
@@ -126,7 +131,8 @@
 
     /* React scroll/hover fill state (mirrors :hover; see ProjectsSection) */
     .pcard[data-fill-active='true'] .pcard-fill {
-      opacity: 1;
+      -webkit-mask-position: 0% 0%;
+      mask-position: 0% 0%;
     }
 
     .pcard[data-fill-active='true'] .pcard-ghost {

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -84,12 +84,12 @@
   .proj-edge{flex-shrink:0;width:calc(50vw - min(280px, 39vw))}
   .pcard{--notch:22px;flex-shrink:0;width:min(560px,78vw);height:min(640px,76vh);position:relative;cursor:pointer;
     transition:transform .35s var(--ease);will-change:transform}
+  .pcard-clip{position:absolute;inset:0;overflow:hidden;
+    clip-path:polygon(var(--notch) 0, 100% 0, 100% calc(100% - var(--notch)), calc(100% - var(--notch)) 100%, 0 100%, 0 var(--notch))}
   .pcard-bg{position:absolute;inset:0;background:var(--color-platinum);
-    clip-path:polygon(var(--notch) 0, 100% 0, 100% calc(100% - var(--notch)), calc(100% - var(--notch)) 100%, 0 100%, 0 var(--notch));
     transition:transform .35s var(--ease)}
   /* diagonal orange fill that slides in from top-left */
   .pcard-fill{position:absolute;inset:0;background:var(--color-atomic-tangerine);
-    clip-path:polygon(var(--notch) 0, 100% 0, 100% calc(100% - var(--notch)), calc(100% - var(--notch)) 100%, 0 100%, 0 var(--notch));
     -webkit-mask-image:linear-gradient(135deg,#000 0%,#000 50%,transparent 50%,transparent 100%);
     mask-image:linear-gradient(135deg,#000 0%,#000 50%,transparent 50%,transparent 100%);
     -webkit-mask-size:300% 300%;mask-size:300% 300%;

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -88,14 +88,10 @@
     clip-path:polygon(var(--notch) 0, 100% 0, 100% calc(100% - var(--notch)), calc(100% - var(--notch)) 100%, 0 100%, 0 var(--notch))}
   .pcard-bg{position:absolute;inset:0;background:var(--color-platinum);
     transition:transform .35s var(--ease)}
-  /* diagonal orange fill that slides in from top-left */
+  /* clipped orange fill without the left-edge diagonal reveal */
   .pcard-fill{position:absolute;inset:0;background:var(--color-atomic-tangerine);
-    -webkit-mask-image:linear-gradient(135deg,#000 0%,#000 50%,transparent 50%,transparent 100%);
-    mask-image:linear-gradient(135deg,#000 0%,#000 50%,transparent 50%,transparent 100%);
-    -webkit-mask-size:300% 300%;mask-size:300% 300%;
-    -webkit-mask-position:100% 100%;mask-position:100% 100%;
-    transition:mask-position .55s var(--ease),-webkit-mask-position .55s var(--ease)}
-  .pcard:hover .pcard-fill{-webkit-mask-position:0% 0%;mask-position:0% 0%}
+    opacity:0;transition:opacity .35s var(--ease)}
+  .pcard:hover .pcard-fill{opacity:1}
   /* notch corner accents — sit outside */
   .pcard-notch{position:absolute;width:calc(var(--notch) * 1.8);height:calc(var(--notch) * 1.8);pointer-events:none}
   .pcard-notch::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,transparent calc(50% - 1px),var(--color-atomic-tangerine) calc(50% - 1px),var(--color-atomic-tangerine) calc(50% + 1px),transparent calc(50% + 1px))}
@@ -131,8 +127,7 @@
 
     /* React scroll/hover fill state (mirrors :hover; see ProjectsSection) */
     .pcard[data-fill-active='true'] .pcard-fill {
-      -webkit-mask-position: 0% 0%;
-      mask-position: 0% 0%;
+      opacity: 1;
     }
 
     .pcard[data-fill-active='true'] .pcard-ghost {


### PR DESCRIPTION
## Purpose
Fix orange diagonal hover/focus fill bleeding past the project card's right edge.

## What it does
Wraps `pcard-bg` and `pcard-fill` in a `.pcard-clip` container that clips overflow to the notched card silhouette, while keeping corner notch accents as siblings outside the clip wrapper.

## Changes
- `ProjectsSection.tsx`: nest bg + fill inside `.pcard-clip`; notches remain direct children of `.pcard`
- `portfolio.css`: add `.pcard-clip` with `overflow:hidden` + shared `clip-path`; remove redundant clip-path from bg/fill children
- Tests: assert fill-inside-clip / notches-outside DOM structure and `.pcard-clip` CSS rule

## Notes
- Hover and `[data-fill-active='true']` mask-position rules unchanged
- Card lift animation (`y: -4`) unchanged
- No `overflow:hidden` on `.pcard` root (preserves notch accents)

Closes #277

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Projects project-card fill reveal and clipping behavior by moving clipping responsibility to a dedicated wrapper and keeping the fill layer properly hidden from assistive technologies.
  * Enhanced interaction handling so hover/unhover and keyboard focus reliably maintain the correct active state without leaving stale visuals.

* **Tests**
  * Expanded project-card interaction and DOM-structure tests to validate active/fill-active transitions, wrapper nesting, and rapid hover/unhover stability.
  * Updated CSS rule assertions to cover the new clipping and mask-reveal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->