### PR TITLE
Loading screen: vanilla CSS boot animation

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -357,6 +357,16 @@ describe('App shell', () => {
       expect(nameLines?.[1]?.textContent).toBe('')
     })
 
+    it('does not wrap the loading screen in framer-motion AnimatePresence (issue #283)', async () => {
+      const { readFile } = await import('node:fs/promises')
+      const { resolve } = await import('node:path')
+      const appPath = resolve(process.cwd(), 'src/App.tsx')
+      const appSource = await readFile(appPath, 'utf-8')
+
+      expect(appSource).not.toMatch(/framer-motion/)
+      expect(appSource).not.toMatch(/AnimatePresence/)
+    })
+
     it('starts hero intro from the beginning after loading completes', async () => {
       render(<App />)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { AnimatePresence } from 'framer-motion'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/react'
 import './index.css'
@@ -64,9 +63,7 @@ function App() {
 
   return (
     <>
-      <AnimatePresence>
-        {loading && <LoadingScreen onComplete={() => setLoading(false)} />}
-      </AnimatePresence>
+      {loading && <LoadingScreen onComplete={() => setLoading(false)} />}
       <Navbar />
       <main>
         <HeroSection introReady={!loading} />


### PR DESCRIPTION
## Purpose

Finish migrating the boot/loading screen off framer-motion so it is a fully vanilla CSS + JS implementation, per the issue's acceptance criteria.

## What it does

Investigation showed `LoadingScreen.tsx` was already implemented as vanilla CSS/JS in a prior change: the progress bar fills via a CSS `@keyframes lf` rule (2.8s), terminal status messages cycle via `useState` + `setInterval`, and the fade-out is a `.out` CSS class toggle with an opacity transition (0.6s) — matching `ideas/Portfolio.html` and `LoadingScreen.test.tsx` already passing with no framer-motion mocks.

The one remaining framer-motion dependency tied to the loading screen lived in `App.tsx`, which wrapped the conditionally-rendered `<LoadingScreen>` in framer-motion's `<AnimatePresence>` — dead weight since `LoadingScreen` has no `motion` components or `exit` prop. This PR removes that wrapper so the boot screen's mount/unmount in the app shell is plain JSX, with zero framer-motion involvement.

## Changes made

- `src/App.tsx` — removed the `AnimatePresence` import and wrapper around `<LoadingScreen>`; replaced with a plain conditional render (`{loading && <LoadingScreen onComplete={...} />}`).
- `src/App.test.tsx` — added a regression test asserting `App.tsx` contains no `framer-motion` / `AnimatePresence` references, to guard against regressions.

## Additional notes

- `src/components/LoadingScreen.tsx`, `LoadingScreen.constants.ts`, and `LoadingScreen.test.tsx` required no changes — they already satisfied every acceptance criterion (CSS `@keyframes` progress bar, `setInterval` message cycling, `.out` CSS fade-out, no framer-motion imports, timing matching the reference `ideas/Portfolio.html`).
- `npm run typecheck` passes clean.
- `npm run test` passes: 456/456 tests (455 pre-existing + 1 new regression test).
- `npm run lint` reports 12 pre-existing errors in `src/hooks/useScrollProgress.ts` and `useTimelineScroll.ts` (react-hooks/refs) — confirmed present on `main` before this change (verified via `git stash`), unrelated to this fix and out of scope for issue #283.

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified loading screen rendering logic.

* **Tests**
  * Added test to verify animation dependencies are not used in the loading sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->