### PR TITLE
Hero section: typewriter chain + fade-up without framer-motion

### DIFF
--- a/src/components/HeroSection.constants.ts
+++ b/src/components/HeroSection.constants.ts
@@ -1,5 +1,3 @@
-import type { Variants } from 'framer-motion'
-
 export const ROLES = ['CS_STUDENT', 'DEVELOPER', 'BUILDER', 'DEBUGGER', 'PROBLEM_SOLVER']
 export const VALUE_PROP = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
 
@@ -9,16 +7,5 @@ export const NAME_SPEED = 40
 
 export const VALUE_PROP_SPEED = 35
 
-export const CTA_FADE_DURATION = 0.4
-
-export const cursorVariants: Variants = {
-  blink: {
-    opacity: [1, 1, 0, 0, 1],
-    transition: {
-      duration: 1,
-      ease: 'linear',
-      repeat: Infinity,
-      times: [0, 0.49, 0.5, 0.99, 1],
-    },
-  },
-}
+/** Stagger (ms) applied between the CTA buttons' CSS fade-up animation delays. */
+export const CTA_FADE_STAGGER_MS = 100

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -2,13 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
 import HeroSection from './HeroSection'
 import {
+  CTA_FADE_STAGGER_MS,
   FIRST_NAME,
   LAST_NAME,
   NAME_SPEED,
   ROLES,
   VALUE_PROP,
   VALUE_PROP_SPEED,
-  cursorVariants,
 } from './HeroSection.constants'
 
 const FIRST_NAME_DURATION = FIRST_NAME.length * NAME_SPEED
@@ -191,6 +191,29 @@ describe('HeroSection', () => {
     expect(nameLines[1]?.contains(cursor)).toBe(true)
   })
 
+  it('renders the name cursor using the CSS blink-cursor animation, not an inline JS animation', () => {
+    render(<HeroSection />)
+
+    advanceToNameComplete()
+
+    const cursor = screen.getByTestId('hero-name-cursor')
+    expect(cursor).toHaveClass('cursor')
+    expect(cursor).not.toHaveAttribute('style')
+  })
+
+  it('renders the value-prop cursor using the same CSS cursor class', () => {
+    render(<HeroSection />)
+
+    advanceToValuePropStart()
+    act(() => {
+      vi.advanceTimersByTime(VALUE_PROP_SPEED)
+    })
+
+    const cursor = screen.getByTestId('value-prop-cursor')
+    expect(cursor).toHaveClass('cursor')
+    expect(cursor).not.toHaveAttribute('style')
+  })
+
   it('types FARHAN completely before MOHAMMED begins', () => {
     render(<HeroSection />)
 
@@ -224,18 +247,18 @@ describe('HeroSection', () => {
     expect(screen.getByTestId('value-prop')).toHaveClass('hero-tag')
   })
 
-  it('uses a step-like one-second blink animation for the cursor', () => {
-    const blink = cursorVariants.blink
+  it('fades up the CTAs using the CSS hero-fade animation class with a staggered delay', () => {
+    render(<HeroSection />)
 
-    expect(blink).toMatchObject({
-      opacity: [1, 1, 0, 0, 1],
-      transition: {
-        duration: 1,
-        ease: 'linear',
-        repeat: Infinity,
-        times: [0, 0.49, 0.5, 0.99, 1],
-      },
-    })
+    advanceToValuePropComplete()
+
+    const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
+    const viewResume = screen.getByRole('link', { name: /VIEW_RESUME →/i })
+
+    expect(viewWork).toHaveClass('hero-fade')
+    expect(viewResume).toHaveClass('hero-fade')
+    expect(viewWork.style.animationDelay).toBe('')
+    expect(viewResume.style.animationDelay).toBe(`${CTA_FADE_STAGGER_MS}ms`)
   })
 
   it('CTAs are absent before sequence completes', () => {

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,24 +1,17 @@
 import { useState } from 'react'
-import { motion } from 'framer-motion'
 import { StickySection } from './StickySection'
 import { TypeIn } from '../animations/TypeIn'
 import { RotatingRole } from '../animations/RotatingRole'
 import {
-  CTA_FADE_DURATION,
+  CTA_FADE_STAGGER_MS,
   FIRST_NAME,
   LAST_NAME,
   NAME_SPEED,
   ROLES,
   VALUE_PROP,
   VALUE_PROP_SPEED,
-  cursorVariants,
 } from './HeroSection.constants'
 import { handleSectionLinkClick } from '../utils/smoothScrollTo'
-
-const ctaVariants = {
-  hidden: { opacity: 0, y: 8 },
-  visible: { opacity: 1, y: 0 },
-}
 
 interface HeroSectionProps {
   introReady?: boolean
@@ -69,13 +62,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ introReady = true }) => {
               }}
             />
             {showNameCursor && (
-              <motion.span
-                data-testid="hero-name-cursor"
-                aria-hidden="true"
-                className="inline-block w-[3px] h-[1.2em] bg-atomic-tangerine align-middle ml-1"
-                variants={cursorVariants}
-                animate="blink"
-              />
+              <span data-testid="hero-name-cursor" aria-hidden="true" className="cursor" />
             )}
           </span>
         </h1>
@@ -100,27 +87,15 @@ const HeroSection: React.FC<HeroSectionProps> = ({ introReady = true }) => {
             }}
           />
           {startValueProp && !valuePropDone && (
-            <motion.span
-              data-testid="value-prop-cursor"
-              aria-hidden="true"
-              className="inline-block w-[3px] h-[1em] bg-atomic-tangerine align-middle ml-0.5"
-              variants={cursorVariants}
-              animate="blink"
-            />
+            <span data-testid="value-prop-cursor" aria-hidden="true" className="cursor" />
           )}
         </p>
 
         {showCTAs && (
-          <motion.div
-            initial="hidden"
-            animate="visible"
-            variants={ctaVariants}
-            transition={{ duration: CTA_FADE_DURATION }}
-            className="hero-cta"
-          >
+          <div className="hero-cta">
             <a
               href="#projects"
-              className="btn btn-fill"
+              className="btn btn-fill hero-fade"
               onClick={(event) => handleSectionLinkClick(event, 'projects')}
             >
               VIEW_WORK <span>→</span>
@@ -129,11 +104,12 @@ const HeroSection: React.FC<HeroSectionProps> = ({ introReady = true }) => {
               href="/resume.pdf"
               target="_blank"
               rel="noopener noreferrer"
-              className="btn btn-outline"
+              className="btn btn-outline hero-fade"
+              style={{ animationDelay: `${CTA_FADE_STAGGER_MS}ms` }}
             >
               VIEW_RESUME <span>→</span>
             </a>
-          </motion.div>
+          </div>
         )}
       </div>
     </StickySection>


### PR DESCRIPTION
## Purpose

Issue #284 asked for the Hero section's boot-sequence animation chain (typewriter + fade-up) to run on pure vanilla JS/CSS, with no framer-motion left in `HeroSection.tsx` or anywhere in `src/animations/`.

## What it does

Investigation showed `TypeIn`, `RotatingRole`, `Typewriter`, `useTypewriter`, and `variants.ts` in `src/animations/` were already framer-motion-free (state/`setTimeout` chains and plain object literals). The only remaining framer-motion usage was inside `HeroSection.tsx` itself: a `motion.span` for the blinking name/value-prop cursor, and a `motion.div` wrapper for the CTA fade-in. This PR removes both.

- The name cursor and value-prop cursor now render as plain `<span className="cursor" />`, relying on the existing `.cursor` / `@keyframes blink-cursor` rules already defined in `src/portfolio.css` (orange block cursor, steps-based blink).
- The CTA row no longer uses a `motion.div`. Each CTA `<a>` now carries the existing `.hero-fade` class (`@keyframes fade-up` already in `portfolio.css`), with the second button getting an inline `animationDelay` (driven by a new `CTA_FADE_STAGGER_MS` constant) so the two buttons stagger in.
- `cursorVariants` (a framer-motion `Variants` object) was removed from `HeroSection.constants.ts` since nothing references it anymore.

`"VIEW_WORK"` smooth-scroll-to-projects and `"VIEW_RESUME"` open-resume-in-new-tab behavior were already implemented and unchanged.

## Changes made

- `src/components/HeroSection.tsx` — removed `framer-motion` import; replaced `motion.span` cursors with CSS `.cursor` spans; replaced `motion.div` CTA wrapper with a plain `div.hero-cta` and per-link `.hero-fade` + staggered `animationDelay`.
- `src/components/HeroSection.constants.ts` — removed `framer-motion` import and `cursorVariants`; added `CTA_FADE_STAGGER_MS`.
- `src/components/HeroSection.test.tsx` — replaced the framer-motion-variant-shape assertion with tests that the cursor spans use the `.cursor` class (no inline animation props) and that CTAs use `.hero-fade` with the expected staggered `animationDelay`.

## Additional notes

- `TypeIn.tsx`, `RotatingRole.tsx`, `Typewriter.tsx`, `useTypewriter.ts`, and `variants.ts` required no changes — they were already vanilla `useState`/`setTimeout` implementations with no framer-motion imports, so the "no framer-motion in `src/animations/`" acceptance criterion was already satisfied going in.
- Kept the tagline (`// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.`) as a character-by-character `TypeIn` typewriter rather than converting it to a fade-up, since that behavior was already vanilla and covered by existing tests; the issue's actionable gap was framer-motion removal, not changing which reveal style the tagline uses.
- `ideas/Portfolio.html` (referenced in the issue as the visual source of truth) does not exist in this repo/branch, so visual parity was verified against the existing CSS classes (`.cursor`, `.hero-fade`, `.hero-cta`, etc.) and current test expectations rather than a literal file diff.
- `framer-motion` remains a `package.json` dependency since other components (`Navbar`, `MobileMenu`, `ProjectsSection`, `ContactSection`, `App`) still use it; removing the dependency entirely is out of scope for this issue.
- `npm run typecheck` and `npm run test` (456 tests across 36 files) pass. `npm run lint` shows the same 12 pre-existing errors present on `main` (in unrelated hook files), confirmed unaffected by this change.

Closes #284