### PR TITLE
Loading screen: vanilla CSS boot animation

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest'
 import { act, render } from '@testing-library/react'
 import App from './App'
@@ -7,6 +9,9 @@ import {
 } from './components/LoadingScreen.constants'
 import { FIRST_NAME, NAME_SPEED } from './components/HeroSection.constants'
 import { SECTIONS, type SectionId } from './data/sections'
+
+const appSourcePath = path.resolve(__dirname, './App.tsx')
+const appSource = readFileSync(appSourcePath, 'utf-8')
 
 const sectionIds = SECTIONS.map((section) => section.id)
 const sections = sectionIds satisfies readonly SectionId[]
@@ -331,6 +336,24 @@ describe('App shell', () => {
       expect(projects.style.transform).toBe('')
       expect(projects.style.transform).not.toContain('translateX')
       expect(carouselTrack.style.transform).toContain('translateX')
+    })
+  })
+
+  describe('issue #283 - loading screen vanilla CSS boot animation', () => {
+    it('renders the loading screen via plain conditional rendering, not AnimatePresence', () => {
+      expect(appSource).not.toMatch(/framer-motion/)
+      expect(appSource).not.toMatch(/AnimatePresence/)
+      expect(appSource).toMatch(/\{loading\s*&&\s*<LoadingScreen/)
+    })
+
+    it('still renders the loading screen on mount', () => {
+      render(<App />)
+      expect(document.getElementById('ls')).toBeInTheDocument()
+    })
+
+    it('still renders Analytics and SpeedInsights alongside the loading screen', () => {
+      expect(appSource).toMatch(/@vercel\/analytics/)
+      expect(appSource).toMatch(/@vercel\/speed-insights/)
     })
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import { AnimatePresence } from 'framer-motion'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/react'
 import './index.css'
@@ -64,9 +63,7 @@ function App() {
 
   return (
     <>
-      <AnimatePresence>
-        {loading && <LoadingScreen onComplete={() => setLoading(false)} />}
-      </AnimatePresence>
+      {loading && <LoadingScreen onComplete={() => setLoading(false)} />}
       <Navbar />
       <main>
         <HeroSection introReady={!loading} />


### PR DESCRIPTION
## Purpose
Remove a vestigial `AnimatePresence` wrapper around `LoadingScreen` in `App.tsx`, since the component already manages its own fade-out via vanilla CSS and has no framer-motion dependency.

## What it does
Replaces `<AnimatePresence>{loading && <LoadingScreen .../>}</AnimatePresence>` with a plain conditional render `{loading && <LoadingScreen .../>}`. `LoadingScreen.tsx` itself was already framer-motion-free (CSS `@keyframes lf` for the progress bar, `setTimeout`/`setInterval` for message cycling, `.out` class for fade-out), so removing the wrapper has no visual effect.

## Changes made
- `src/App.tsx` — removed `import { AnimatePresence } from 'framer-motion'` and the `<AnimatePresence>` wrapper around `LoadingScreen`; replaced with plain `{loading && <LoadingScreen onComplete={...} />}`.
- `src/App.test.tsx` — added a regression test asserting `App.tsx` source contains no `framer-motion`/`AnimatePresence` references and uses the `{loading && <LoadingScreen` conditional pattern, plus coverage that the loading screen still mounts and that `@vercel/analytics`/`@vercel/speed-insights` remain present.

## Additional notes
- `@vercel/analytics` and `@vercel/speed-insights` were left untouched per the issue's acceptance criteria.
- This issue is scoped narrowly to the `App.tsx` wiring; other framer-motion usages noted in `PRD.md` (HeroSection, Navbar, MobileMenu, ContactSection, variants.ts) are out of scope here and left for follow-up issues.
- `npm run typecheck` passes; full suite `npm run test` passes (483/483). Pre-existing `npm run lint` errors in `useScrollProgress.ts`/`useTimelineScroll.ts` (react-hooks/refs) are unrelated to this change and present on `main` before this branch.

Closes #283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Loading screen animation updated to use vanilla CSS for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->