### PR TITLE
Hero section: typewriter chain + fade-up without framer-motion

### DIFF
--- a/src/components/HeroSection.constants.ts
+++ b/src/components/HeroSection.constants.ts
@@ -1,5 +1,3 @@
-import type { Variants } from 'framer-motion'
-
 export const ROLES = ['CS_STUDENT', 'DEVELOPER', 'BUILDER', 'DEBUGGER', 'PROBLEM_SOLVER']
 export const VALUE_PROP = '// I BUILD THINGS THAT ARE FUN TO FIGURE OUT.'
 
@@ -8,17 +6,3 @@ export const LAST_NAME = 'MOHAMMED'
 export const NAME_SPEED = 40
 
 export const VALUE_PROP_SPEED = 35
-
-export const CTA_FADE_DURATION = 0.4
-
-export const cursorVariants: Variants = {
-  blink: {
-    opacity: [1, 1, 0, 0, 1],
-    transition: {
-      duration: 1,
-      ease: 'linear',
-      repeat: Infinity,
-      times: [0, 0.49, 0.5, 0.99, 1],
-    },
-  },
-}

--- a/src/components/HeroSection.test.tsx
+++ b/src/components/HeroSection.test.tsx
@@ -8,7 +8,6 @@ import {
   ROLES,
   VALUE_PROP,
   VALUE_PROP_SPEED,
-  cursorVariants,
 } from './HeroSection.constants'
 
 const FIRST_NAME_DURATION = FIRST_NAME.length * NAME_SPEED
@@ -224,18 +223,36 @@ describe('HeroSection', () => {
     expect(screen.getByTestId('value-prop')).toHaveClass('hero-tag')
   })
 
-  it('uses a step-like one-second blink animation for the cursor', () => {
-    const blink = cursorVariants.blink
+  it('drives the name cursor blink with the CSS .cursor class, not framer-motion', () => {
+    render(<HeroSection />)
 
-    expect(blink).toMatchObject({
-      opacity: [1, 1, 0, 0, 1],
-      transition: {
-        duration: 1,
-        ease: 'linear',
-        repeat: Infinity,
-        times: [0, 0.49, 0.5, 0.99, 1],
-      },
-    })
+    advanceToNameComplete()
+
+    const cursor = screen.getByTestId('hero-name-cursor')
+    expect(cursor).toHaveClass('cursor')
+    expect(cursor.tagName).toBe('SPAN')
+  })
+
+  it('drives the value-prop cursor blink with the CSS .cursor class', () => {
+    render(<HeroSection />)
+
+    advanceToValuePropStart()
+    advanceRoleTyping(ROLES[1])
+
+    const cursor = screen.getByTestId('value-prop-cursor')
+    expect(cursor).toHaveClass('cursor')
+    expect(cursor.tagName).toBe('SPAN')
+  })
+
+  it('applies the CSS .hero-fade class to the CTA row instead of framer-motion', () => {
+    render(<HeroSection />)
+
+    advanceToValuePropComplete()
+
+    const viewWork = screen.getByRole('link', { name: /VIEW_WORK →/i })
+    const ctaRow = viewWork.parentElement
+
+    expect(ctaRow).toHaveClass('hero-fade')
   })
 
   it('CTAs are absent before sequence completes', () => {

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,24 +1,16 @@
 import { useState } from 'react'
-import { motion } from 'framer-motion'
 import { StickySection } from './StickySection'
 import { TypeIn } from '../animations/TypeIn'
 import { RotatingRole } from '../animations/RotatingRole'
 import {
-  CTA_FADE_DURATION,
   FIRST_NAME,
   LAST_NAME,
   NAME_SPEED,
   ROLES,
   VALUE_PROP,
   VALUE_PROP_SPEED,
-  cursorVariants,
 } from './HeroSection.constants'
 import { handleSectionLinkClick } from '../utils/smoothScrollTo'
-
-const ctaVariants = {
-  hidden: { opacity: 0, y: 8 },
-  visible: { opacity: 1, y: 0 },
-}
 
 interface HeroSectionProps {
   introReady?: boolean
@@ -69,13 +61,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ introReady = true }) => {
               }}
             />
             {showNameCursor && (
-              <motion.span
-                data-testid="hero-name-cursor"
-                aria-hidden="true"
-                className="inline-block w-[3px] h-[1.2em] bg-atomic-tangerine align-middle ml-1"
-                variants={cursorVariants}
-                animate="blink"
-              />
+              <span data-testid="hero-name-cursor" aria-hidden="true" className="cursor" />
             )}
           </span>
         </h1>
@@ -100,24 +86,12 @@ const HeroSection: React.FC<HeroSectionProps> = ({ introReady = true }) => {
             }}
           />
           {startValueProp && !valuePropDone && (
-            <motion.span
-              data-testid="value-prop-cursor"
-              aria-hidden="true"
-              className="inline-block w-[3px] h-[1em] bg-atomic-tangerine align-middle ml-0.5"
-              variants={cursorVariants}
-              animate="blink"
-            />
+            <span data-testid="value-prop-cursor" aria-hidden="true" className="cursor" />
           )}
         </p>
 
         {showCTAs && (
-          <motion.div
-            initial="hidden"
-            animate="visible"
-            variants={ctaVariants}
-            transition={{ duration: CTA_FADE_DURATION }}
-            className="hero-cta"
-          >
+          <div className="hero-cta hero-fade">
             <a
               href="#projects"
               className="btn btn-fill"
@@ -133,7 +107,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ introReady = true }) => {
             >
               VIEW_RESUME <span>→</span>
             </a>
-          </motion.div>
+          </div>
         )}
       </div>
     </StickySection>


### PR DESCRIPTION
## Purpose
Continue the framer-motion removal effort (tracked in PRD.md) by replacing the last three framer-motion usages in `HeroSection.tsx` with the vanilla-CSS equivalents that already exist in `portfolio.css`.

## What it does
Removes `framer-motion` from the hero typewriter/CTA sequence. The typewriter chain (`TypeIn`, `RotatingRole`) was already pure React and is untouched; only the blinking cursors and CTA fade-up animation change implementation, with identical visual behavior driven by CSS keyframes instead of framer-motion variants.

## Changes made
- `src/components/HeroSection.tsx`:
  - `hero-name-cursor` and `value-prop-cursor`: `motion.span` with `cursorVariants` → plain `<span className="cursor">`, using the existing `.cursor` class + `@keyframes blink-cursor` (portfolio.css line 186-187)
  - CTA row: `motion.div` with `ctaVariants`/`transition` → plain `<div className="hero-cta hero-fade">`, using the existing `.hero-fade` class + `@keyframes fade-up` (portfolio.css line 188-189)
  - Removed the `framer-motion` import and the local `ctaVariants` object
- `src/components/HeroSection.constants.ts`:
  - Removed `import type { Variants } from 'framer-motion'`
  - Deleted `cursorVariants` (no longer referenced) and `CTA_FADE_DURATION` (timing is now hardcoded in the CSS `@keyframes`)
- `src/components/HeroSection.test.tsx`:
  - Removed the `cursorVariants` import and the test asserting its framer-motion transition shape
  - Added three tests asserting the cursors and CTA row carry the `.cursor` / `.hero-fade` CSS classes instead

## Additional notes
- `VIEW_WORK` smooth-scroll and `VIEW_RESUME` new-tab behavior are unchanged (not touched by this diff).
- Other framer-motion usages called out in the PRD (`App.tsx`, `ContactSection.tsx`, `ProjectsSection.tsx`, `Navbar.tsx`, `MobileMenu.tsx`) are out of scope for this issue and left untouched.
- Verified `npm run typecheck` (clean) and `npm run test` (482/482 passing, including 3 new tests and all 29 in `HeroSection.test.tsx`). `npm run lint` shows pre-existing, unrelated errors in `useScrollProgress.ts`/`useTimelineScroll.ts`; no lint issues in any file touched here.

Closes #284