### PR TITLE
Navbar active state + mobile hamburger overlay

### DIFF
--- a/src/components/MobileMenu.test.tsx
+++ b/src/components/MobileMenu.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobileMenu from './MobileMenu'
+
+const LINKS = [
+  { label: 'HOME', href: '#home' },
+  { label: 'PROJECTS', href: '#projects' },
+  { label: 'SKILLS', href: '#skills' },
+  { label: 'TIMELINE', href: '#timeline' },
+  { label: 'CONTACT', href: '#contact' },
+]
+
+function renderMenu(isOpen: boolean, onClose = vi.fn()) {
+  return render(<MobileMenu isOpen={isOpen} onClose={onClose} links={LINKS} />)
+}
+
+describe('MobileMenu', () => {
+  it('stays mounted in the DOM when closed, but hidden from the accessibility tree', () => {
+    renderMenu(false)
+
+    const dialog = screen.queryByRole('dialog', { hidden: true })
+    expect(dialog).not.toBeNull()
+    expect(dialog).toHaveAttribute('aria-hidden', 'true')
+    expect(dialog).toHaveAttribute('inert')
+
+    // Not exposed via accessible role queries while closed.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('removes aria-hidden/inert and exposes the dialog when open', () => {
+    renderMenu(true)
+
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).not.toHaveAttribute('aria-hidden')
+    expect(dialog).not.toHaveAttribute('inert')
+  })
+
+  it('renders all provided nav links when open', () => {
+    renderMenu(true)
+
+    const dialog = screen.getByRole('dialog')
+    const links = within(dialog).getAllByRole('link')
+    const hrefs = links.map((l) => l.getAttribute('href'))
+
+    for (const { href, label } of LINKS) {
+      expect(hrefs).toContain(href)
+      expect(within(dialog).getByText(label)).toBeInTheDocument()
+    }
+  })
+
+  it('calls onClose when a nav link is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderMenu(true, onClose)
+
+    const dialog = screen.getByRole('dialog')
+    await user.click(within(dialog).getByRole('link', { name: 'HOME' }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the close button is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    renderMenu(true, onClose)
+
+    await user.click(screen.getByRole('button', { name: /close menu/i }))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not use framer-motion AnimatePresence mount/unmount for the overlay', () => {
+    renderMenu(false)
+    // Overlay element exists in the DOM tree even when closed (CSS-driven visibility).
+    const dialog = document.querySelector('[role="dialog"]')
+    expect(dialog).not.toBeNull()
+  })
+})

--- a/src/components/MobileMenu.tsx
+++ b/src/components/MobileMenu.tsx
@@ -1,5 +1,3 @@
-import { AnimatePresence, motion } from 'framer-motion'
-import { hoverEase } from '../animations/variants'
 import { handleSectionLinkClick } from '../utils/smoothScrollTo'
 
 interface NavLink {
@@ -15,53 +13,37 @@ interface MobileMenuProps {
 
 export default function MobileMenu({ isOpen, onClose, links }: MobileMenuProps) {
   return (
-    <AnimatePresence>
-      {isOpen && (
-        <motion.div
-          role="dialog"
-          aria-modal="true"
-          aria-label="Mobile navigation"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.25 }}
-          className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-graphite"
-        >
-          <motion.button
-            onClick={onClose}
-            aria-label="Close menu"
-            variants={hoverEase}
-            initial="idle"
-            whileHover="hover"
-            className="absolute top-5 right-6 text-periwinkle"
-          >
-            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-              <line x1="18" y1="6" x2="6" y2="18" />
-              <line x1="6" y1="6" x2="18" y2="18" />
-            </svg>
-          </motion.button>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Mobile navigation"
+      aria-hidden={isOpen ? undefined : true}
+      inert={isOpen ? undefined : true}
+      className={`mobile-menu${isOpen ? ' mobile-menu-open' : ''}`}
+    >
+      <button onClick={onClose} aria-label="Close menu" className="mobile-menu-close">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
 
-          <ul className="flex flex-col gap-8 list-none items-center p-0 m-0">
-            {links.map(({ label, href }) => (
-              <li key={label}>
-                <motion.a
-                  href={href}
-                  onClick={(event) => {
-                    handleSectionLinkClick(event, href.slice(1))
-                    onClose()
-                  }}
-                  variants={hoverEase}
-                  initial="idle"
-                  whileHover="hover"
-                  className="font-body text-2xl text-periwinkle no-underline"
-                >
-                  {label}
-                </motion.a>
-              </li>
-            ))}
-          </ul>
-        </motion.div>
-      )}
-    </AnimatePresence>
+      <ul className="mobile-menu-list">
+        {links.map(({ label, href }) => (
+          <li key={label}>
+            <a
+              href={href}
+              onClick={(event) => {
+                handleSectionLinkClick(event, href.slice(1))
+                onClose()
+              }}
+              className="mobile-menu-link"
+            >
+              {label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -37,6 +37,14 @@ function dispatchScrollUpdate() {
   })
 }
 
+// Mobile menu now stays permanently mounted in the DOM (CSS-driven visibility),
+// so desktop-nav-link assertions must be scoped to the desktop <nav> to avoid
+// matching the duplicate links rendered inside the mobile menu.
+function getDesktopNavText(text: string) {
+  const nav = screen.getByRole('navigation')
+  return within(nav).getByText(text)
+}
+
 describe('Navbar', () => {
   beforeEach(() => {
     Object.defineProperty(window, 'innerHeight', {
@@ -69,7 +77,7 @@ describe('Navbar', () => {
   it('shows label text for all registry nav links', () => {
     render(<Navbar />)
     for (const label of expectedNavLabels) {
-      expect(screen.getByText(label)).toBeInTheDocument()
+      expect(getDesktopNavText(label)).toBeInTheDocument()
     }
   })
 
@@ -135,9 +143,9 @@ describe('Navbar', () => {
       render(<Navbar />)
       dispatchScrollUpdate()
 
-      const skillsLink = screen.getByText('SKILLS').closest('a')
+      const skillsLink = getDesktopNavText('SKILLS').closest('a')
       expect(skillsLink).not.toBeNull()
-      const skillsLabel = screen.getByText('SKILLS')
+      const skillsLabel = getDesktopNavText('SKILLS')
 
       expect(skillsLink).toHaveClass('nav-link', 'active')
       expect(skillsLabel).toHaveClass('nav-label')
@@ -160,10 +168,10 @@ describe('Navbar', () => {
       )
       dispatchScrollUpdate()
 
-      const skillsLink = screen.getByText('SKILLS').closest('a')
-      const skillsLabel = screen.getByText('SKILLS')
-      const projectsLink = screen.getByText('PROJECTS').closest('a')
-      const projectsLabel = screen.getByText('PROJECTS')
+      const skillsLink = getDesktopNavText('SKILLS').closest('a')
+      const skillsLabel = getDesktopNavText('SKILLS')
+      const projectsLink = getDesktopNavText('PROJECTS').closest('a')
+      const projectsLabel = getDesktopNavText('PROJECTS')
 
       expect(skillsLink!.querySelector('[data-testid="nav-caret"]')).not.toBeNull()
       expect(skillsLink).not.toHaveClass('active')
@@ -182,8 +190,8 @@ describe('Navbar', () => {
       render(<Navbar />)
       dispatchScrollUpdate()
 
-      expect(screen.getByText('PROJECTS').closest('a')).toHaveClass('active')
-      expect(screen.getByText('SKILLS').closest('a')).not.toHaveClass('active')
+      expect(getDesktopNavText('PROJECTS').closest('a')).toHaveClass('active')
+      expect(getDesktopNavText('SKILLS').closest('a')).not.toHaveClass('active')
     })
 
     it('keeps TIMELINE active for its owning scroll runway when no internal panel owns the sample line', () => {
@@ -196,8 +204,8 @@ describe('Navbar', () => {
       render(<Navbar />)
       dispatchScrollUpdate()
 
-      expect(screen.getByText('TIMELINE').closest('a')).toHaveClass('active')
-      expect(screen.getByText('CONTACT').closest('a')).not.toHaveClass('active')
+      expect(getDesktopNavText('TIMELINE').closest('a')).toHaveClass('active')
+      expect(getDesktopNavText('CONTACT').closest('a')).not.toHaveClass('active')
     })
   })
 
@@ -257,8 +265,8 @@ describe('Navbar', () => {
       render(<Navbar />)
       dispatchScrollUpdate()
 
-      const skillsLink = screen.getByText('SKILLS').closest('a')
-      const skillsLabel = screen.getByText('SKILLS')
+      const skillsLink = getDesktopNavText('SKILLS').closest('a')
+      const skillsLabel = getDesktopNavText('SKILLS')
 
       expect(skillsLink).toHaveClass('nav-link', 'active')
       expect(skillsLabel).toHaveClass('nav-label')
@@ -339,7 +347,7 @@ describe('Navbar', () => {
         )
         dispatchScrollUpdate()
 
-        expect(screen.getByText('PROJECTS').closest('a')).toHaveClass('active')
+        expect(getDesktopNavText('PROJECTS').closest('a')).toHaveClass('active')
       }
     })
 
@@ -358,7 +366,7 @@ describe('Navbar', () => {
         )
         dispatchScrollUpdate()
 
-        expect(screen.getByText('TIMELINE').closest('a')).toHaveClass('active')
+        expect(getDesktopNavText('TIMELINE').closest('a')).toHaveClass('active')
       }
     })
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,4 @@
 import { useState } from 'react'
-import { motion } from 'framer-motion'
-import { hoverEase } from '../animations/variants'
 import { SECTIONS } from '../data/sections'
 import { useActiveMajorSection } from '../hooks/useActiveMajorSection'
 import { handleSectionLinkClick, smoothScrollToSection } from '../utils/smoothScrollTo'
@@ -50,12 +48,9 @@ export default function Navbar() {
           })}
         </ul>
 
-        <motion.button
-          className="flex md:hidden text-periwinkle"
+        <button
+          className="nav-hamburger flex md:hidden text-periwinkle"
           onClick={() => setMenuOpen(true)}
-          variants={hoverEase}
-          initial="idle"
-          whileHover="hover"
           aria-label="Open menu"
         >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
@@ -63,7 +58,7 @@ export default function Navbar() {
             <line x1="3" y1="12" x2="21" y2="12" />
             <line x1="3" y1="18" x2="21" y2="18" />
           </svg>
-        </motion.button>
+        </button>
       </nav>
 
       <MobileMenu

--- a/src/integration.smoke.test.ts
+++ b/src/integration.smoke.test.ts
@@ -166,11 +166,11 @@ describe('maintainability smoke path (issue #261)', () => {
       })
 
       expect(sectionLinks).toHaveLength(2)
-      expect(screen.getByText('ABOUT US')).toBeInTheDocument()
+      expect(within(nav).getByText('ABOUT US')).toBeInTheDocument()
       expect(links.some((link) => link.getAttribute('href') === '#about')).toBe(true)
       expect(links.filter((link) => link.getAttribute('href') === '#home')).toHaveLength(1)
-      expect(screen.queryByText('PROJECTS')).not.toBeInTheDocument()
-      expect(screen.queryByText('TIMELINE')).not.toBeInTheDocument()
+      expect(within(nav).queryByText('PROJECTS')).not.toBeInTheDocument()
+      expect(within(nav).queryByText('TIMELINE')).not.toBeInTheDocument()
     } finally {
       vi.doUnmock('./data/sections')
       vi.resetModules()

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -44,6 +44,17 @@
   .nav-link:hover .nav-caret,.nav-link.active .nav-caret{opacity:1;transform:translateX(0)}
   .nav-link:hover .nav-label::after,.nav-link.active .nav-label::after{transform:scaleX(1)}
   .nav-link.active .nav-label{color:var(--color-atomic-tangerine)}
+  .nav-hamburger{transition:transform .25s var(--ease);background:none;border:none;cursor:pointer}
+  .nav-hamburger:hover{transform:scale(1.05)}
+
+  /* ─── MOBILE MENU ──── */
+  .mobile-menu{position:fixed;inset:0;z-index:50;display:flex;flex-direction:column;align-items:center;justify-content:center;background:var(--color-graphite);opacity:0;pointer-events:none;transition:opacity .25s var(--ease)}
+  .mobile-menu.mobile-menu-open{opacity:1;pointer-events:auto}
+  .mobile-menu-close{position:absolute;top:20px;right:24px;color:var(--color-periwinkle);background:none;border:none;cursor:pointer;transition:transform .25s var(--ease)}
+  .mobile-menu-close:hover{transform:scale(1.05)}
+  .mobile-menu-list{display:flex;flex-direction:column;align-items:center;gap:32px;list-style:none;padding:0;margin:0}
+  .mobile-menu-link{font-family:var(--font-body);font-size:24px;color:var(--color-periwinkle);text-decoration:none;transition:transform .25s var(--ease)}
+  .mobile-menu-link:hover{transform:scale(1.05)}
 
   /* ─── HERO ──── */
   #home{width:100%;min-height:100vh;display:flex;flex-direction:column;justify-content:center;padding:0 5vw;position:relative;overflow:hidden}


### PR DESCRIPTION
## Purpose
Remove framer-motion from `Navbar.tsx` and `MobileMenu.tsx`, replacing motion-driven hover/overlay animations with CSS transitions consistent with the rest of `portfolio.css`.

## What it does
- Replaces `motion.button` (hamburger) in `Navbar.tsx` with a plain `<button>` using a CSS hover transition.
- Replaces `AnimatePresence` + `motion.div`/`motion.button`/`motion.a` in `MobileMenu.tsx` with a permanently-mounted overlay `<div>` whose visibility is toggled via a `.mobile-menu-open` class (opacity + pointer-events transitions), plus plain `<button>`/`<a>` elements with CSS hover.
- Applies `aria-hidden` and `inert` to the overlay when closed so its contents are excluded from the accessibility tree and are non-interactive while hidden.
- Adds `MobileMenu.test.tsx` covering: overlay stays mounted in the DOM when closed (hidden via `aria-hidden`/`inert`, not unmounted), all links render when open, link click and close-button click both call `onClose`.

## Changes made
- `src/components/Navbar.tsx` — drop framer-motion import / `motion.button`; plain `<button className="nav-hamburger">`.
- `src/components/MobileMenu.tsx` — drop framer-motion / `AnimatePresence`; permanently-mounted `<div role="dialog">` toggled via CSS class, plain `<button>`/`<a>` for close button and nav links.
- `src/portfolio.css` — new rules: `.nav-hamburger`, `.mobile-menu`, `.mobile-menu-open`, `.mobile-menu-close`, `.mobile-menu-list`, `.mobile-menu-link`.
- `src/components/MobileMenu.test.tsx` (new) — tests for mount-persistence, aria-hidden/inert toggling, link rendering, and close behavior.
- `src/components/Navbar.test.tsx` — several pre-existing tests used `screen.getByText(label)` to find nav link text, which became ambiguous once `MobileMenu` started staying mounted in the DOM at all times (its links now have a permanent, hidden DOM presence). Scoped those queries to the desktop `<nav>` via `within(screen.getByRole('navigation'))` to preserve original test intent.
- `src/integration.smoke.test.ts` — same scoping fix for the SECTIONS-registry-propagation test, which had the same ambiguous-query issue.

## Additional notes
- `src/animations/variants.ts` is intentionally left in place — `ContactSection.tsx` still imports `hoverEase` from it, so it wasn't deleted (per the issue's instructions).
- The CSS hover scale (`transform: scale(1.05)`, 0.25s ease) mirrors the previous `hoverEase` framer-motion variant values for visual parity.
- `npm run typecheck` and `npm run test` both pass (486 tests across 38 files).
- No body-scroll-lock behavior was added — the issue did not call for it and it was out of scope.

Closes #285