### PR TITLE
Skills section: 19-tile bento grid with palette tile

### DIFF
--- a/src/components/SkillsSection.test.tsx
+++ b/src/components/SkillsSection.test.tsx
@@ -107,10 +107,10 @@ describe('SkillsSection', () => {
   it('renders bento skill tiles from the reference layout', () => {
     render(<SkillsSection />)
     const required = [
-      'Python', 'TypeScript', 'JavaScript', 'C / C++',
-      'Docker', 'Git',
-      'NumPy', 'Pandas',
-      'FastAPI', 'PyTorch', 'Hugging Face', 'Scikit-learn',
+      'Python', 'TypeScript', 'JavaScript', 'C++', 'C', 'SQL',
+      'Docker', 'Git', 'Linux', 'Ansible', 'Jupyter',
+      'NumPy', 'Pandas', 'Matplotlib',
+      'FastAPI', 'PyTorch', 'Hugging Face', 'Scikit-learn', 'Transformers',
     ]
     for (const skill of required) {
       expect(screen.getByText(skill)).toBeInTheDocument()
@@ -119,7 +119,7 @@ describe('SkillsSection', () => {
 
   it('renders all category label types', () => {
     render(<SkillsSection />)
-    const categories = ['LANGUAGE', 'FRAMEWORK', 'TOOL', 'ML / DL', 'DATA']
+    const categories = ['ML / DL', 'DATA & COMPUTATION', 'LANGUAGES', 'TOOLS & SYSTEMS']
     for (const category of categories) {
       expect(screen.getAllByText(category).length).toBeGreaterThan(0)
     }
@@ -131,14 +131,14 @@ describe('SkillsSection', () => {
     expect(grid).toHaveClass('bento')
   })
 
-  it('renders 12 skill tiles and 1 palette tile with bi class', () => {
+  it('renders 19 skill tiles and 1 palette tile with bi class', () => {
     render(<SkillsSection />)
 
-    const categoryLabels = screen.getAllByText(/^(LANGUAGE|FRAMEWORK|TOOL|ML \/ DL|DATA)$/)
-    expect(categoryLabels).toHaveLength(12)
+    const categoryLabels = screen.getAllByText(/^(ML \/ DL|DATA & COMPUTATION|LANGUAGES|TOOLS & SYSTEMS)$/)
+    expect(categoryLabels).toHaveLength(19)
 
     const biTiles = document.querySelectorAll('.bi')
-    expect(biTiles).toHaveLength(13)
+    expect(biTiles).toHaveLength(20)
   })
 
   it('section header uses hscroll classes with orange slash and pixel font name', () => {
@@ -158,6 +158,9 @@ describe('SkillsSection', () => {
     expect(getSkillTile('Python').className).toContain('c-orange')
     expect(getSkillTile('Python').className).toContain('bi-lg')
 
+    expect(getSkillTile('PyTorch').className).toContain('bi-fl')
+    expect(getSkillTile('PyTorch').className).toContain('bi-lg')
+
     expect(getSkillTile('TypeScript').className).toContain('bi-js')
     expect(getSkillTile('TypeScript').className).toContain('c-blue')
 
@@ -165,21 +168,27 @@ describe('SkillsSection', () => {
     expect(getSkillTile('Docker').className).toContain('c-platinum')
 
     expect(getSkillTile('JavaScript').className).toContain('bi-re')
-    expect(getSkillTile('C / C++').className).toContain('bi-cc')
+    expect(getSkillTile('C++').className).toContain('bi-cc')
+    expect(getSkillTile('C').className).toContain('bi-ci')
+    expect(getSkillTile('SQL').className).toContain('bi-sq')
     expect(getSkillTile('NumPy').className).toContain('bi-nd')
+    expect(getSkillTile('Pandas').className).toContain('bi-pd')
+    expect(getSkillTile('Matplotlib').className).toContain('bi-mp')
     expect(getSkillTile('FastAPI').className).toContain('bi-nx')
-    expect(getSkillTile('PyTorch').className).toContain('bi-fl')
+    expect(getSkillTile('Transformers').className).toContain('bi-tr')
     expect(getSkillTile('Hugging Face').className).toContain('bi-gt')
-    expect(getSkillTile('Scikit-learn').className).toContain('bi-pg')
-    expect(getSkillTile('Pandas').className).toContain('bi-fg')
+    expect(getSkillTile('Scikit-learn').className).toContain('bi-sk')
     expect(getSkillTile('Git').className).toContain('bi-mn')
+    expect(getSkillTile('Linux').className).toContain('bi-lx')
+    expect(getSkillTile('Ansible').className).toContain('bi-an')
+    expect(getSkillTile('Jupyter').className).toContain('bi-jp')
   })
 
   it('uses bi-cat and bi-name hierarchy inside each tile', () => {
     render(<SkillsSection />)
 
     const pythonTile = getSkillTile('Python')
-    expect(pythonTile.querySelector('.bi-cat')?.textContent).toBe('LANGUAGE')
+    expect(pythonTile.querySelector('.bi-cat')?.textContent).toBe('LANGUAGES')
     expect(pythonTile.querySelector('.bi-name')?.textContent).toBe('Python')
   })
 
@@ -248,14 +257,14 @@ describe('SkillsSection', () => {
     fireIntersection(true)
 
     const delays = getLatestSkillTileTransitionDelays().map(([, delay]) => delay)
-    expect(new Set(delays).size).toBe(13)
+    expect(new Set(delays).size).toBe(20)
   })
 
   it('resets to hidden after leaving the viewport', () => {
     render(<SkillsSection />)
 
     fireIntersection(true)
-    expect(document.querySelectorAll('.bi.in')).toHaveLength(13)
+    expect(document.querySelectorAll('.bi.in')).toHaveLength(20)
 
     fireIntersection(false)
 
@@ -268,7 +277,7 @@ describe('SkillsSection', () => {
     render(<SkillsSection />)
 
     fireIntersection(true)
-    expect(new Set(getLatestSkillTileTransitionDelays().map(([, delay]) => delay)).size).toBe(13)
+    expect(new Set(getLatestSkillTileTransitionDelays().map(([, delay]) => delay)).size).toBe(20)
 
     fireIntersection(false)
 
@@ -288,7 +297,7 @@ describe('SkillsSection', () => {
 
     fireIntersection(true)
     expect(getLatestSkillTileTransitionDelays()).toEqual(firstDelays)
-    expect(random).toHaveBeenCalledTimes(12)
+    expect(random).toHaveBeenCalledTimes(19)
   })
 
   it('generates a fresh reveal order on each viewport entry and replays the reveal', () => {
@@ -299,7 +308,7 @@ describe('SkillsSection', () => {
 
     fireIntersection(true)
     const firstDelays = getLatestSkillTileTransitionDelays()
-    expect(document.querySelectorAll('.bi.in')).toHaveLength(13)
+    expect(document.querySelectorAll('.bi.in')).toHaveLength(20)
 
     fireIntersection(false)
     for (const tile of document.querySelectorAll('.bi')) {
@@ -313,7 +322,7 @@ describe('SkillsSection', () => {
     })
 
     fireIntersection(true)
-    expect(document.querySelectorAll('.bi.in')).toHaveLength(13)
+    expect(document.querySelectorAll('.bi.in')).toHaveLength(20)
 
     const secondDelays = getLatestSkillTileTransitionDelays()
     expect(secondDelays).not.toEqual(firstDelays)

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -145,7 +145,7 @@ export function SkillsSection() {
   }, [])
 
   return (
-    <StickySection id="skills" className="flex flex-col justify-center py-14 px-8 bg-graphite">
+    <StickySection id="skills" className="flex flex-col justify-start bg-graphite">
       <div className="w-full">
         <div className="hscroll-head">
           <span className="hscroll-no">// 02</span>

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -3,7 +3,7 @@ import { StickySection } from './StickySection'
 
 const TILE_REVEAL_STEP_S = 0.12
 
-type Category = 'LANGUAGE' | 'FRAMEWORK' | 'TOOL' | 'ML / DL' | 'DATA'
+type Category = 'ML / DL' | 'DATA & COMPUTATION' | 'LANGUAGES' | 'TOOLS & SYSTEMS'
 type TileColor = 'orange' | 'blue' | 'fuchsia' | 'peri' | 'dark' | 'platinum' | 'yellow'
 
 interface SkillTile {
@@ -15,21 +15,38 @@ interface SkillTile {
 }
 
 const tiles: SkillTile[] = [
-  { area: 'py', category: 'LANGUAGE', name: 'Python', color: 'orange', large: true },
-  { area: 'js', category: 'LANGUAGE', name: 'TypeScript', color: 'blue' },
-  { area: 'dk', category: 'TOOL', name: 'Docker', color: 'platinum' },
-  { area: 're', category: 'LANGUAGE', name: 'JavaScript', color: 'peri' },
-  { area: 'cc', category: 'LANGUAGE', name: 'C / C++', color: 'fuchsia' },
-  { area: 'nd', category: 'DATA', name: 'NumPy', color: 'blue' },
-  { area: 'nx', category: 'FRAMEWORK', name: 'FastAPI', color: 'orange' },
-  { area: 'fl', category: 'ML / DL', name: 'PyTorch', color: 'yellow' },
+  // ML / DL
+  { area: 'fl', category: 'ML / DL', name: 'PyTorch', color: 'yellow', large: true },
+  { area: 'tr', category: 'ML / DL', name: 'Transformers', color: 'yellow' },
   { area: 'gt', category: 'ML / DL', name: 'Hugging Face', color: 'yellow' },
-  { area: 'pg', category: 'ML / DL', name: 'Scikit-learn', color: 'yellow' },
-  { area: 'fg', category: 'DATA', name: 'Pandas', color: 'fuchsia' },
-  { area: 'mn', category: 'TOOL', name: 'Git', color: 'dark' },
+  // Data & Computation
+  { area: 'nd', category: 'DATA & COMPUTATION', name: 'NumPy', color: 'blue' },
+  { area: 'pd', category: 'DATA & COMPUTATION', name: 'Pandas', color: 'fuchsia' },
+  { area: 'sk', category: 'DATA & COMPUTATION', name: 'Scikit-learn', color: 'blue' },
+  { area: 'mp', category: 'DATA & COMPUTATION', name: 'Matplotlib', color: 'fuchsia' },
+  // Languages
+  { area: 'py', category: 'LANGUAGES', name: 'Python', color: 'orange', large: true },
+  { area: 'cc', category: 'LANGUAGES', name: 'C++', color: 'peri' },
+  { area: 'ci', category: 'LANGUAGES', name: 'C', color: 'peri' },
+  { area: 'sq', category: 'LANGUAGES', name: 'SQL', color: 'fuchsia' },
+  { area: 're', category: 'LANGUAGES', name: 'JavaScript', color: 'peri' },
+  { area: 'js', category: 'LANGUAGES', name: 'TypeScript', color: 'blue' },
+  // Tools & Systems
+  { area: 'mn', category: 'TOOLS & SYSTEMS', name: 'Git', color: 'dark' },
+  { area: 'dk', category: 'TOOLS & SYSTEMS', name: 'Docker', color: 'platinum' },
+  { area: 'lx', category: 'TOOLS & SYSTEMS', name: 'Linux', color: 'dark' },
+  { area: 'an', category: 'TOOLS & SYSTEMS', name: 'Ansible', color: 'platinum' },
+  { area: 'jp', category: 'TOOLS & SYSTEMS', name: 'Jupyter', color: 'orange' },
+  { area: 'nx', category: 'TOOLS & SYSTEMS', name: 'FastAPI', color: 'orange' },
 ]
 
-export const REVEAL_AREAS = ['py', 'js', 'dk', 're', 'cc', 'nd', 'nx', 'fl', 'gt', 'pg', 'fg', 'mn', 'pal'] as const
+export const REVEAL_AREAS = [
+  'fl', 'tr', 'gt',
+  'nd', 'pd', 'sk', 'mp',
+  'py', 'cc', 'ci', 'sq', 're', 'js',
+  'mn', 'dk', 'lx', 'an', 'jp', 'nx',
+  'pal',
+] as const
 
 export function createShuffledRevealOrder(
   random: () => number = Math.random,

--- a/src/data/resume-audit.test.ts
+++ b/src/data/resume-audit.test.ts
@@ -1,11 +1,22 @@
-import { describe, expect, it } from 'vitest'
+import { createElement } from 'react'
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { projects } from './projects'
 import { timelineEntries, type TimelineEntry } from './timeline'
 import { FIRST_NAME, LAST_NAME } from '../components/HeroSection.constants'
+import { SkillsSection } from '../components/SkillsSection'
 
 // Resume source-of-truth constants (from public/resume.pdf)
 const RESUME_FULL_NAME = 'Farhan Mohammed'
 const RESUME_EMAIL = 'famohammed@shockers.wichita.edu'
+
+// 19 resume skills across the resume's 4 categories (public/resume.pdf "Skills" section).
+const RESUME_SKILLS = [
+  'PyTorch', 'Transformers', 'Hugging Face',
+  'NumPy', 'Pandas', 'Scikit-learn', 'Matplotlib',
+  'Python', 'C++', 'C', 'SQL', 'JavaScript', 'TypeScript',
+  'Git', 'Docker', 'Linux', 'Ansible', 'Jupyter', 'FastAPI',
+]
 
 const RESUME_TIMELINE = {
   netapp: {
@@ -199,6 +210,40 @@ describe('resume source-of-truth audit', () => {
       )
       expect(bs.bullets[0]).toContain("Dean's List")
       expect(bs.bullets[1]).toContain('Relevant Coursework')
+    })
+  })
+
+  describe('skills', () => {
+    beforeEach(() => {
+      vi.stubGlobal(
+        'IntersectionObserver',
+        vi.fn(function () {
+          return {
+            observe: vi.fn(),
+            disconnect: vi.fn(),
+            unobserve: vi.fn(),
+          }
+        }),
+      )
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('all 19 resume skills are present as tiles', () => {
+      render(createElement(SkillsSection))
+      for (const skill of RESUME_SKILLS) {
+        expect(screen.getByText(skill)).toBeInTheDocument()
+      }
+    })
+
+    it('Python and PyTorch are marked as large hero tiles', () => {
+      render(createElement(SkillsSection))
+      const python = screen.getByText('Python').closest('.bi')
+      const pytorch = screen.getByText('PyTorch').closest('.bi')
+      expect(python).toHaveClass('bi-lg')
+      expect(pytorch).toHaveClass('bi-lg')
     })
   })
 })

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -85,7 +85,7 @@
      to the viewport top (0px) and relies solely on .hscroll-head's 74px padding-top to clear
      the navbar. Subtracting that 56px here keeps the SKILLS title at the same on-screen
      distance below the navbar as PROJECTS' title. */
-  #skills .hscroll-head{padding-top:18px}
+  #skills .hscroll-head{padding-top:18px;padding-bottom:32px}
   .hscroll-no{font-size:14px;color:var(--color-atomic-tangerine);letter-spacing:3px}
   .hscroll-name{font-family:var(--font-display);font-size:18px;color:var(--color-platinum);letter-spacing:3px}
   .hscroll-rule{flex:1;height:1px;background:var(--color-graphite-light)}
@@ -207,9 +207,9 @@
   @keyframes fade-up{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
 
   /* ─── SKILLS ──── */
-  #skills{width:100%;padding:0 5vw 60px;position:relative}
+  #skills{width:100%;padding:0 0 60px;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
-  .bento{display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:120px 100px 80px 80px 80px 70px 50px;gap:12px;
+  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:120px 100px 80px 80px 80px 70px 50px;gap:12px;
     grid-template-areas:
       "py py py js js dk"
       "py py py re re cc"

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -200,7 +200,7 @@
   @keyframes fade-up{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
 
   /* ─── SKILLS ──── */
-  #skills{width:100%;padding:60px 5vw 60px;position:relative}
+  #skills{width:100%;padding:74px 5vw 60px;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
   .bento{display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:120px 100px 80px 80px 80px 70px 50px;gap:12px;
     grid-template-areas:

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -200,9 +200,9 @@
   @keyframes fade-up{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
 
   /* ─── SKILLS ──── */
-  #skills{width:100%;padding:120px 5vw 140px;position:relative}
-  .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:80px}
-  .bento{display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:170px 150px 110px 110px 110px 90px 60px;gap:12px;
+  #skills{width:100%;padding:60px 5vw 60px;position:relative}
+  .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
+  .bento{display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:120px 100px 80px 80px 80px 70px 50px;gap:12px;
     grid-template-areas:
       "py py py js js dk"
       "py py py re re cc"

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -207,7 +207,7 @@
   @keyframes fade-up{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
 
   /* ─── SKILLS ──── */
-  #skills{width:100%;padding:0 0 60px;position:relative}
+  #skills{width:100%;padding:0;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
   .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:120px 100px 80px 80px 80px 70px 50px;gap:12px;
     grid-template-areas:

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -209,7 +209,7 @@
   /* ─── SKILLS ──── */
   #skills{width:100%;padding:0;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
-  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:120px 100px 80px 80px 80px 70px 50px;gap:12px;
+  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:2fr 1.5fr 1fr 1fr 1fr 1fr 0.6fr;gap:12px;flex:1;
     grid-template-areas:
       "py py py js js dk"
       "py py py re re cc"

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -79,6 +79,13 @@
   .hscroll{position:relative;width:100%;height:100%}
   .hscroll-sticky,[data-sticky-viewport="true"]{position:sticky;top:0;height:100vh;width:100%;max-width:100%;overflow:hidden;display:flex;flex-direction:column}
   .hscroll-head{padding:74px 5vw 18px;display:flex;align-items:center;gap:18px;flex-shrink:0}
+  /* #skills is a normal scroll-snapped section (no sticky-pinned wrapper), so its section
+     top already sits 56px below the viewport top (clearing the fixed navbar) once snapped
+     into place via `scroll-padding-top:56px`. Projects' sticky wrapper instead pins flush
+     to the viewport top (0px) and relies solely on .hscroll-head's 74px padding-top to clear
+     the navbar. Subtracting that 56px here keeps the SKILLS title at the same on-screen
+     distance below the navbar as PROJECTS' title. */
+  #skills .hscroll-head{padding-top:18px}
   .hscroll-no{font-size:14px;color:var(--color-atomic-tangerine);letter-spacing:3px}
   .hscroll-name{font-family:var(--font-display);font-size:18px;color:var(--color-platinum);letter-spacing:3px}
   .hscroll-rule{flex:1;height:1px;background:var(--color-graphite-light)}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -200,7 +200,7 @@
   @keyframes fade-up{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
 
   /* ─── SKILLS ──── */
-  #skills{width:100%;padding:74px 5vw 60px;position:relative}
+  #skills{width:100%;padding:0 5vw 60px;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
   .bento{display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:120px 100px 80px 80px 80px 70px 50px;gap:12px;
     grid-template-areas:

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -202,12 +202,15 @@
   /* ─── SKILLS ──── */
   #skills{width:100%;padding:120px 5vw 140px;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:80px}
-  .bento{display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:170px 150px 110px 90px;gap:12px;
+  .bento{display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:170px 150px 110px 110px 110px 90px 60px;gap:12px;
     grid-template-areas:
       "py py py js js dk"
       "py py py re re cc"
-      "nd nd nx fl gt gt"
-      "pg pg pg fg mn pal";}
+      "ci sq nd nd pd pd"
+      "sk sk mp mp fl fl"
+      "tr tr gt gt fl fl"
+      "mn lx an jp nx nx"
+      "pal pal pal pal pal pal";}
   .bi{padding:24px;display:flex;flex-direction:column;justify-content:flex-end;overflow:hidden;position:relative;opacity:0;transform:translateY(30px) scale(.94);transition:opacity .7s var(--ease),transform .7s var(--ease),filter .2s ease}
   .bi.in{opacity:1;transform:none}
   .bi:hover{filter:brightness(1.1)}
@@ -218,10 +221,13 @@
   .bi-py{grid-area:py}.bi-js{grid-area:js}.bi-dk{grid-area:dk}
   .bi-re{grid-area:re}.bi-cc{grid-area:cc}.bi-nd{grid-area:nd}
   .bi-nx{grid-area:nx}.bi-fl{grid-area:fl}.bi-gt{grid-area:gt}
-  .bi-pg{grid-area:pg}.bi-fg{grid-area:fg}.bi-mn{grid-area:mn}
-  .bi-pal{grid-area:pal;display:grid;grid-template-columns:1fr 1fr;grid-template-rows:1fr 1fr;gap:5px;padding:0;background:transparent}
+  .bi-mn{grid-area:mn}.bi-tr{grid-area:tr}.bi-pd{grid-area:pd}
+  .bi-sk{grid-area:sk}.bi-mp{grid-area:mp}.bi-ci{grid-area:ci}
+  .bi-sq{grid-area:sq}.bi-lx{grid-area:lx}.bi-an{grid-area:an}
+  .bi-jp{grid-area:jp}
+  .bi-pal{grid-area:pal;display:flex;flex-direction:row;gap:5px;padding:0;background:transparent}
   .bi-pal:hover{filter:none}
-  .pswatch{}
+  .pswatch{flex:1 1 0;height:100%}
   .c-orange{background:var(--color-atomic-tangerine);color:var(--color-graphite)}
   .c-blue{background:var(--color-ultrasonic-blue);color:var(--color-platinum)}
   .c-fuchsia{background:var(--color-fuchsia-flame);color:var(--color-platinum)}


### PR DESCRIPTION
**Purpose**
Expand the Skills bento grid from 12 to 19 tiles so it matches every tool/framework/language listed in `public/resume.pdf`, organized under the resume's 4 categories.

**What it does**
Adds the 7 missing skill tiles (Transformers, Matplotlib, SQL, C, Linux, Ansible, Jupyter), splits the old combined "C / C++" tile into separate C++ and C tiles, marks PyTorch as a `large` hero tile alongside Python, and switches the 5 old categories (LANGUAGE/FRAMEWORK/TOOL/ML‑DL/DATA) to the resume's 4 (ML/DL, Data & Computation, Languages, Tools & Systems). The bento grid CSS is redesigned with new grid-template-areas/rows for 19 tiles, and the palette tile switches from a 2×2 grid to 4 full-height flex bars. The existing vanilla IntersectionObserver stagger-reveal logic (no framer-motion) is preserved unchanged.

**Changes made**
- `src/components/SkillsSection.tsx` — tile data expanded to 19 entries across the resume's 4 categories; `REVEAL_AREAS` updated to the new 19 skill areas + palette.
- `src/portfolio.css` — `.bento` grid-template-areas/rows redesigned for 19 areas (preserves the pinned `"py py py js js dk"` first row asserted by `portfolio-css.test.ts`); new `.bi-{area}` rules for the 10 new/renamed areas; `.bi-pal` changed from 2×2 grid to `display:flex;flex-direction:row` with `.pswatch` bars stretched full height.
- `src/components/SkillsSection.test.tsx` — updated tile/category/count assertions (12→19 skill tiles, 13→20 total `.bi` nodes, reveal-delay uniqueness and `Math.random` call-count updated for the 20-item shuffle).
- `src/data/resume-audit.test.ts` — new skills data-completeness test asserting all 19 resume skills render and that Python + PyTorch both carry `bi-lg`.

**Additional notes**
- Mobile breakpoint behavior (`@media (max-width:760px)` 2-column collapse) is untouched and still applies generically via `.bi{grid-area:auto !important}`, so no mobile-specific CSS changes were needed.
- `npm run typecheck` and `npm run test` (493 tests) pass locally.
- No blockers for follow-up work.

Closes #286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded the skills showcase with a larger, reorganized tile taxonomy and updated category groupings.
  * Refreshed reveal animation sequencing and tile area mappings to match the new skills layout.
* **Styling**
  * Adjusted skills-section spacing and scroll alignment to better match the fixed navbar.
  * Updated the Skills bento/grid layout and redesigned the palette tile presentation.
* **Tests**
  * Updated automated coverage to verify all skills render and hero-tile styling (Python/PyTorch), plus updated reveal timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->