### PR TITLE
Contact/footer: typewriter reveal + social links

### DIFF
--- a/src/components/ContactSection.test.tsx
+++ b/src/components/ContactSection.test.tsx
@@ -1,19 +1,40 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, within, act } from '@testing-library/react'
-import { useInView } from 'framer-motion'
 import ContactSection from './ContactSection'
 
-vi.mock('framer-motion', async () => {
-  const actual = await vi.importActual<typeof import('framer-motion')>('framer-motion')
-  return { ...actual, useInView: vi.fn().mockReturnValue(false) }
-})
+let observerCallback!: IntersectionObserverCallback
+let observedElement: Element | undefined
+
+function stubIntersectionObserver() {
+  vi.stubGlobal('IntersectionObserver', vi.fn(function (
+    cb: IntersectionObserverCallback,
+  ) {
+    observerCallback = cb
+    return {
+      observe: vi.fn((element: Element) => {
+        observedElement = element
+      }),
+      disconnect: vi.fn(),
+      unobserve: vi.fn(),
+    }
+  }))
+}
+
+function setInView(isIntersecting: boolean) {
+  act(() => {
+    observerCallback(
+      [{ target: observedElement!, isIntersecting } as unknown as IntersectionObserverEntry],
+      {} as IntersectionObserver,
+    )
+  })
+}
 
 const canonicalEmailHref = 'mailto:famohammed@shockers.wichita.edu'
 
 function renderWithTypingComplete() {
-  vi.mocked(useInView).mockReturnValue(true)
   vi.useFakeTimers()
   render(<ContactSection />)
+  setInView(true)
   act(() => { vi.advanceTimersByTime(250) })
   act(() => { vi.advanceTimersByTime(400) })
 }
@@ -21,11 +42,12 @@ function renderWithTypingComplete() {
 describe('ContactSection', () => {
 
   beforeEach(() => {
-    vi.mocked(useInView).mockReturnValue(false)
+    stubIntersectionObserver()
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   it('renders the send message link with the expected destination', () => {
@@ -72,16 +94,13 @@ describe('ContactSection', () => {
 
   describe('issue #222 - reset and replay type-in on re-entry', () => {
     it('resets heading and cursor when section leaves view and replays from start on re-entry', () => {
-      let inView = false
-      vi.mocked(useInView).mockImplementation(() => inView)
       vi.useFakeTimers()
 
-      const { rerender } = render(<ContactSection />)
+      render(<ContactSection />)
 
       expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
 
-      inView = true
-      rerender(<ContactSection />)
+      setInView(true)
 
       act(() => { vi.advanceTimersByTime(250) })
       expect(screen.getByText("LET'S")).toBeInTheDocument()
@@ -90,15 +109,13 @@ describe('ContactSection', () => {
       expect(document.querySelector('#contact .footer-big')).toHaveTextContent("LET'SCONNECT.")
       expect(document.querySelector('[data-testid="contact-cursor"]')).toBeInTheDocument()
 
-      inView = false
-      rerender(<ContactSection />)
+      setInView(false)
 
       expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
       expect(document.querySelector('[data-testid="contact-cursor"]')).not.toBeInTheDocument()
       expect(document.querySelector('#contact .period')).not.toBeInTheDocument()
 
-      inView = true
-      rerender(<ContactSection />)
+      setInView(true)
 
       expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
 
@@ -112,14 +129,11 @@ describe('ContactSection', () => {
     })
 
     it('clears partial type-in when section leaves mid-animation', () => {
-      let inView = false
-      vi.mocked(useInView).mockImplementation(() => inView)
       vi.useFakeTimers()
 
-      const { rerender } = render(<ContactSection />)
+      render(<ContactSection />)
 
-      inView = true
-      rerender(<ContactSection />)
+      setInView(true)
 
       act(() => { vi.advanceTimersByTime(250) })
       expect(screen.getByText("LET'S")).toBeInTheDocument()
@@ -128,8 +142,7 @@ describe('ContactSection', () => {
       expect(screen.getByText('CON')).toBeInTheDocument()
       expect(document.querySelector('[data-testid="contact-cursor"]')).not.toBeInTheDocument()
 
-      inView = false
-      rerender(<ContactSection />)
+      setInView(false)
 
       expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
       expect(screen.queryByText('CON')).not.toBeInTheDocument()
@@ -137,22 +150,17 @@ describe('ContactSection', () => {
     })
 
     it('does not flash cursor or period on immediate re-entry after full animation', () => {
-      let inView = false
-      vi.mocked(useInView).mockImplementation(() => inView)
       vi.useFakeTimers()
 
-      const { rerender } = render(<ContactSection />)
+      render(<ContactSection />)
 
-      inView = true
-      rerender(<ContactSection />)
+      setInView(true)
       act(() => { vi.advanceTimersByTime(250) })
       act(() => { vi.advanceTimersByTime(400) })
       expect(document.querySelector('[data-testid="contact-cursor"]')).toBeInTheDocument()
 
-      inView = false
-      rerender(<ContactSection />)
-      inView = true
-      rerender(<ContactSection />)
+      setInView(false)
+      setInView(true)
 
       expect(document.querySelector('[data-testid="contact-cursor"]')).not.toBeInTheDocument()
       expect(document.querySelector('#contact .period')).not.toBeInTheDocument()
@@ -162,17 +170,16 @@ describe('ContactSection', () => {
 
   describe('issue #87 - LET\'S CONNECT. typewriter', () => {
     it('heading is not visible when section is out of view', () => {
-      vi.mocked(useInView).mockReturnValue(false)
       render(<ContactSection />)
 
       expect(screen.queryByText("LET'S")).not.toBeInTheDocument()
     })
 
     it('heading types out character by character when section enters viewport', () => {
-      vi.mocked(useInView).mockReturnValue(true)
       vi.useFakeTimers()
 
       render(<ContactSection />)
+      setInView(true)
 
       // 5 chars × 50ms = 250ms for "LET'S"
       act(() => { vi.advanceTimersByTime(250) })
@@ -184,10 +191,10 @@ describe('ContactSection', () => {
     })
 
     it('blinking cursor persists after typing completes', () => {
-      vi.mocked(useInView).mockReturnValue(true)
       vi.useFakeTimers()
 
       render(<ContactSection />)
+      setInView(true)
 
       // Wait for typing to complete: 12 chars × 50ms = 600ms + buffer
       act(() => { vi.advanceTimersByTime(250) })

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,7 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { motion, useInView } from 'framer-motion'
 import { TypeIn } from '../animations/TypeIn'
-import { hoverEase } from '../animations/variants'
 import { StickySection } from './StickySection'
 
 const EMAIL = 'famohammed@shockers.wichita.edu'
@@ -15,9 +13,23 @@ const footerLinks = [
 ]
 
 export default function ContactSection() {
-  const ref = useRef(null)
-  const isInView = useInView(ref)
+  const ref = useRef<HTMLDivElement>(null)
+  const [isInView, setIsInView] = useState(false)
   const [step, setStep] = useState(0)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) {
+      return
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsInView(entry.isIntersecting)
+    })
+
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
 
   useEffect(() => {
     if (!isInView) {
@@ -51,31 +63,22 @@ export default function ContactSection() {
           </span>
         </div>
 
-        <motion.a
-          href={`mailto:${EMAIL}`}
-          variants={hoverEase}
-          initial="idle"
-          whileHover="hover"
-          className="btn btn-fill"
-        >
+        <a href={`mailto:${EMAIL}`} className="btn btn-fill">
           SEND_MESSAGE <span>→</span>
-        </motion.a>
+        </a>
 
         <div className="footer-socials">
           {footerLinks.map(({ label, href, target }) => (
-            <motion.a
+            <a
               key={label}
               href={href}
               target={target}
               aria-label={`// ${label}`}
               rel={target === '_blank' ? 'noopener noreferrer' : undefined}
-              variants={hoverEase}
-              initial="idle"
-              whileHover="hover"
               className="slink"
             >
               {label}
-            </motion.a>
+            </a>
           ))}
         </div>
       </div>

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -67,8 +67,9 @@
   .hero-role{font-size:clamp(11px,1.1vw,15px);color:var(--color-periwinkle);letter-spacing:5px;margin-bottom:24px}
   .hero-tag{font-size:clamp(12px,1.2vw,16px);color:var(--color-platinum);letter-spacing:1px;margin-bottom:48px;max-width:760px;line-height:1.8}
   .hero-cta{display:flex;gap:18px;flex-wrap:wrap}
-  .btn{font-family:var(--font-body);font-size:11px;letter-spacing:3px;padding:16px 26px;cursor:pointer;display:inline-flex;align-items:center;gap:12px;text-decoration:none;border:none;transition:transform .2s var(--ease),background .2s var(--ease),color .2s var(--ease)}
+  .btn{font-family:var(--font-body);font-size:11px;letter-spacing:3px;padding:16px 26px;cursor:pointer;display:inline-flex;align-items:center;gap:12px;text-decoration:none;border:none;transition:transform .25s var(--ease),background .2s var(--ease),color .2s var(--ease)}
   .btn span{transition:transform .2s var(--ease)}
+  .btn:hover{transform:scale(1.05)}
   .btn:hover span{transform:translateX(4px)}
   .btn-fill{background:var(--color-atomic-tangerine);color:var(--color-graphite);font-weight:700}
   .btn-fill:hover{background:#ff9d6b}
@@ -258,9 +259,9 @@
   .footer-big-line{display:block}
   .footer-big .period{color:var(--color-atomic-tangerine)}
   .footer-socials{display:flex;gap:36px;flex-wrap:wrap;justify-content:center;margin-top:24px}
-  .slink{font-size:14px;color:var(--color-periwinkle);text-decoration:none;letter-spacing:2px;transition:color .15s var(--ease)}
+  .slink{display:inline-block;font-size:14px;color:var(--color-periwinkle);text-decoration:none;letter-spacing:2px;transition:color .15s var(--ease),transform .25s var(--ease)}
   .slink::before{content:'//';color:var(--color-atomic-tangerine);margin-right:6px}
-  .slink:hover{color:var(--color-platinum)}
+  .slink:hover{color:var(--color-platinum);transform:scale(1.05)}
   .footer-copy{display:flex;justify-content:space-between;align-items:center;padding:24px 5vw;border-top:1px solid var(--color-graphite-light);font-size:14px;color:var(--color-periwinkle);letter-spacing:2px;opacity:.9}
   .footer-copy span:last-child{opacity:.75}
 


### PR DESCRIPTION
## Purpose

Remove the last `framer-motion` dependency from `ContactSection.tsx` so the contact/footer section's typewriter reveal and social-link hovers run on vanilla React + CSS, consistent with the Navbar/MobileMenu/HeroSection migrations already merged.

## What it does

Replaces framer-motion's `useInView` with a vanilla `IntersectionObserver` that drives the existing "LET'S" → "CONNECT." typewriter sequence and viewport-leave reset (unchanged behavior). Replaces `motion.a` hover scaling on the SEND_MESSAGE CTA and the GITHUB/LINKEDIN/EMAIL/RESUME social links with plain `<a>` elements styled by new CSS `:hover { transform: scale(1.05) }` rules that mirror the removed `hoverEase` variant (scale 1.05, ~0.25s ease).

## Changes made

- `src/components/ContactSection.tsx` — drop `framer-motion`/`hoverEase` imports; `isInView` now comes from an `IntersectionObserver` observing the footer-cta ref; `motion.a` → plain `<a>` for the CTA button and social links
- `src/components/ContactSection.test.tsx` — replace the framer-motion `useInView` mock with an `IntersectionObserver` stub (same capture-callback-and-fire pattern as `SkillsSection.test.tsx`), add a `setInView()` helper, drop now-unneeded `rerender()` calls
- `src/portfolio.css` — add `.btn:hover{transform:scale(1.05)}` and `.slink:hover{transform:scale(1.05)}` (plus matching `transition`) to replace the removed motion hover

## Additional notes

- `framer-motion` (the package) and `src/animations/variants.ts` are left in place since `ProjectsSection.tsx` still depends on both — full removal is out of scope for this issue.
- Social link URLs (GITHUB, LINKEDIN, EMAIL, RESUME) were already correct prior to this change; no URL changes were needed.
- Verified: `npm run typecheck` and `npm run test` pass (491 tests, 38 files); `npm run build` succeeds; pre-existing lint error count (12, unrelated to this file's prior code) is unchanged before/after this diff.

Closes #289