### PR TITLE
Projects section: horizontal scroll, card hover, tag colors

### DIFF
--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -1,20 +1,13 @@
 import { useMemo, useRef, useState } from 'react'
-import { motion } from 'framer-motion'
 import { useHorizontalScroll } from '../hooks/useHorizontalScroll'
 import type { Project } from '../data/projects'
-import { formatProjectNumber, getProjectsScrollRunwayPx, getScrollRangeVh } from './projectsGeometry'
+import { formatProjectNumber, getProjectsScrollRunwayPx, getScrollRangeVh, getTagVariant } from './projectsGeometry'
 
 interface Props {
   projects: Project[]
 }
 
-const TAG_VARIANTS = ['fuchsia', 'blue', 'orange', 'yellow'] as const
-
 const INVERTED_TAG_CLASS = 'ptag-inverted'
-
-const CARD_HOVER_TRANSITION = {
-  y: { duration: 0.2, ease: 'easeOut' },
-} as const
 
 function clampIndex(index: number, projectCount: number) {
   return Math.max(0, Math.min(projectCount - 1, index))
@@ -88,27 +81,14 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
           <div className="proj-edge" aria-hidden="true" />
         </div>
 
-        <motion.div
+        <div
           data-testid="scroll-hint"
           data-visible={progress === 0}
           aria-hidden="true"
-          animate={{ opacity: progress === 0 ? 0.85 : 0 }}
-          transition={{ duration: 0.3 }}
           className="hscroll-hint pointer-events-none"
         >
-          SCROLL{' '}
-          <motion.span
-            animate={progress === 0 ? { x: [0, 6, 0] } : { x: 0 }}
-            transition={
-              progress === 0
-                ? { duration: 1.6, repeat: Infinity, ease: 'easeInOut' }
-                : { duration: 0 }
-            }
-            style={{ display: 'inline-block' }}
-          >
-            →
-          </motion.span>
-        </motion.div>
+          SCROLL <span>→</span>
+        </div>
       </div>
     </section>
   )
@@ -121,7 +101,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
   const projectNumber = formatProjectNumber(project.id)
 
   return (
-    <motion.article
+    <article
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onFocusCapture={() => setHasFocus(true)}
@@ -130,8 +110,6 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
           setHasFocus(false)
         }
       }}
-      animate={{ y: isFillActive ? -4 : 0 }}
-      transition={CARD_HOVER_TRANSITION}
       data-testid="project-card"
       data-fill-active={isFillActive}
       className="pcard shrink-0"
@@ -166,7 +144,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
             <span
               key={tag}
               data-inverted={isFillActive}
-              className={`ptag ptag-${TAG_VARIANTS[tagIndex % TAG_VARIANTS.length]} ${isFillActive ? INVERTED_TAG_CLASS : ''}`}
+              className={`ptag ptag-${getTagVariant(tagIndex)} ${isFillActive ? INVERTED_TAG_CLASS : ''}`}
             >
               {tag}
             </span>
@@ -187,7 +165,7 @@ const ProjectCard: React.FC<{ project: Project }> = ({ project }) => {
           ))}
         </div>
       </div>
-    </motion.article>
+    </article>
   )
 }
 

--- a/src/components/projectsGeometry.test.ts
+++ b/src/components/projectsGeometry.test.ts
@@ -10,9 +10,11 @@ import {
   getProjectsTrackTranslate,
   getEdgeSpacerWidth,
   getScrollRangeVh,
+  getTagVariant,
   PROJECT_CARD_GAP,
   PROJECT_CARD_WIDTH,
   PROJECTS_SECTION_PADDING_X,
+  TAG_VARIANTS,
 } from './projectsGeometry'
 
 describe('projectsGeometry', () => {
@@ -242,6 +244,26 @@ describe('projectsGeometry', () => {
         const tx = getProjectsTrackTranslate(0, trackWidth, viewportWidth)
         expect(getProjectCardCenterX(tx, 0, viewportWidth)).toBeCloseTo(carouselViewportWidth / 2, 5)
       }
+    })
+  })
+
+  describe('getTagVariant', () => {
+    it('returns fuchsia, blue, orange, yellow in order for the first four tag indices', () => {
+      expect(getTagVariant(0)).toBe('fuchsia')
+      expect(getTagVariant(1)).toBe('blue')
+      expect(getTagVariant(2)).toBe('orange')
+      expect(getTagVariant(3)).toBe('yellow')
+    })
+
+    it('cycles back to fuchsia after exhausting the palette', () => {
+      expect(getTagVariant(4)).toBe('fuchsia')
+      expect(getTagVariant(5)).toBe('blue')
+    })
+
+    it('cycles deterministically for an arbitrary number of tags', () => {
+      const indices = Array.from({ length: 10 }, (_, i) => i)
+      const variants = indices.map(getTagVariant)
+      expect(variants).toEqual(indices.map((i) => TAG_VARIANTS[i % TAG_VARIANTS.length]))
     })
   })
 })

--- a/src/components/projectsGeometry.ts
+++ b/src/components/projectsGeometry.ts
@@ -147,3 +147,11 @@ export function getProjectsTrackState(
 export function formatProjectNumber(id: string) {
   return `_${id.padStart(2, '0')}`
 }
+
+/** Ordered tag color palette; cycles via `getTagVariant` for tags beyond the palette length. */
+export const TAG_VARIANTS = ['fuchsia', 'blue', 'orange', 'yellow'] as const
+
+/** Returns the palette variant for a given tag index, cycling through `TAG_VARIANTS`. */
+export function getTagVariant(tagIndex: number) {
+  return TAG_VARIANTS[tagIndex % TAG_VARIANTS.length]
+}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -86,8 +86,10 @@
   .hscroll-progress-track{width:80px;height:1px;background:var(--color-graphite-light);position:relative}
   .hscroll-progress-fill{position:absolute;left:0;top:0;height:100%;background:var(--color-atomic-tangerine);transition:width .1s linear}
   .hscroll-track{flex:1;display:flex;align-items:center;will-change:transform}
-  .hscroll-hint{position:absolute;left:50%;bottom:28px;transform:translateX(-50%);font-size:14px;color:var(--color-periwinkle);letter-spacing:3px;opacity:.85;display:flex;align-items:center;gap:12px}
-  .hscroll-hint span{display:inline-block;animation:nudge 1.6s var(--ease) infinite}
+  .hscroll-hint{position:absolute;left:50%;bottom:28px;transform:translateX(-50%);font-size:14px;color:var(--color-periwinkle);letter-spacing:3px;display:flex;align-items:center;gap:12px;opacity:0;transition:opacity .3s var(--ease)}
+  .hscroll-hint[data-visible="true"]{opacity:.85}
+  .hscroll-hint span{display:inline-block}
+  .hscroll-hint[data-visible="true"] span{animation:nudge 1.6s var(--ease) infinite}
   @keyframes nudge{0%,100%{transform:translateX(0)}50%{transform:translateX(6px)}}
 
   /* ─── PROJECTS ──── */
@@ -97,7 +99,8 @@
      card centered in the visible viewport (see projectsGeometry.ts getEdgeSpacerWidth). */
   .proj-edge{flex-shrink:0;width:calc(50vw - 88px - min(280px, 39vw))}
   .pcard{--notch:22px;flex-shrink:0;width:min(560px,78vw);height:min(640px,76vh);position:relative;cursor:pointer;
-    transition:transform .35s var(--ease);will-change:transform}
+    transition:transform .2s ease-out;will-change:transform}
+  .pcard:hover,.pcard[data-fill-active='true']{transform:translateY(-4px)}
   .pcard-clip{position:absolute;inset:0;overflow:hidden;
     clip-path:polygon(var(--notch) 0, 100% 0, 100% calc(100% - var(--notch)), calc(100% - var(--notch)) 100%, 0 100%, 0 var(--notch))}
   .pcard-bg{position:absolute;inset:0;background:var(--color-platinum);
@@ -128,7 +131,7 @@
   .ptag{font-size:14px;padding:8px 14px;letter-spacing:1.5px;font-weight:700;transition:background .35s var(--ease),color .35s var(--ease),border-color .35s var(--ease)}
   .ptag-fuchsia{background:var(--color-fuchsia-flame);color:var(--color-platinum)}
   .ptag-blue{background:var(--color-ultrasonic-blue);color:var(--color-platinum)}
-  .ptag-orange{background:var(--color-graphite);color:var(--color-atomic-tangerine);box-shadow:inset 0 0 0 1px var(--color-atomic-tangerine)}
+  .ptag-orange{background:var(--color-atomic-tangerine);color:var(--color-graphite)}
   .ptag-yellow{background:var(--color-golden-pollen);color:var(--color-graphite)}
   .pcard:hover .ptag{background:var(--color-platinum);color:var(--color-graphite);box-shadow:none}
   .pcard-links{display:flex;gap:20px;margin-top:20px;padding-top:18px;border-top:1px dashed rgba(42,43,42,.25);position:relative;z-index:2;transition:border-color .35s var(--ease)}


### PR DESCRIPTION
## Purpose

Remove the last `framer-motion` usages from `ProjectsSection.tsx` and invert the `ptag-orange` tag style, so the section's hover/scroll-hint animation is fully CSS-driven and consistent with the diagonal hover fill that already runs on CSS.

## What it does

Replaces `motion.div`/`motion.span` (scroll hint opacity + arrow nudge) and `motion.article` (card hover lift) with plain elements driven by CSS transitions/keyframes keyed off the existing `data-visible` and `data-fill-active` attributes. Extracts the tag-color cycling logic into a pure, unit-tested helper.

## Changes made

- `src/components/ProjectsSection.tsx` — dropped the `framer-motion` import and all `motion.*` usages; scroll hint and card now render as plain `<div>`/`<article>`; tag class now calls `getTagVariant(tagIndex)` instead of inlining the cycling logic.
- `src/components/projectsGeometry.ts` — added `TAG_VARIANTS` and `getTagVariant(tagIndex)`, alongside the project's other pure geometry/formatting helpers.
- `src/components/projectsGeometry.test.ts` — new unit tests for `getTagVariant` (ordered palette, cycling past the palette length, deterministic cycling over an arbitrary range).
- `src/portfolio.css` —
  - `.hscroll-hint` now starts at `opacity:0` with a `.3s` transition, and `[data-visible="true"]` sets `opacity:.85`; the arrow `nudge` keyframe animation only runs while `data-visible="true"`.
  - `.pcard` transition shortened to `.2s ease-out` and a `translateY(-4px)` lift rule added for `:hover` and `[data-fill-active='true']`, replacing the removed `motion.article` `animate={{ y: ... }}`.
  - `.ptag-orange` inverted to a solid `var(--color-atomic-tangerine)` background with `var(--color-graphite)` text and no border (previously a graphite background with an orange outline).

## Additional notes

- The horizontal scroll, edge spacer geometry, `.pcard-clip` wrapper, and diagonal hover fill were already CSS-driven and untouched by this change.
- `framer-motion` remains a dependency since it's still used by `HeroSection`, `Navbar`/`MobileMenu`, and `ContactSection`.
- `npm run typecheck` and `npm run test` (494 tests across 38 files) pass.

Closes #287