### PR TITLE
Timeline section: horizontal scroll + typewriter panels

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -272,7 +272,7 @@ describe('App shell', () => {
       expect(timeline).toBeInTheDocument()
       expect(document.getElementById('timeline-a3f9d2b')).not.toBeInTheDocument()
       expect(timeline?.querySelector('[data-timeline-track="true"]')).toBeInTheDocument()
-      expect(timeline?.querySelectorAll('.snap-anchor')).toHaveLength(3)
+      expect(timeline?.querySelectorAll('.snap-anchor')).toHaveLength(4)
     })
 
     it('projects outer scroll host keeps an internal sticky viewport only', () => {

--- a/src/components/TimelineSection.ordering.test.tsx
+++ b/src/components/TimelineSection.ordering.test.tsx
@@ -17,7 +17,7 @@ describe('TimelineSection ordering', () => {
 
   describe('issue #78 - newest-first ordering', () => {
     it('newest entry is the first user-facing panel at section start', () => {
-      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -27,7 +27,7 @@ describe('TimelineSection ordering', () => {
 
       const newestPanel = document.querySelector('[data-content-index="0"]')
       expect(newestPanel?.querySelector('[data-testid="commit-hash"]')?.textContent).toBe(
-        'commit d4e8f2c',
+        'commit e5f1a3d',
       )
       expect(newestPanel?.querySelector('[data-testid="commit-institution"]')?.textContent).toBe(
         'NETAPP INC.',
@@ -39,7 +39,7 @@ describe('TimelineSection ordering', () => {
     it('activates the newest entry by default from useTimelineScroll', () => {
       render(<TimelineSection />)
 
-      expect(useTimelineScroll).toHaveBeenCalledWith(expect.objectContaining({ current: null }), 3)
+      expect(useTimelineScroll).toHaveBeenCalledWith(expect.objectContaining({ current: null }), 4)
       expect(getTimelinePanel(0).getAttribute('data-content-index')).toBe('0')
       expect(getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')).toBeNull()
     })

--- a/src/components/TimelineSection.rendering.test.tsx
+++ b/src/components/TimelineSection.rendering.test.tsx
@@ -18,7 +18,7 @@ describe('TimelineSection rendering', () => {
   it('each entry uses tl-panel layout class', () => {
     render(<TimelineSection />)
     const commitEntries = screen.getAllByTestId('commit-entry')
-    expect(commitEntries.length).toBe(3)
+    expect(commitEntries.length).toBe(4)
     commitEntries.forEach((entry) => {
       expect(entry).toHaveClass('tl-panel')
     })
@@ -34,7 +34,7 @@ describe('TimelineSection rendering', () => {
 
       expect(timelineSection).toBeInTheDocument()
       expect(track).toBeInTheDocument()
-      expect(panels).toHaveLength(3)
+      expect(panels).toHaveLength(4)
       panels.forEach((panel) => {
         expect(panel.querySelector('.tl-panel')).toBeInTheDocument()
       })
@@ -44,10 +44,10 @@ describe('TimelineSection rendering', () => {
       render(<TimelineSection />)
 
       const sectionLabels = document.querySelectorAll('[data-testid="section-label"]')
-      expect(sectionLabels.length).toBe(3)
+      expect(sectionLabels.length).toBe(4)
 
       const labelTexts = Array.from(sectionLabels).map((el) => el.textContent)
-      expect(labelTexts).toContain('//EXPERIENCE')
+      expect(labelTexts.filter((t) => t === '//EXPERIENCE').length).toBe(2)
       expect(labelTexts.filter((t) => t === '//EDUCATION').length).toBe(2)
     })
 
@@ -122,7 +122,7 @@ describe('TimelineSection rendering', () => {
 
       const role = getTimelinePanel(0).querySelector('[data-testid="commit-role"]')
       expect(role).toHaveClass('tl-title')
-      expect(role?.textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+      expect(role?.textContent).toBe('SOFTWARE_ENGINEER_INTERN')
     })
 
     it('bullets use tl-bullets portfolio class', () => {
@@ -146,9 +146,12 @@ describe('TimelineSection rendering', () => {
         'experience',
       )
       expect(getTimelinePanel(1).querySelector('[data-testid="section-label"]')?.className).toContain(
-        'education',
+        'experience',
       )
       expect(getTimelinePanel(2).querySelector('[data-testid="section-label"]')?.className).toContain(
+        'education',
+      )
+      expect(getTimelinePanel(3).querySelector('[data-testid="section-label"]')?.className).toContain(
         'education',
       )
     })
@@ -168,6 +171,54 @@ describe('TimelineSection rendering', () => {
     })
   })
 
+  describe('issue #288 - persistent blinking carets after typing completes', () => {
+    it('shows no caret on institution or role while typing is still in progress', () => {
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false, false]))
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(100)
+      })
+
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-institution-caret"]')).toBeNull()
+      expect(getTimelinePanel(0).querySelector('[data-testid="commit-role-caret"]')).toBeNull()
+    })
+
+    it('renders a persistent caret on the institution heading once typed', () => {
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false, false]))
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const institution = getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')
+      const caret = institution?.querySelector('[data-testid="commit-institution-caret"]')
+      expect(caret).toBeInTheDocument()
+      expect(caret).toHaveClass('caret')
+    })
+
+    it('renders a persistent caret on the role line once typed', () => {
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false, false]))
+      vi.useFakeTimers()
+
+      render(<TimelineSection />)
+
+      act(() => {
+        vi.advanceTimersByTime(15000)
+      })
+
+      const role = getTimelinePanel(0).querySelector('[data-testid="commit-role"]')
+      const caret = role?.querySelector('[data-testid="commit-role-caret"]')
+      expect(caret).toBeInTheDocument()
+      expect(caret).toHaveClass('caret')
+    })
+  })
+
   describe('issue #206 - timeline section chrome', () => {
     it('renders // 03 TIMELINE header with hscroll classes', () => {
       render(<TimelineSection />)
@@ -178,27 +229,27 @@ describe('TimelineSection rendering', () => {
       expect(document.querySelector('.hscroll-rule')).toBeInTheDocument()
     })
 
-    it('renders progress counter with resume entry count 01 / 03', () => {
-      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
+    it('renders progress counter with resume entry count 01 / 04', () => {
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false, false]))
 
       render(<TimelineSection />)
 
-      expect(screen.getByTestId('progress-count')).toHaveTextContent('01 / 03')
+      expect(screen.getByTestId('progress-count')).toHaveTextContent('01 / 04')
     })
 
     it('progress counter advances with active panel index', () => {
       vi.mocked(useTimelineScroll).mockReturnValue(
-        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5 }),
+        mockTimelineScrollState([false, true, false, false], { activeIndex: 1, progress: 0.5 }),
       )
 
       render(<TimelineSection />)
 
-      expect(screen.getByTestId('progress-count')).toHaveTextContent('02 / 03')
+      expect(screen.getByTestId('progress-count')).toHaveTextContent('02 / 04')
     })
 
     it('progress fill width reflects scroll progress', () => {
       vi.mocked(useTimelineScroll).mockReturnValue(
-        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5 }),
+        mockTimelineScrollState([false, true, false, false], { activeIndex: 1, progress: 0.5 }),
       )
 
       render(<TimelineSection />)
@@ -234,7 +285,7 @@ describe('TimelineSection rendering', () => {
 
     it('hides scroll hint after first panel beat', () => {
       vi.mocked(useTimelineScroll).mockReturnValue(
-        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5 }),
+        mockTimelineScrollState([false, true, false, false], { activeIndex: 1, progress: 0.5 }),
       )
 
       render(<TimelineSection />)

--- a/src/components/TimelineSection.scroll.test.tsx
+++ b/src/components/TimelineSection.scroll.test.tsx
@@ -79,7 +79,7 @@ describe('TimelineSection scroll', () => {
       const panels = track?.querySelectorAll('[data-testid="timeline-panel"]')
 
       expect(track).toHaveClass('hscroll-track')
-      expect(panels).toHaveLength(3)
+      expect(panels).toHaveLength(4)
     })
 
     it('renders one snap anchor per timeline entry', () => {
@@ -88,20 +88,21 @@ describe('TimelineSection scroll', () => {
       const timeline = document.getElementById('timeline')
       const anchors = timeline?.querySelectorAll('.snap-anchor')
 
-      expect(anchors).toHaveLength(3)
+      expect(anchors).toHaveLength(4)
       anchors?.forEach((anchor) => {
         expect(anchor.parentElement).toBe(timeline)
       })
       expect(anchors?.[0]).toHaveStyle({ top: '0vh' })
       expect(anchors?.[1]).toHaveStyle({ top: '100vh' })
       expect(anchors?.[2]).toHaveStyle({ top: '200vh' })
+      expect(anchors?.[3]).toHaveStyle({ top: '300vh' })
     })
 
     it('uses one viewport of section height per entry', () => {
       render(<TimelineSection />)
 
       const timeline = document.getElementById('timeline')
-      expect(timeline).toHaveStyle({ height: '300vh' })
+      expect(timeline).toHaveStyle({ height: '400vh' })
     })
 
     it('does not render each entry as a separate global sticky section', () => {
@@ -117,8 +118,8 @@ describe('TimelineSection scroll', () => {
       const panels = Array.from(document.querySelectorAll('[data-testid="timeline-panel"]'))
       const contentIndexes = panels.map((panel) => panel.getAttribute('data-content-index'))
 
-      expect(contentIndexes).toEqual(['2', '1', '0'])
-      expect(panels[2]?.getAttribute('data-content-index')).toBe('0')
+      expect(contentIndexes).toEqual(['3', '2', '1', '0'])
+      expect(panels[3]?.getAttribute('data-content-index')).toBe('0')
     })
   })
 
@@ -136,7 +137,7 @@ describe('TimelineSection scroll', () => {
 
   describe('issue #237 - newest-to-oldest slide direction', () => {
     it('renders the track oldest-to-newest while preserving newest-first content semantics', () => {
-      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, true, true]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, true, true, true]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -152,30 +153,42 @@ describe('TimelineSection scroll', () => {
         (panel) => panel.querySelector('[data-testid="commit-hash"]')?.textContent,
       )
 
-      expect(renderedContentIndexes).toEqual(['2', '1', '0'])
-      expect(renderedHashes).toEqual(['commit b7c3e1a', 'commit a3f9d2b', 'commit d4e8f2c'])
+      expect(renderedContentIndexes).toEqual(['3', '2', '1', '0'])
+      expect(renderedHashes).toEqual([
+        'commit b7c3e1a',
+        'commit a3f9d2b',
+        'commit d4e8f2c',
+        'commit e5f1a3d',
+      ])
     })
 
     it.each([
       {
-        active: [true, false, false],
+        active: [true, false, false, false],
         activeIndex: 0,
+        expectedHash: 'commit e5f1a3d',
+        expectedCount: '01 / 04',
+        expectedTx: 'translateX(-3000px)',
+      },
+      {
+        active: [false, true, false, false],
+        activeIndex: 1,
         expectedHash: 'commit d4e8f2c',
-        expectedCount: '01 / 03',
+        expectedCount: '02 / 04',
         expectedTx: 'translateX(-2000px)',
       },
       {
-        active: [false, true, false],
-        activeIndex: 1,
+        active: [false, false, true, false],
+        activeIndex: 2,
         expectedHash: 'commit a3f9d2b',
-        expectedCount: '02 / 03',
+        expectedCount: '03 / 04',
         expectedTx: 'translateX(-1000px)',
       },
       {
-        active: [false, false, true],
-        activeIndex: 2,
+        active: [false, false, false, true],
+        activeIndex: 3,
         expectedHash: 'commit b7c3e1a',
-        expectedCount: '03 / 03',
+        expectedCount: '04 / 04',
         expectedTx: 'translateX(0px)',
       },
     ])(
@@ -184,7 +197,7 @@ describe('TimelineSection scroll', () => {
         vi.mocked(useTimelineScroll).mockReturnValue(
           mockTimelineScrollState(active, {
             activeIndex,
-            tx: activeIndex === 0 ? -2000 : activeIndex === 1 ? -1000 : 0,
+            tx: -(3 - activeIndex) * 1000,
           }),
         )
         vi.useFakeTimers()
@@ -257,7 +270,7 @@ describe('TimelineSection scroll', () => {
         const { unmount } = render(<TimelineSection />)
 
         expect(screen.getByTestId('progress-count')).toHaveTextContent(
-          `${String(scenario.activeIndex + 1).padStart(2, '0')} / 03`,
+          `${String(scenario.activeIndex + 1).padStart(2, '0')} / 04`,
         )
         expect(document.querySelector('[data-timeline-track="true"]')).toHaveStyle({
           transform: `translateX(${scenario.tx}px)`,

--- a/src/components/TimelineSection.test-setup.ts
+++ b/src/components/TimelineSection.test-setup.ts
@@ -7,7 +7,7 @@ const {
   getTimelinePanel,
   mockUseTimelineScroll,
 } = vi.hoisted(() => {
-  const DEFAULT_ACTIVE = [true, false, false] as const
+  const DEFAULT_ACTIVE = [true, false, false, false] as const
 
   function mockTimelineScrollState(
     active: boolean[],

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -64,14 +64,18 @@ function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean 
           <div className="tl-sep" aria-hidden="true" />
           <h2 className="tl-org" data-testid="commit-institution" data-typewriter-line>
             {institutionLine}
-            {institutionTyped && <span className="caret" data-testid="commit-institution-caret" aria-hidden="true" />}
+            {institutionTyped && (
+              <span className="caret" data-testid="commit-institution-caret" aria-hidden="true" />
+            )}
           </h2>
         </>
       )}
       {roleLine !== undefined && (
         <p className="tl-title" data-testid="commit-role" data-typewriter-line>
           {roleLine}
-          {roleTyped && <span className="caret" data-testid="commit-role-caret" aria-hidden="true" />}
+          {roleTyped && (
+            <span className="caret" data-testid="commit-role-caret" aria-hidden="true" />
+          )}
         </p>
       )}
       {bulletLines.length > 0 && (

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -37,6 +37,9 @@ function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean 
     .map((_, index) => displayedLines[METADATA_LINE_COUNT + 2 + index])
     .filter((line): line is string => line !== undefined && line !== '')
 
+  const institutionTyped = institutionLine === entry.institution
+  const roleTyped = roleLine === entry.role
+
   return (
     <div className="tl-panel" data-testid="commit-entry">
       <div data-testid="commit-metadata">
@@ -61,12 +64,14 @@ function CommitEntry({ entry, active }: { entry: TimelineEntry; active: boolean 
           <div className="tl-sep" aria-hidden="true" />
           <h2 className="tl-org" data-testid="commit-institution" data-typewriter-line>
             {institutionLine}
+            {institutionTyped && <span className="caret" data-testid="commit-institution-caret" aria-hidden="true" />}
           </h2>
         </>
       )}
       {roleLine !== undefined && (
         <p className="tl-title" data-testid="commit-role" data-typewriter-line>
           {roleLine}
+          {roleTyped && <span className="caret" data-testid="commit-role-caret" aria-hidden="true" />}
         </p>
       )}
       {bulletLines.length > 0 && (

--- a/src/components/TimelineSection.typewriter.test.tsx
+++ b/src/components/TimelineSection.typewriter.test.tsx
@@ -38,7 +38,7 @@ describe('TimelineSection typewriter', () => {
       const allLines = document.querySelectorAll('[data-typewriter-line]')
       const firstPanelLines = Array.from(allLines).filter((_, i) => i < 5)
       expect(firstPanelLines.length).toBeGreaterThan(0)
-      expect(firstPanelLines[0].textContent).toBe('commit d4e8f2c')
+      expect(firstPanelLines[0].textContent).toBe('commit e5f1a3d')
     })
 
     it('Typewriter types all fields to completion when panel stays active', () => {
@@ -54,11 +54,11 @@ describe('TimelineSection typewriter', () => {
       const allLines = document.querySelectorAll('[data-typewriter-line]')
       const texts = Array.from(allLines).map((el) => el.textContent)
 
-      expect(texts).toContain('commit d4e8f2c')
+      expect(texts).toContain('commit e5f1a3d')
       expect(texts).toContain('Author: Farhan Mohammed')
-      expect(texts).toContain('Date:   AUG 2024 – PRESENT')
+      expect(texts).toContain('Date:   JUN 2026 – PRESENT')
       expect(texts).toContain('NETAPP INC.')
-      expect(texts).toContain('SOFTWARE_ENGINEER_IN_TEST')
+      expect(texts).toContain('SOFTWARE_ENGINEER_INTERN')
     })
 
     it('Typewriter types bullets when present', () => {
@@ -74,7 +74,7 @@ describe('TimelineSection typewriter', () => {
       const allLines = document.querySelectorAll('[data-typewriter-line]')
       const texts = Array.from(allLines).map((el) => el.textContent)
 
-      expect(texts.some((text) => text?.includes('Built automated analysis pipeline'))).toBe(true)
+      expect(texts.some((text) => text?.includes('Contributed to web platform development'))).toBe(true)
     })
 
     it('inactive panels remain empty', () => {
@@ -144,7 +144,7 @@ describe('TimelineSection typewriter', () => {
     })
 
     it('issue #98 - longest bullet completes within 2.5s', () => {
-      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -284,7 +284,7 @@ describe('TimelineSection typewriter', () => {
         getTimelinePanel(0).querySelectorAll('[data-typewriter-line]'),
       ).map((el) => el.textContent)
 
-      expect(panel1Texts).toContain('commit d4e8f2c')
+      expect(panel1Texts).toContain('commit e5f1a3d')
       expect(panel1Texts).toContain('NETAPP INC.')
 
       vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, true, false]))
@@ -298,7 +298,7 @@ describe('TimelineSection typewriter', () => {
         getTimelinePanel(0).querySelectorAll('[data-typewriter-line]'),
       ).map((el) => el.textContent)
 
-      expect(panel1TextsAfter).toContain('commit d4e8f2c')
+      expect(panel1TextsAfter).toContain('commit e5f1a3d')
       expect(panel1TextsAfter).toContain('NETAPP INC.')
     })
   })
@@ -317,13 +317,13 @@ describe('TimelineSection typewriter', () => {
       const metadata = getTimelinePanel(0).querySelector('[data-testid="commit-metadata"]')
       expect(metadata).toBeInTheDocument()
       expect(metadata?.querySelector('[data-testid="commit-hash"]')?.textContent).toBe(
-        'commit d4e8f2c'
+        'commit e5f1a3d'
       )
       expect(metadata?.querySelector('[data-testid="commit-author"]')?.textContent).toBe(
         'Author: Farhan Mohammed'
       )
       expect(metadata?.querySelector('[data-testid="commit-date"]')?.textContent).toBe(
-        'Date:   AUG 2024 – PRESENT'
+        'Date:   JUN 2026 – PRESENT'
       )
     })
 
@@ -353,11 +353,11 @@ describe('TimelineSection typewriter', () => {
       })
 
       const role = getTimelinePanel(0).querySelector('[data-testid="commit-role"]')
-      expect(role?.textContent).toBe('SOFTWARE_ENGINEER_IN_TEST')
+      expect(role?.textContent).toBe('SOFTWARE_ENGINEER_INTERN')
     })
 
     it('renders bullets as semantic list items', () => {
-      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, true, false, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -366,7 +366,7 @@ describe('TimelineSection typewriter', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const details = getTimelinePanel(0).querySelector('[data-testid="commit-details"]')
+      const details = getTimelinePanel(1).querySelector('[data-testid="commit-details"]')
       expect(details?.tagName).toBe('UL')
 
       const items = details?.querySelectorAll('li') ?? []
@@ -390,7 +390,7 @@ describe('TimelineSection typewriter', () => {
     })
 
     it('omits commit-details list when entry has no bullets', () => {
-      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, true, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([false, false, true, false]))
       vi.useFakeTimers()
 
       render(<TimelineSection />)
@@ -399,7 +399,7 @@ describe('TimelineSection typewriter', () => {
         vi.advanceTimersByTime(15000)
       })
 
-      const msPanel = getTimelinePanel(1)
+      const msPanel = getTimelinePanel(2)
       expect(msPanel.querySelector('[data-testid="commit-details"]')).not.toBeInTheDocument()
       expect(msPanel.querySelector('[data-testid="commit-institution"]')?.textContent).toBe(
         'WICHITA STATE UNIVERSITY'
@@ -436,7 +436,7 @@ describe('TimelineSection typewriter', () => {
 
   describe('issue #238 - HTML-reference typewriter pacing', () => {
     it('preserves inactive text but restarts from the first line when reactivated', () => {
-      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false]))
+      vi.mocked(useTimelineScroll).mockReturnValue(mockTimelineScrollState([true, false, false, false]))
       vi.useFakeTimers()
 
       const { rerender } = render(<TimelineSection />)
@@ -446,14 +446,14 @@ describe('TimelineSection typewriter', () => {
       })
 
       expect(getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')).toHaveTextContent(
-        'commit d4e8f2c',
+        'commit e5f1a3d',
       )
       expect(getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')).toHaveTextContent(
         'NETAPP INC.',
       )
 
       vi.mocked(useTimelineScroll).mockReturnValue(
-        mockTimelineScrollState([false, true, false], { activeIndex: 1, progress: 0.5, tx: -1000 }),
+        mockTimelineScrollState([false, true, false, false], { activeIndex: 1, progress: 0.5, tx: -2000 }),
       )
       rerender(<TimelineSection />)
 
@@ -462,14 +462,14 @@ describe('TimelineSection typewriter', () => {
       })
 
       expect(getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')).toHaveTextContent(
-        'commit d4e8f2c',
+        'commit e5f1a3d',
       )
       expect(getTimelinePanel(0).querySelector('[data-testid="commit-institution"]')).toHaveTextContent(
         'NETAPP INC.',
       )
 
       vi.mocked(useTimelineScroll).mockReturnValue(
-        mockTimelineScrollState([true, false, false], { activeIndex: 0, progress: 0, tx: -2000 }),
+        mockTimelineScrollState([true, false, false, false], { activeIndex: 0, progress: 0, tx: -3000 }),
       )
       rerender(<TimelineSection />)
 
@@ -478,7 +478,7 @@ describe('TimelineSection typewriter', () => {
       })
 
       expect(getTimelinePanel(0).querySelector('[data-testid="commit-hash"]')).toHaveTextContent(
-        'commit d4e8f2c',
+        'commit e5f1a3d',
       )
       expect(
         getTimelinePanel(0).querySelector('[data-testid="commit-institution"]'),

--- a/src/data/resume-audit.test.ts
+++ b/src/data/resume-audit.test.ts
@@ -8,16 +8,22 @@ const RESUME_FULL_NAME = 'Farhan Mohammed'
 const RESUME_EMAIL = 'famohammed@shockers.wichita.edu'
 
 const RESUME_TIMELINE = {
+  netappIntern: {
+    institution: 'NetApp Inc.',
+    role: 'Software Engineer Intern',
+    dateRange: 'Jun 2026 – Present',
+    category: 'experience' as const,
+  },
   netapp: {
     institution: 'NetApp Inc.',
     role: 'Software Engineer in Test',
-    dateRange: 'Aug 2024 – Present',
+    dateRange: 'Jul 2024 – Jun 2026',
     category: 'experience' as const,
   },
   ms: {
     institution: 'Wichita State University',
     role: 'Accelerated M.S. Computer Science',
-    dateRange: 'Jan 2026 – Dec 2027 (Expected)',
+    dateRange: 'Jan 2026 – May 2027 (Expected)',
     category: 'education' as const,
   },
   bs: {
@@ -101,33 +107,92 @@ describe('resume source-of-truth audit', () => {
   })
 
   describe('timeline', () => {
-    it('entry count matches resume (1 experience + 2 education)', () => {
-      expect(timelineEntries).toHaveLength(3)
-      expect(timelineEntries.filter((e) => e.category === 'experience')).toHaveLength(1)
+    it('entry count matches resume (2 experience + 2 education)', () => {
+      expect(timelineEntries).toHaveLength(4)
+      expect(timelineEntries.filter((e) => e.category === 'experience')).toHaveLength(2)
       expect(timelineEntries.filter((e) => e.category === 'education')).toHaveLength(2)
     })
 
-    it('NetApp institution matches resume', () => {
-      const netapp = findEntry((e) => e.category === 'experience')
+    it('NetApp Intern institution matches resume', () => {
+      const intern = findEntry(
+        (e) =>
+          e.category === 'experience' &&
+          normalizeResumeText(e.role).includes('software engineer intern'),
+      )
+      expect(normalizeResumeText(intern.institution)).toBe(
+        normalizeResumeText(RESUME_TIMELINE.netappIntern.institution),
+      )
+    })
+
+    it('NetApp Intern role matches resume', () => {
+      const intern = findEntry(
+        (e) =>
+          e.category === 'experience' &&
+          normalizeResumeText(e.role).includes('software engineer intern'),
+      )
+      expect(normalizeResumeText(intern.role)).toBe(
+        normalizeResumeText(RESUME_TIMELINE.netappIntern.role),
+      )
+    })
+
+    it('NetApp Intern date range matches resume', () => {
+      const intern = findEntry(
+        (e) =>
+          e.category === 'experience' &&
+          normalizeResumeText(e.role).includes('software engineer intern'),
+      )
+      expect(normalizeResumeText(intern.dateRange)).toBe(
+        normalizeResumeText(RESUME_TIMELINE.netappIntern.dateRange),
+      )
+    })
+
+    it('NetApp Intern bullet matches resume content', () => {
+      const intern = findEntry(
+        (e) =>
+          e.category === 'experience' &&
+          normalizeResumeText(e.role).includes('software engineer intern'),
+      )
+      expect(intern.bullets).toHaveLength(1)
+      expect(intern.bullets[0]).toContain('Contributed to web platform development')
+    })
+
+    it('NetApp SWE in Test institution matches resume', () => {
+      const netapp = findEntry(
+        (e) =>
+          e.category === 'experience' &&
+          normalizeResumeText(e.role).includes('software engineer in test'),
+      )
       expect(normalizeResumeText(netapp.institution)).toBe(
         normalizeResumeText(RESUME_TIMELINE.netapp.institution),
       )
     })
 
-    it('NetApp role matches resume', () => {
-      const netapp = findEntry((e) => e.category === 'experience')
+    it('NetApp SWE in Test role matches resume', () => {
+      const netapp = findEntry(
+        (e) =>
+          e.category === 'experience' &&
+          normalizeResumeText(e.role).includes('software engineer in test'),
+      )
       expect(normalizeResumeText(netapp.role)).toBe(normalizeResumeText(RESUME_TIMELINE.netapp.role))
     })
 
-    it('NetApp date range matches resume', () => {
-      const netapp = findEntry((e) => e.category === 'experience')
+    it('NetApp SWE in Test date range matches resume', () => {
+      const netapp = findEntry(
+        (e) =>
+          e.category === 'experience' &&
+          normalizeResumeText(e.role).includes('software engineer in test'),
+      )
       expect(normalizeResumeText(netapp.dateRange)).toBe(
         normalizeResumeText(RESUME_TIMELINE.netapp.dateRange),
       )
     })
 
-    it('NetApp bullets match resume content', () => {
-      const netapp = findEntry((e) => e.category === 'experience')
+    it('NetApp SWE in Test bullets match resume content', () => {
+      const netapp = findEntry(
+        (e) =>
+          e.category === 'experience' &&
+          normalizeResumeText(e.role).includes('software engineer in test'),
+      )
       expect(netapp.bullets).toHaveLength(4)
       expect(netapp.bullets[0]).toContain('automated analysis pipeline')
       expect(netapp.bullets[1]).toContain('30%')

--- a/src/data/timeline.ts
+++ b/src/data/timeline.ts
@@ -9,8 +9,18 @@ export interface TimelineEntry {
 
 export const timelineEntries: TimelineEntry[] = [
   {
+    hash: 'e5f1a3d',
+    dateRange: 'JUN 2026 – PRESENT',
+    institution: 'NETAPP INC.',
+    role: 'SOFTWARE_ENGINEER_INTERN',
+    bullets: [
+      'Contributed to web platform development in TypeScript and PostgreSQL, implementing API endpoints, refactoring existing code, and reviewing pull requests',
+    ],
+    category: 'experience',
+  },
+  {
     hash: 'd4e8f2c',
-    dateRange: 'AUG 2024 – PRESENT',
+    dateRange: 'JUL 2024 – JUN 2026',
     institution: 'NETAPP INC.',
     role: 'SOFTWARE_ENGINEER_IN_TEST',
     bullets: [
@@ -23,7 +33,7 @@ export const timelineEntries: TimelineEntry[] = [
   },
   {
     hash: 'a3f9d2b',
-    dateRange: 'JAN 2026 – DEC 2027 (EXPECTED)',
+    dateRange: 'JAN 2026 – MAY 2027 (EXPECTED)',
     institution: 'WICHITA STATE UNIVERSITY',
     role: 'ACCELERATED_M.S._COMPUTER_SCIENCE',
     bullets: [],


### PR DESCRIPTION
## Purpose
The timeline section's data drifted out of sync with `public/resume.pdf`, and the org/title lines lacked the persistent blinking caret used elsewhere on the site.

## What it does
Updates `src/data/timeline.ts` to add the missing NetApp Software Engineer Intern entry and correct two date ranges, then applies the existing `.caret` CSS class to the institution (`tl-org`) and role (`tl-title`) lines in `TimelineSection.tsx` once each line finishes typing.

## Changes made
- `src/data/timeline.ts` — added NetApp SWE Intern entry ("JUN 2026 – PRESENT", with its resume bullet); corrected NetApp SWE in Test to "JUL 2024 – JUN 2026"; corrected WSU M.S. to "JAN 2026 – MAY 2027 (EXPECTED)".
- `src/components/TimelineSection.tsx` — renders a `<span className="caret">` immediately after the institution/role text once the typed line equals the entry's full target string (line-mode typing means equality implies the line is fully typed).
- `src/components/TimelineSection.{rendering,scroll,ordering,typewriter}.test.tsx`, `TimelineSection.test-setup.ts` — updated fixtures/assertions for 4 timeline entries (previously 3) and added new caret-rendering test coverage.
- `src/data/resume-audit.test.ts` — corrected the source-of-truth constants (the test previously encoded the stale resume facts as its own expectations) and split assertions for the new intern entry vs. the existing SWE-in-Test entry.
- `src/App.test.tsx` — updated snap-anchor count assertion from 3 to 4.

## Additional notes
- The new intern entry is the most recent role, so it was inserted at array index 0 (newest-first ordering), shifting the existing three entries down by one — all dependent test fixtures were updated accordingly.
- Caret visibility is derived by comparing the typed line to the entry's full institution/role string rather than adding a new "done" flag to `useTypewriter`, since line-mode typing writes the whole line atomically.
- `npm run typecheck` and `npm run test` both pass (499/499). Pre-existing `react-hooks/refs` lint errors in `useScrollProgress.ts`/`useTimelineScroll.ts` are unrelated to this change (verified present on `main` before this branch).

Closes #288