### PR TITLE
Bump small font sizes + fix skill category label contrast

### DIFF
--- a/src/components/ProjectsSection.tsx
+++ b/src/components/ProjectsSection.tsx
@@ -36,7 +36,7 @@ const ProjectsSection: React.FC<Props> = ({ projects }) => {
       ref={outerRef}
       id="projects"
       data-sticky-scroll-host="true"
-      className="relative hscroll min-h-screen px-8 bg-graphite-light"
+      className="relative hscroll min-h-screen px-8 bg-graphite"
       style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'clip' }}
     >
       {projects.map((_, index) => (

--- a/src/components/SkillsSection.tsx
+++ b/src/components/SkillsSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { StickySection } from './StickySection'
 
-const TILE_REVEAL_STEP_S = 0.12
+const TILE_REVEAL_STEP_S = 0.08
 
 type Category = 'ML / DL' | 'DATA & COMPUTATION' | 'LANGUAGES' | 'TOOLS & SYSTEMS'
 type TileColor = 'orange' | 'blue' | 'fuchsia' | 'peri' | 'dark' | 'platinum' | 'yellow'

--- a/src/components/TimelineSection.tsx
+++ b/src/components/TimelineSection.tsx
@@ -136,7 +136,7 @@ const TimelineSection: React.FC = () => {
       ref={outerRef}
       id="timeline"
       data-sticky-scroll-host="true"
-      className="relative hscroll min-h-screen bg-graphite-light"
+      className="relative hscroll min-h-screen bg-graphite"
       style={{ height: `${scrollRangeVh * 100}vh`, overflowX: 'clip' }}
     >
       {timelineEntries.map((entry, index) => (

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -213,7 +213,7 @@
   /* ─── SKILLS ──── */
   #skills{width:100%;padding:0;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
-  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:2fr 1.5fr 1.2fr 1.2fr 1.2fr 1.2fr 0.8fr;gap:12px;flex:1;
+  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:2fr 1.5fr 1fr 1fr 1fr 1fr 0.6fr;gap:12px;flex:1;
     grid-template-areas:
       "py py py js js dk"
       "py py py re re cc"
@@ -222,10 +222,10 @@
       "tr tr gt gt fl fl"
       "mn lx an jp nx nx"
       "pal pal pal pal pal pal";}
-  .bi{padding:28px;display:flex;flex-direction:column;justify-content:flex-end;overflow:hidden;position:relative;opacity:0;transform:translateY(30px) scale(.94);transition:opacity .7s var(--ease),transform .7s var(--ease),filter .2s ease}
+  .bi{padding:24px;display:flex;flex-direction:column;justify-content:flex-end;overflow:hidden;position:relative;opacity:0;transform:translateY(30px) scale(.94);transition:opacity .7s var(--ease),transform .7s var(--ease),filter .2s ease}
   .bi.in{opacity:1;transform:none}
   .bi:hover{filter:brightness(1.1)}
-  .bi-cat{font-size:10px;letter-spacing:2.5px;margin-bottom:10px;color:inherit;opacity:.55}
+  .bi-cat{font-size:10px;letter-spacing:2.5px;margin-bottom:10px;color:inherit}
   .bi-name{font-size:16px;font-weight:700;letter-spacing:1px}
   .bi-lg .bi-name{font-size:26px}
   .bi-lg .bi-cat{font-size:11px;margin-bottom:14px}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -213,7 +213,7 @@
   /* ─── SKILLS ──── */
   #skills{width:100%;padding:0;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
-  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:2fr 1.5fr 1fr 1fr 1fr 1fr 0.6fr;gap:12px;flex:1;
+  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:2fr 1.5fr 1.2fr 1.2fr 1.2fr 1.2fr 0.8fr;gap:12px;flex:1;
     grid-template-areas:
       "py py py js js dk"
       "py py py re re cc"
@@ -222,12 +222,12 @@
       "tr tr gt gt fl fl"
       "mn lx an jp nx nx"
       "pal pal pal pal pal pal";}
-  .bi{padding:24px;display:flex;flex-direction:column;justify-content:flex-end;overflow:hidden;position:relative;opacity:0;transform:translateY(30px) scale(.94);transition:opacity .7s var(--ease),transform .7s var(--ease),filter .2s ease}
+  .bi{padding:28px;display:flex;flex-direction:column;justify-content:flex-end;overflow:hidden;position:relative;opacity:0;transform:translateY(30px) scale(.94);transition:opacity .7s var(--ease),transform .7s var(--ease),filter .2s ease}
   .bi.in{opacity:1;transform:none}
   .bi:hover{filter:brightness(1.1)}
-  .bi-cat{font-size:10px;letter-spacing:2.5px;margin-bottom:10px;color:rgba(42,43,42,.7)}
-  .bi-name{font-size:14px;font-weight:700;letter-spacing:1px}
-  .bi-lg .bi-name{font-size:22px}
+  .bi-cat{font-size:10px;letter-spacing:2.5px;margin-bottom:10px;color:inherit;opacity:.55}
+  .bi-name{font-size:16px;font-weight:700;letter-spacing:1px}
+  .bi-lg .bi-name{font-size:26px}
   .bi-lg .bi-cat{font-size:11px;margin-bottom:14px}
   .bi-py{grid-area:py}.bi-js{grid-area:js}.bi-dk{grid-area:dk}
   .bi-re{grid-area:re}.bi-cc{grid-area:cc}.bi-nd{grid-area:nd}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -26,12 +26,12 @@
   #ls{position:fixed;inset:0;background:var(--color-graphite);z-index:9999;display:flex;align-items:center;justify-content:center;transition:opacity .5s}
   #ls.out{opacity:0;pointer-events:none}
   .ls-inner{width:280px}
-  .ls-sys{font-size:9px;color:var(--color-periwinkle);letter-spacing:3px;margin-bottom:10px;opacity:.5}
+  .ls-sys{font-size:11px;color:var(--color-periwinkle);letter-spacing:3px;margin-bottom:10px;opacity:.5}
   .ls-name{font-family:var(--font-display);font-size:13px;color:var(--color-platinum);line-height:2;margin-bottom:28px}
   .ls-track{height:1px;background:var(--color-graphite-light)}
   .ls-fill{height:1px;background:var(--color-atomic-tangerine);width:0%;animation:lf 2.4s ease forwards .3s}
   @keyframes lf{to{width:100%}}
-  .ls-msg{font-size:9px;color:var(--color-periwinkle);margin-top:14px;letter-spacing:1px;opacity:.5}
+  .ls-msg{font-size:11px;color:var(--color-periwinkle);margin-top:14px;letter-spacing:1px;opacity:.5}
 
   /* ─── NAV ──── */
   .nav{position:fixed;top:0;left:0;right:0;z-index:100;background:rgba(42,43,42,.92);backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);border-bottom:1px solid var(--color-graphite-light);height:56px;padding:0 32px;display:flex;align-items:center;justify-content:space-between}
@@ -60,14 +60,14 @@
   #home{width:100%;min-height:100vh;display:flex;flex-direction:column;justify-content:center;padding:0 5vw;position:relative;overflow:hidden}
   .hero-grid{position:absolute;inset:0;background-image:linear-gradient(var(--color-graphite-light) 1px,transparent 1px),linear-gradient(90deg,var(--color-graphite-light) 1px,transparent 1px);background-size:80px 80px;opacity:.35;mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%);-webkit-mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%)}
   .hero-inner{position:relative;z-index:1;width:100%;padding:0 5vw}
-  .hero-init{font-size:11px;color:var(--color-atomic-tangerine);letter-spacing:4px;margin-bottom:18px}
+  .hero-init{font-size:13px;color:var(--color-atomic-tangerine);letter-spacing:4px;margin-bottom:18px}
   .hero-bar{width:48px;height:2px;background:var(--color-atomic-tangerine);margin-bottom:32px}
   .hero-name{font-family:var(--font-display);font-size:clamp(40px,12vw,180px);line-height:1.05;color:var(--color-platinum);letter-spacing:-2px;margin-bottom:36px}
   .hero-name-line{display:block;min-height:1.1em}
   .hero-role{font-size:clamp(11px,1.1vw,15px);color:var(--color-periwinkle);letter-spacing:5px;margin-bottom:24px}
   .hero-tag{font-size:clamp(12px,1.2vw,16px);color:var(--color-platinum);letter-spacing:1px;margin-bottom:48px;max-width:760px;line-height:1.8}
   .hero-cta{display:flex;gap:18px;flex-wrap:wrap}
-  .btn{font-family:var(--font-body);font-size:11px;letter-spacing:3px;padding:16px 26px;cursor:pointer;display:inline-flex;align-items:center;gap:12px;text-decoration:none;border:none;transition:transform .25s var(--ease),background .2s var(--ease),color .2s var(--ease)}
+  .btn{font-family:var(--font-body);font-size:13px;letter-spacing:3px;padding:16px 26px;cursor:pointer;display:inline-flex;align-items:center;gap:12px;text-decoration:none;border:none;transition:transform .25s var(--ease),background .2s var(--ease),color .2s var(--ease)}
   .btn span{transition:transform .2s var(--ease)}
   .btn:hover{transform:scale(1.05)}
   .btn:hover span{transform:translateX(4px)}
@@ -90,7 +90,7 @@
   .hscroll-no{font-size:14px;color:var(--color-atomic-tangerine);letter-spacing:3px}
   .hscroll-name{font-family:var(--font-display);font-size:18px;color:var(--color-platinum);letter-spacing:3px}
   .hscroll-rule{flex:1;height:1px;background:var(--color-graphite-light)}
-  .hscroll-progress{display:flex;align-items:center;gap:10px;font-size:9px;color:var(--color-periwinkle);letter-spacing:2px}
+  .hscroll-progress{display:flex;align-items:center;gap:10px;font-size:11px;color:var(--color-periwinkle);letter-spacing:2px}
   .hscroll-progress-track{width:80px;height:1px;background:var(--color-graphite-light);position:relative}
   .hscroll-progress-fill{position:absolute;left:0;top:0;height:100%;background:var(--color-atomic-tangerine);transition:width .1s linear}
   .hscroll-track{flex:1;display:flex;align-items:center;will-change:transform}
@@ -225,10 +225,10 @@
   .bi{padding:24px;display:flex;flex-direction:column;justify-content:flex-end;overflow:hidden;position:relative;opacity:0;transform:translateY(30px) scale(.94);transition:opacity .7s var(--ease),transform .7s var(--ease),filter .2s ease}
   .bi.in{opacity:1;transform:none}
   .bi:hover{filter:brightness(1.1)}
-  .bi-cat{font-size:8px;letter-spacing:2.5px;margin-bottom:10px;opacity:.55}
+  .bi-cat{font-size:10px;letter-spacing:2.5px;margin-bottom:10px;color:rgba(42,43,42,.7)}
   .bi-name{font-size:14px;font-weight:700;letter-spacing:1px}
   .bi-lg .bi-name{font-size:22px}
-  .bi-lg .bi-cat{font-size:9px;margin-bottom:14px}
+  .bi-lg .bi-cat{font-size:11px;margin-bottom:14px}
   .bi-py{grid-area:py}.bi-js{grid-area:js}.bi-dk{grid-area:dk}
   .bi-re{grid-area:re}.bi-cc{grid-area:cc}.bi-nd{grid-area:nd}
   .bi-nx{grid-area:nx}.bi-fl{grid-area:fl}.bi-gt{grid-area:gt}
@@ -293,7 +293,7 @@
 
   @media (max-width:760px){
     .nav-list{gap:14px}
-    .nav-link{font-size:9px}
+    .nav-link{font-size:11px}
     .bento{grid-template-columns:repeat(2,1fr);grid-template-rows:none;grid-template-areas:none}
     .bi{grid-area:auto !important;min-height:120px}
     .pcard{width:88vw;height:64vh}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -59,7 +59,7 @@
   /* ─── HERO ──── */
   #home{width:100%;min-height:100vh;display:flex;flex-direction:column;justify-content:center;padding:0 5vw;position:relative;overflow:hidden}
   .hero-grid{position:absolute;inset:0;background-image:linear-gradient(var(--color-graphite-light) 1px,transparent 1px),linear-gradient(90deg,var(--color-graphite-light) 1px,transparent 1px);background-size:80px 80px;opacity:.35;mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%);-webkit-mask-image:radial-gradient(ellipse at 30% 50%,#000 30%,transparent 75%)}
-  .hero-inner{position:relative;z-index:1;width:100%;padding:0 5vw}
+  .hero-inner{position:relative;z-index:1;width:100%;padding:0}
   .hero-init{font-size:13px;color:var(--color-atomic-tangerine);letter-spacing:4px;margin-bottom:18px}
   .hero-bar{width:48px;height:2px;background:var(--color-atomic-tangerine);margin-bottom:32px}
   .hero-name{font-family:var(--font-display);font-size:clamp(40px,12vw,180px);line-height:1.05;color:var(--color-platinum);letter-spacing:-2px;margin-bottom:36px}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -136,7 +136,7 @@
   .pcard-desc{font-size:16px;color:var(--color-graphite);opacity:.85;line-height:1.85;margin-top:20px;flex:1;position:relative;z-index:2;text-wrap:pretty;transition:color .35s var(--ease),opacity .35s var(--ease)}
   .pcard:hover .pcard-desc{color:var(--color-platinum);opacity:1}
   .pcard-tags{display:flex;gap:8px;flex-wrap:wrap;margin-top:18px;position:relative;z-index:2}
-  .ptag{font-size:16px;padding:8px 14px;letter-spacing:1.5px;font-weight:700;transition:background .35s var(--ease),color .35s var(--ease),border-color .35s var(--ease)}
+  .ptag{font-size:14px;padding:8px 14px;letter-spacing:1.5px;font-weight:700;transition:background .35s var(--ease),color .35s var(--ease),border-color .35s var(--ease)}
   .ptag-fuchsia{background:var(--color-fuchsia-flame);color:var(--color-platinum)}
   .ptag-blue{background:var(--color-ultrasonic-blue);color:var(--color-platinum)}
   .ptag-orange{background:var(--color-atomic-tangerine);color:var(--color-graphite)}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -133,10 +133,10 @@
   .pcard:hover .pcard-num{color:var(--color-platinum);opacity:.9}
   .pcard-name{font-family:var(--font-display);font-size:clamp(20px,2vw,26px);color:var(--color-graphite);letter-spacing:2px;margin-top:30px;position:relative;z-index:2;line-height:1.3;transition:color .35s var(--ease)}
   .pcard:hover .pcard-name{color:var(--color-platinum)}
-  .pcard-desc{font-size:14px;color:var(--color-graphite);opacity:.85;line-height:1.85;margin-top:20px;flex:1;position:relative;z-index:2;text-wrap:pretty;transition:color .35s var(--ease),opacity .35s var(--ease)}
+  .pcard-desc{font-size:16px;color:var(--color-graphite);opacity:.85;line-height:1.85;margin-top:20px;flex:1;position:relative;z-index:2;text-wrap:pretty;transition:color .35s var(--ease),opacity .35s var(--ease)}
   .pcard:hover .pcard-desc{color:var(--color-platinum);opacity:1}
   .pcard-tags{display:flex;gap:8px;flex-wrap:wrap;margin-top:18px;position:relative;z-index:2}
-  .ptag{font-size:14px;padding:8px 14px;letter-spacing:1.5px;font-weight:700;transition:background .35s var(--ease),color .35s var(--ease),border-color .35s var(--ease)}
+  .ptag{font-size:16px;padding:8px 14px;letter-spacing:1.5px;font-weight:700;transition:background .35s var(--ease),color .35s var(--ease),border-color .35s var(--ease)}
   .ptag-fuchsia{background:var(--color-fuchsia-flame);color:var(--color-platinum)}
   .ptag-blue{background:var(--color-ultrasonic-blue);color:var(--color-platinum)}
   .ptag-orange{background:var(--color-atomic-tangerine);color:var(--color-graphite)}
@@ -144,7 +144,7 @@
   .pcard:hover .ptag{background:var(--color-platinum);color:var(--color-graphite);box-shadow:none}
   .pcard-links{display:flex;gap:20px;margin-top:20px;padding-top:18px;border-top:1px dashed rgba(42,43,42,.25);position:relative;z-index:2;transition:border-color .35s var(--ease)}
   .pcard:hover .pcard-links{border-top-color:rgba(239,241,243,.32)}
-  .plink{font-size:14px;color:var(--color-graphite);text-decoration:none;letter-spacing:2px;display:inline-flex;align-items:center;gap:6px;font-weight:700;transition:color .35s var(--ease)}
+  .plink{font-size:16px;color:var(--color-graphite);text-decoration:none;letter-spacing:2px;display:inline-flex;align-items:center;gap:6px;font-weight:700;transition:color .35s var(--ease)}
   .plink::before{content:'//';color:var(--color-graphite);opacity:.5;margin-right:2px;transition:color .35s var(--ease)}
   .pcard:hover .plink{color:var(--color-platinum)}
   .pcard:hover .plink::before{color:var(--color-platinum);opacity:.6}

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -213,7 +213,7 @@
   /* ─── SKILLS ──── */
   #skills{width:100%;padding:0;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
-  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:2fr 1.5fr 1fr 1fr 1fr 1fr 0.6fr;gap:12px;flex:1;
+  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:1.6fr 1.2fr 0.8fr 0.8fr 0.8fr 0.8fr 0.5fr;gap:12px;flex:1;
     grid-template-areas:
       "py py py js js dk"
       "py py py re re cc"

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -259,7 +259,7 @@
   .tl-bullets li{font-size:clamp(12px,1.1vw,15px);color:var(--color-periwinkle);letter-spacing:1px;padding-left:24px;position:relative;line-height:1.7;min-height:1.7em}
   .tl-bullets li::before{content:'•';position:absolute;left:0;color:var(--color-atomic-tangerine)}
   .tl-section-tag{position:absolute;top:0;left:8vw;display:flex;align-items:baseline;gap:10px;line-height:1}
-  .tl-section-slash{font-family:var(--font-body);font-size:14px;color:var(--color-atomic-tangerine);letter-spacing:3px}
+  .tl-section-slash{font-family:var(--font-display);font-size:14px;color:var(--color-atomic-tangerine);letter-spacing:3px}
   .tl-section-kind{font-family:var(--font-display);font-size:clamp(14px,1.8vw,22px);letter-spacing:5px;color:var(--color-atomic-tangerine)}
   .tl-section-tag.education .tl-section-slash,
   .tl-section-tag.experience .tl-section-slash,

--- a/src/portfolio.css
+++ b/src/portfolio.css
@@ -213,7 +213,7 @@
   /* ─── SKILLS ──── */
   #skills{width:100%;padding:0;position:relative}
   .skills-head{display:flex;align-items:center;gap:18px;margin-bottom:32px}
-  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:1.6fr 1.2fr 0.8fr 0.8fr 0.8fr 0.8fr 0.5fr;gap:12px;flex:1;
+  .bento{padding:0 5vw;display:grid;grid-template-columns:repeat(6,1fr);grid-template-rows:1.8fr 1.35fr 0.9fr 0.9fr 0.9fr 0.9fr 0.55fr;gap:12px;flex:1;
     grid-template-areas:
       "py py py js js dk"
       "py py py re re cc"


### PR DESCRIPTION
## Summary
- Bump 8px/9px/11px font sizes to 10px/11px/13px for readability across loading screen, hero init label, buttons, nav links, scroll progress, and skill tile category labels
- Fix skill tile category label contrast: replace opacity:.55 with color:rgba(42,43,42,.7) so labels are readable on bright tile backgrounds (orange, fuchsia, yellow)

## Test plan
- [ ] Loading screen text readable
- [ ] Hero "// INIT" label and CTA button text readable
- [ ] Scroll progress counter readable
- [ ] Skill tile category labels readable on all tile colors
- [ ] Mobile nav links readable

Closes #286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved typography and spacing across loading states, hero layout, buttons, and horizontal scroll progress labels for clearer readability.
  * Enhanced Projects and Skills text scaling for stronger visual hierarchy.
  * Rebalanced Skills bento grid proportions and text sizes to improve layout consistency.
  * Updated mobile navigation link sizing for a better responsive experience.
  * Faster staggered Skills tile reveal animation timing for snappier in-view effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->