### PR TITLE
mochi: ignore local HANDOFF.md, drop dead .scratch entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ dist-ssr
 
 .env
 ideas/
-.scratch/
+HANDOFF.md


### PR DESCRIPTION
Adds `HANDOFF.md` to `.gitignore` — it is a local-only handoff document for a fresh agent and should never be committed.

Also removes the `.scratch/` entry, which points at a directory that no longer exists in this repo.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)