### PR TITLE
mochi: section shell and fluid viewport-fit layout system

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,12 +1,40 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import App from './App'
+import { sections } from '@/data/sections'
 
+/**
+ * Seam 1 (application root) coverage for issue #311: the six sections
+ * render, in the specified order, each identifiable and scroll-targetable
+ * by id. Viewport fit and scroll-snap behaviour cannot be asserted here --
+ * jsdom has no layout engine -- and are verified manually (see PR/spec).
+ */
 describe('App', () => {
-  it('renders the under-construction placeholder copy', () => {
+  it('renders exactly the six sections, in the specified order', () => {
     render(<App />)
 
-    expect(screen.getByRole('heading', { name: /under construction/i })).toBeInTheDocument()
-    expect(screen.getByText(/being rebuilt from scratch/i)).toBeInTheDocument()
+    const regions = screen.getAllByRole('region')
+    expect(regions).toHaveLength(sections.length)
+
+    const renderedIds = regions.map((region) => region.id)
+    expect(renderedIds).toEqual(sections.map((section) => section.id))
+  })
+
+  it('gives every section its documented id and accessible name, in DOM order', () => {
+    render(<App />)
+
+    for (const section of sections) {
+      const region = document.getElementById(section.id)
+      expect(region).not.toBeNull()
+      expect(region).toHaveAttribute('aria-label', section.label)
+    }
+  })
+
+  it('renders each section as scroll-targetable (a real element with its id, reachable via #id)', () => {
+    render(<App />)
+
+    for (const section of sections) {
+      expect(document.querySelector(`#${section.id}`)).toBeInTheDocument()
+    }
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,33 +1,36 @@
+import { Contact } from '@/components/sections/Contact'
+import { EducationExperience } from '@/components/sections/EducationExperience'
+import { Hero } from '@/components/sections/Hero'
+import { ProjectsFeatured } from '@/components/sections/ProjectsFeatured'
+import { ProjectsOther } from '@/components/sections/ProjectsOther'
+import { Skills } from '@/components/sections/Skills'
 import { cn } from '@/lib/cn'
 
 /**
- * Static under-construction placeholder. The rewrite (spec at
- * docs/spec-portfolio-rewrite.md) replaces this with the full six-section
- * page in later tickets. This ticket only lays the foundation: strict TS,
- * the `@/*` alias, self-hosted fonts, the `cn()` helper, and the ORIGINAL
- * theme's colour tokens.
+ * The six-section page shell (spec at docs/spec-portfolio-rewrite.md,
+ * issue #311). Sections render in a fixed order -- hero, projects
+ * (featured), projects (other), skills, education & experience, contact --
+ * each with placeholder content for now.
  *
- * No animation, no loading gate, no header — first paint is the finished
- * page.
+ * Layout/viewport-fit system: above 880px `.snap-shell` + `.section-shell`
+ * (src/styles/layout.css) make every section exactly one viewport tall
+ * with scroll-snap between them; below 880px both release and sections
+ * stack as ordinary flow content. There is no JavaScript measuring loop --
+ * fit comes entirely from the fluid type scale and CSS documented in that
+ * file.
+ *
+ * Out of scope here: the Go board (#316), header/nav (#312), and real
+ * section content (#317-#321).
  */
 function App() {
   return (
-    <main
-      className={cn(
-        'flex min-h-screen flex-col items-center justify-center gap-6 px-6 text-center',
-        'bg-bg text-fg',
-      )}
-    >
-      <h1
-        className={cn(
-          'font-display text-[clamp(1.1rem,4vw,1.75rem)] leading-relaxed text-accent-2',
-        )}
-      >
-        UNDER CONSTRUCTION
-      </h1>
-      <p className={cn('font-mono text-sm text-dim md:text-base')}>
-        Farhan Mohammed's portfolio is being rebuilt from scratch. Check back soon.
-      </p>
+    <main className={cn('snap-shell', 'flex min-h-screen flex-col', 'bg-bg text-fg')}>
+      <Hero />
+      <ProjectsFeatured />
+      <ProjectsOther />
+      <Skills />
+      <EducationExperience />
+      <Contact />
     </main>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,12 +12,14 @@ import { cn } from '@/lib/cn'
  * (featured), projects (other), skills, education & experience, contact --
  * each with placeholder content for now.
  *
- * Layout/viewport-fit system: above 880px `.snap-shell` + `.section-shell`
- * (src/styles/layout.css) make every section exactly one viewport tall
- * with scroll-snap between them; below 880px both release and sections
- * stack as ordinary flow content. There is no JavaScript measuring loop --
- * fit comes entirely from the fluid type scale and CSS documented in that
- * file.
+ * Layout/viewport-fit system: above 880px `.section-shell` (src/styles/
+ * layout.css) makes every section exactly one viewport tall, while the
+ * scroll-snap itself lives on `:root` (the document is the real scroll
+ * container, not `<main>`) so sections snap between whole screens; below
+ * 880px both release and sections stack as ordinary flow content.
+ * `.snap-shell` on <main> is a marker class only -- it carries no CSS of
+ * its own. There is no JavaScript measuring loop -- fit comes entirely
+ * from the fluid type scale and CSS documented in that file.
  *
  * Out of scope here: the Go board (#316), header/nav (#312), and real
  * section content (#317-#321).

--- a/src/components/layout/Section.tsx
+++ b/src/components/layout/Section.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from 'react'
+import { cn } from '@/lib/cn'
+
+interface SectionProps {
+  id: string
+  label: string
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * Shared shell for the six top-level sections.
+ *
+ * Fit is achieved purely by CSS (`.section-shell` / `.snap-shell` in
+ * `src/styles/layout.css`, driven by the fluid type scale documented
+ * there) -- there is no JavaScript measuring or `zoom` fallback. Above
+ * 880px each section is exactly one viewport tall and snaps; below 880px
+ * the fixed height and snap both release and the section is ordinary
+ * flow content.
+ */
+export function Section({ id, label, children, className }: SectionProps) {
+  return (
+    <section
+      id={id}
+      aria-label={label}
+      className={cn('section-shell', className)}
+    >
+      {children}
+    </section>
+  )
+}

--- a/src/components/layout/Section.tsx
+++ b/src/components/layout/Section.tsx
@@ -11,12 +11,13 @@ interface SectionProps {
 /**
  * Shared shell for the six top-level sections.
  *
- * Fit is achieved purely by CSS (`.section-shell` / `.snap-shell` in
- * `src/styles/layout.css`, driven by the fluid type scale documented
- * there) -- there is no JavaScript measuring or `zoom` fallback. Above
- * 880px each section is exactly one viewport tall and snaps; below 880px
- * the fixed height and snap both release and the section is ordinary
- * flow content.
+ * Fit is achieved purely by CSS (`.section-shell` in `src/styles/
+ * layout.css`, driven by the fluid type scale documented there) -- there
+ * is no JavaScript measuring or `zoom` fallback. Above 880px each section
+ * is exactly one viewport tall and snaps; below 880px the fixed height
+ * and snap both release and the section is ordinary flow content. The
+ * scroll-snap-type/scroll-behavior that drive snapping live on `:root`
+ * (the actual document scroll container), not on this class.
  */
 export function Section({ id, label, children, className }: SectionProps) {
   return (

--- a/src/components/layout/SectionPlaceholder.tsx
+++ b/src/components/layout/SectionPlaceholder.tsx
@@ -1,0 +1,23 @@
+import type { SectionMeta } from '@/data/sections'
+import { cn } from '@/lib/cn'
+
+/**
+ * Shared placeholder body for a section: eyebrow, title, blurb. All sizing
+ * comes from the fluid type scale in `src/styles/layout.css` -- no section
+ * defines its own font size.
+ *
+ * Real per-section content (the Go board, the pipeline animation, the
+ * skills graph, etc.) replaces this in #316-#321. This exists only so the
+ * shell and layout system have something to fill each screen with now.
+ */
+export function SectionPlaceholder({ eyebrow, title, blurb }: SectionMeta) {
+  return (
+    <div className="flex max-w-3xl flex-col gap-[var(--space-sm)]">
+      {eyebrow && (
+        <p className={cn('text-fluid-xs font-mono tracking-[0.2em] text-dim')}>{eyebrow}</p>
+      )}
+      <h2 className={cn('font-display text-fluid-2xl leading-tight text-fg')}>{title}</h2>
+      <p className={cn('text-fluid-base font-mono text-fg-2')}>{blurb}</p>
+    </div>
+  )
+}

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,0 +1,14 @@
+import { Section } from '@/components/layout/Section'
+import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
+import { sections } from '@/data/sections'
+
+const meta = sections[5]
+
+/** Contact placeholder. Real content lands in #321. */
+export function Contact() {
+  return (
+    <Section id={meta.id} label={meta.label}>
+      <SectionPlaceholder {...meta} />
+    </Section>
+  )
+}

--- a/src/components/sections/EducationExperience.tsx
+++ b/src/components/sections/EducationExperience.tsx
@@ -1,0 +1,14 @@
+import { Section } from '@/components/layout/Section'
+import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
+import { sections } from '@/data/sections'
+
+const meta = sections[4]
+
+/** Education & experience placeholder. Real content lands in #320. */
+export function EducationExperience() {
+  return (
+    <Section id={meta.id} label={meta.label}>
+      <SectionPlaceholder {...meta} />
+    </Section>
+  )
+}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,23 @@
+import { Section } from '@/components/layout/Section'
+import { sections } from '@/data/sections'
+import { cn } from '@/lib/cn'
+
+const meta = sections[0]
+
+/**
+ * Hero placeholder. The real Go board replay (#316) replaces the body
+ * below; the display heading uses the hero step of the fluid type scale
+ * (`--text-hero`, documented in `src/styles/layout.css`) since it is the
+ * largest text on the page.
+ */
+export function Hero() {
+  return (
+    <Section id={meta.id} label={meta.label}>
+      <div className="flex max-w-3xl flex-col gap-[var(--space-sm)]">
+        <p className={cn('text-fluid-xs font-mono tracking-[0.2em] text-dim')}>{meta.eyebrow}</p>
+        <h1 className={cn('font-display text-fluid-hero leading-tight text-fg')}>{meta.title}</h1>
+        <p className={cn('text-fluid-lg font-mono text-fg-2')}>{meta.blurb}</p>
+      </div>
+    </Section>
+  )
+}

--- a/src/components/sections/ProjectsFeatured.tsx
+++ b/src/components/sections/ProjectsFeatured.tsx
@@ -1,0 +1,14 @@
+import { Section } from '@/components/layout/Section'
+import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
+import { sections } from '@/data/sections'
+
+const meta = sections[1]
+
+/** Featured project (Leviathan) placeholder. Real content lands in #317. */
+export function ProjectsFeatured() {
+  return (
+    <Section id={meta.id} label={meta.label}>
+      <SectionPlaceholder {...meta} />
+    </Section>
+  )
+}

--- a/src/components/sections/ProjectsOther.tsx
+++ b/src/components/sections/ProjectsOther.tsx
@@ -1,0 +1,19 @@
+import { Section } from '@/components/layout/Section'
+import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
+import { sections } from '@/data/sections'
+
+const meta = sections[2]
+
+/**
+ * Secondary projects screen placeholder. Per the spec's fixed defect, this
+ * screen deliberately has no eyebrow number -- the reference reused
+ * "01 PROJECTS" on both project screens, which reads as a rendering bug.
+ * Real content lands in #318.
+ */
+export function ProjectsOther() {
+  return (
+    <Section id={meta.id} label={meta.label}>
+      <SectionPlaceholder {...meta} />
+    </Section>
+  )
+}

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -1,0 +1,14 @@
+import { Section } from '@/components/layout/Section'
+import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
+import { sections } from '@/data/sections'
+
+const meta = sections[3]
+
+/** Skills graph placeholder. Real content lands in #319. */
+export function Skills() {
+  return (
+    <Section id={meta.id} label={meta.label}>
+      <SectionPlaceholder {...meta} />
+    </Section>
+  )
+}

--- a/src/data/sections.ts
+++ b/src/data/sections.ts
@@ -1,0 +1,64 @@
+/**
+ * Canonical list of the six top-level sections, in page order.
+ *
+ * This is the single source of truth for section identity: `App` renders
+ * exactly this list, in this order, and nav targets (#312) resolve against
+ * these `id`s. Placeholder copy only -- real content lands in #317-#321.
+ */
+export interface SectionMeta {
+  /** DOM id; also the scroll/nav target. */
+  id: string
+  /** Accessible name for the section landmark. */
+  label: string
+  /** Small eyebrow shown above the title, e.g. "02 · PROJECTS". */
+  eyebrow: string
+  /** Placeholder heading. */
+  title: string
+  /** Placeholder supporting line. */
+  blurb: string
+}
+
+export const sections: SectionMeta[] = [
+  {
+    id: 'top',
+    label: 'Hero',
+    eyebrow: '00 · HELLO',
+    title: 'Farhan Mohammed',
+    blurb: 'Placeholder hero copy -- the Go board replay lands in #316.',
+  },
+  {
+    id: 'projects',
+    label: 'Projects — featured',
+    eyebrow: '01 · PROJECTS',
+    title: 'Leviathan',
+    blurb: 'Placeholder featured-project copy -- full content lands in #317.',
+  },
+  {
+    id: 'more',
+    label: 'Projects — other',
+    eyebrow: '',
+    title: 'Other work',
+    blurb: 'Placeholder secondary-projects copy -- full content lands in #318.',
+  },
+  {
+    id: 'skills',
+    label: 'Skills',
+    eyebrow: '02 · SKILLS',
+    title: 'Skills',
+    blurb: 'Placeholder skills-graph copy -- full content lands in #319.',
+  },
+  {
+    id: 'path',
+    label: 'Education and experience',
+    eyebrow: '03 · PATH',
+    title: 'Education & experience',
+    blurb: 'Placeholder timeline copy -- full content lands in #320.',
+  },
+  {
+    id: 'contact',
+    label: 'Contact',
+    eyebrow: '04 · CONTACT',
+    title: 'Get in touch',
+    blurb: 'Placeholder contact copy -- full content lands in #321.',
+  },
+]

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import './styles/fonts.css';
 @import './styles/themes.css';
+@import './styles/layout.css';
 
 /*
  * Tailwind's theme keys are mapped onto the swappable custom properties

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -93,6 +93,19 @@
  *
  * 880px is the one hard breakpoint in the layout system; everything within
  * a section is otherwise fluid.
+ *
+ * `.snap-shell` (applied to <main>, see src/App.tsx) is NOT the scroll
+ * container -- there is no `overflow`/height constraint on it, so the
+ * viewport/document itself is what actually scrolls. `scroll-snap-type`
+ * and `scroll-behavior` only take effect on the element that is the real
+ * scroll container, so both live on `:root` (the document scrolling box)
+ * below, not on `.snap-shell`. `.snap-shell` is kept purely as a marker
+ * class for readability/documentation of intent on <main>.
+ *
+ * Note for later tickets (#316-#321): `min-height: 100dvh` + `mandatory`
+ * snap assumes each section fits (or slightly exceeds) one viewport. If
+ * real content grows taller than the viewport, mandatory snap can make it
+ * hard to scroll within an overflowing section. Not addressed here.
  */
 
 .section-shell {
@@ -104,18 +117,12 @@
   justify-content: center;
 }
 
-.snap-shell {
+:root {
   scroll-behavior: smooth;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .snap-shell {
-    scroll-behavior: auto;
-  }
-}
-
 @media (min-width: 880px) {
-  .snap-shell {
+  :root {
     scroll-snap-type: y mandatory;
   }
 
@@ -124,5 +131,19 @@
     scroll-snap-align: start;
     padding-block: var(--space-xl) var(--space-lg);
     padding-inline: var(--space-xl);
+  }
+}
+
+/*
+ * This block must stay AFTER the `min-width: 880px` block above: both
+ * rules target `:root` at equal specificity, so when a reduced-motion
+ * user is also above 880px, source order (not just specificity) decides
+ * which wins. Placing this last guarantees reduced motion always relaxes
+ * snapping and smooth scrolling, regardless of viewport width.
+ */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    scroll-behavior: auto;
+    scroll-snap-type: none;
   }
 }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,0 +1,128 @@
+/*
+ * Section shell + fluid type scale.
+ *
+ * ---------------------------------------------------------------------
+ * FLUID TYPE SCALE
+ * ---------------------------------------------------------------------
+ * One scale, designed once, consumed by every section. Every step is a
+ * `clamp(min, preferred, max)` where the preferred value is a rem/vw
+ * blend, so type grows continuously with the viewport instead of jumping
+ * between fixed breakpoint values. Steps compound by roughly 1.25x, close
+ * to a major third -- enough to read as a deliberate scale without huge
+ * jumps between adjacent steps.
+ *
+ *   --text-2xs   clamp(0.66rem, 0.6rem  + 0.3vw, 0.78rem)  micro labels, meta
+ *   --text-xs    clamp(0.78rem, 0.7rem  + 0.4vw, 0.92rem)  captions, eyebrows
+ *   --text-sm    clamp(0.9rem,  0.8rem  + 0.5vw, 1.05rem)  body small
+ *   --text-base  clamp(1rem,    0.9rem  + 0.6vw, 1.2rem)   body
+ *   --text-lg    clamp(1.2rem,  1.05rem + 0.9vw, 1.5rem)   section lede / intro line
+ *   --text-xl    clamp(1.55rem, 1.3rem  + 1.6vw, 2.1rem)   subheadings
+ *   --text-2xl   clamp(2.1rem,  1.6rem  + 3vw,   3.4rem)   section titles
+ *   --text-hero  clamp(2.6rem,  1.7rem  + 5.5vw, 5.4rem)   hero display line
+ *
+ * Spacing follows the same construction so gaps and padding stay
+ * proportional to the viewport rather than being retro-fitted per section:
+ *
+ *   --space-3xs  clamp(0.25rem, 0.2rem  + 0.2vw, 0.4rem)
+ *   --space-2xs  clamp(0.4rem,  0.3rem  + 0.3vw, 0.6rem)
+ *   --space-xs   clamp(0.65rem, 0.5rem  + 0.5vw, 0.95rem)
+ *   --space-sm   clamp(1rem,    0.8rem  + 0.8vw, 1.5rem)
+ *   --space-md   clamp(1.6rem,  1.2rem  + 1.6vw, 2.4rem)
+ *   --space-lg   clamp(2.4rem,  1.6rem  + 2.8vw, 3.6rem)
+ *   --space-xl   clamp(3.2rem,  2rem    + 4vw,   5.2rem)
+ *
+ * These are plain custom properties (not Tailwind `@theme` keys) so they
+ * stay decoupled from Tailwind's own `text-*`/`spacing-*` namespace and the
+ * scale can be audited in one place. Utility classes below expose them;
+ * components must consume the classes/variables rather than writing their
+ * own ad-hoc clamp().
+ */
+
+:root {
+  --text-2xs: clamp(0.66rem, 0.6rem + 0.3vw, 0.78rem);
+  --text-xs: clamp(0.78rem, 0.7rem + 0.4vw, 0.92rem);
+  --text-sm: clamp(0.9rem, 0.8rem + 0.5vw, 1.05rem);
+  --text-base: clamp(1rem, 0.9rem + 0.6vw, 1.2rem);
+  --text-lg: clamp(1.2rem, 1.05rem + 0.9vw, 1.5rem);
+  --text-xl: clamp(1.55rem, 1.3rem + 1.6vw, 2.1rem);
+  --text-2xl: clamp(2.1rem, 1.6rem + 3vw, 3.4rem);
+  --text-hero: clamp(2.6rem, 1.7rem + 5.5vw, 5.4rem);
+
+  --space-3xs: clamp(0.25rem, 0.2rem + 0.2vw, 0.4rem);
+  --space-2xs: clamp(0.4rem, 0.3rem + 0.3vw, 0.6rem);
+  --space-xs: clamp(0.65rem, 0.5rem + 0.5vw, 0.95rem);
+  --space-sm: clamp(1rem, 0.8rem + 0.8vw, 1.5rem);
+  --space-md: clamp(1.6rem, 1.2rem + 1.6vw, 2.4rem);
+  --space-lg: clamp(2.4rem, 1.6rem + 2.8vw, 3.6rem);
+  --space-xl: clamp(3.2rem, 2rem + 4vw, 5.2rem);
+}
+
+.text-2xs {
+  font-size: var(--text-2xs);
+}
+.text-fluid-xs {
+  font-size: var(--text-xs);
+}
+.text-fluid-sm {
+  font-size: var(--text-sm);
+}
+.text-fluid-base {
+  font-size: var(--text-base);
+}
+.text-fluid-lg {
+  font-size: var(--text-lg);
+}
+.text-fluid-xl {
+  font-size: var(--text-xl);
+}
+.text-fluid-2xl {
+  font-size: var(--text-2xl);
+}
+.text-fluid-hero {
+  font-size: var(--text-hero);
+}
+
+/*
+ * ---------------------------------------------------------------------
+ * SECTION SHELL + SNAP
+ * ---------------------------------------------------------------------
+ * Below 880px sections are ordinary flow content: no fixed height, no
+ * snapping, so nothing is ever shrunk to force a fit. At 880px and above,
+ * each section becomes exactly one viewport tall and the page scrolls as a
+ * sequence of whole screens.
+ *
+ * 880px is the one hard breakpoint in the layout system; everything within
+ * a section is otherwise fluid.
+ */
+
+.section-shell {
+  width: 100%;
+  padding-block: var(--space-lg) var(--space-md);
+  padding-inline: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.snap-shell {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .snap-shell {
+    scroll-behavior: auto;
+  }
+}
+
+@media (min-width: 880px) {
+  .snap-shell {
+    scroll-snap-type: y mandatory;
+  }
+
+  .section-shell {
+    min-height: 100dvh;
+    scroll-snap-align: start;
+    padding-block: var(--space-xl) var(--space-lg);
+    padding-inline: var(--space-xl);
+  }
+}


### PR DESCRIPTION
## Summary

- Replaces the under-construction placeholder with the six real sections in order — hero, projects (featured), projects (other), skills, education & experience, contact — each rendered via a shared `Section` shell with placeholder content
- Adds a single documented fluid type scale (`src/styles/layout.css`) — eight `clamp()`-based font-size steps (`--text-2xs` … `--text-hero`) and seven spacing steps (`--space-3xs` … `--space-xl`), compounding ~1.25x — consumed by every section via `.text-fluid-*` utility classes and `var(--space-*)`
- Above 880px, `.section-shell` gets `min-height: 100dvh` + `scroll-snap-align: start` and `.snap-shell` gets `scroll-snap-type: y mandatory`, so each section is exactly one viewport and scrolling snaps between them
- Below 880px both rules release entirely: sections become ordinary flow content with no fixed height, no snap, and no shrunk content
- No `zoom`-based or JS measuring/`fitAll()` routine anywhere — fit is CSS-only, as the issue requires
- Section data lives in `src/data/sections.ts` (id, accessible label, eyebrow, title, blurb) — components are pure presentation over it

## Manual-verification-only (cannot be asserted in jsdom — no layout engine)

- That each section occupies exactly one viewport above 880px
- That scroll snapping actually settles on whole screens above 880px
- That sections release fixed height and stack/scroll normally below 880px, with no illegible shrinking
- That the fluid type scale reads well across the range, not just that the CSS parses

I have **not** opened this in a browser myself in this session — I verified only via `npm run build` (successful Vite/Tailwind compile of the new CSS) and by reading the generated CSS output. The above four points still need hands-on browser verification above and below 880px before this is considered visually done, per the issue's explicit honesty requirement.

## What was actually verified (automated)

- `npm run typecheck` — passes, no errors
- `npm run lint` — passes, no errors
- `npm run test` — 7/7 tests pass across 2 files; `App.test.tsx` renders the app and asserts (via `getByRole('region')`) that exactly six sections render, in the specified order, each with its documented `id` and accessible name — no class-name, stylesheet, or internal-state assertions
- `npm run build` — successful production build (tsc + vite), emits `dist/assets/index-*.css` including the new layout rules

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`
- [ ] Manual: open the built app in a browser at >880px width and confirm each section fills one viewport with snap settling on section boundaries
- [ ] Manual: resize/open below 880px and confirm sections stack, scroll normally, and no text/content is illegibly shrunk

Refs #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the under-construction page with a six-section portfolio layout.
  * Added Hero, Projects, Skills, Education & Experience, and Contact sections with placeholder content.
  * Added accessible section labels and direct navigation targets.
  * Introduced responsive spacing, fluid typography, and viewport-based scrolling with reduced-motion support.

* **Tests**
  * Added coverage verifying section count, order, accessibility labels, and scroll-target links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->