### PR TITLE
mochi: build the Leviathan featured-project section

### DIFF
--- a/src/components/sections/ProjectsFeatured.test.tsx
+++ b/src/components/sections/ProjectsFeatured.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ProjectsFeatured } from './ProjectsFeatured'
+import { LEVIATHAN_HOOK, LEVIATHAN_LINKS, LEVIATHAN_STATS } from '@/data/leviathan'
+import { sections } from '@/data/sections'
+
+/**
+ * Smoke coverage for issue #317: this component is pure presentation over
+ * `src/data/leviathan.ts`, so the real correctness weight sits in
+ * `src/lib/leviathan/pipeline.test.ts` and `countUp.test.ts` instead.
+ * These assertions only check the public-interface shape a visitor and a
+ * screen reader actually see: the section landmark, the one-line hook, the
+ * three stats by their accessible names, and the two links resolving to
+ * the right URLs.
+ */
+describe('ProjectsFeatured', () => {
+  it('renders the featured-project section with its documented id and label', () => {
+    render(<ProjectsFeatured />)
+
+    const region = screen.getByRole('region', { name: sections[1].label })
+    expect(region).toHaveAttribute('id', sections[1].id)
+  })
+
+  it('states the one-line hook before any supporting detail', () => {
+    render(<ProjectsFeatured />)
+
+    expect(screen.getByText(LEVIATHAN_HOOK)).toBeInTheDocument()
+  })
+
+  it('presents all three headline stats by their full accessible figures', () => {
+    render(<ProjectsFeatured />)
+
+    for (const stat of LEVIATHAN_STATS) {
+      expect(screen.getByRole('group', { name: stat.accessibleName })).toBeInTheDocument()
+    }
+  })
+
+  it('links to the source and the live demo with the correct URLs', () => {
+    render(<ProjectsFeatured />)
+
+    for (const link of LEVIATHAN_LINKS) {
+      const anchor = screen.getByRole('link', { name: new RegExp(link.label, 'i') })
+      expect(anchor).toHaveAttribute('href', link.href)
+      expect(anchor).toHaveAttribute('target', '_blank')
+    }
+  })
+
+  it('renders the animated inference-pipeline panel', () => {
+    render(<ProjectsFeatured />)
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Inference pipeline: position to tokens to attention to policy to move',
+      }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/sections/ProjectsFeatured.tsx
+++ b/src/components/sections/ProjectsFeatured.tsx
@@ -1,14 +1,84 @@
 import { Section } from '@/components/layout/Section'
-import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
+import { InferencePipeline } from '@/components/sections/leviathan/InferencePipeline'
+import { StatCounter } from '@/components/sections/leviathan/StatCounter'
+import {
+  LEVIATHAN_BULLETS,
+  LEVIATHAN_HOOK,
+  LEVIATHAN_LINKS,
+  LEVIATHAN_STATS,
+  LEVIATHAN_SUBTITLE,
+  LEVIATHAN_SUMMARY,
+} from '@/data/leviathan'
 import { sections } from '@/data/sections'
 
 const meta = sections[1]
 
-/** Featured project (Leviathan) placeholder. Real content lands in #317. */
+/**
+ * Featured project: Leviathan gets a full screen to itself (issue #317),
+ * so the strongest work is not diluted by the second projects screen
+ * (#318). A visitor reads the one-line hook before any detail, then three
+ * bullets covering the memory, tokenizer, and training decisions, then the
+ * headline stats and links, alongside the looping inference-pipeline
+ * panel that is the visual argument for "it never searches."
+ *
+ * All copy and figures live in `src/data/leviathan.ts` -- every factual
+ * figure there is sourced from `public/resume.pdf`. This component is pure
+ * presentation. The two animated pieces (`StatCounter`, `InferencePipeline`)
+ * each own their own state/timer/observer, scoped to themselves, so this
+ * section itself never re-renders on a frame tick or a count-up tick.
+ */
 export function ProjectsFeatured() {
   return (
     <Section id={meta.id} label={meta.label}>
-      <SectionPlaceholder {...meta} />
+      <div className="flex h-full flex-col gap-[var(--space-md)] lg:flex-row">
+        <div className="flex flex-1 flex-col gap-[var(--space-sm)]">
+          <p className="font-mono text-fluid-xs tracking-[0.2em] text-dim">{meta.eyebrow}</p>
+
+          <div className="flex items-baseline gap-[var(--space-xs)] flex-wrap">
+            <h2 className="font-display text-fluid-2xl leading-tight text-fg">Leviathan</h2>
+            <span className="text-2xs tracking-[0.18em] text-dim">{LEVIATHAN_SUBTITLE}</span>
+          </div>
+
+          <p className="text-fluid-lg text-accent-2">{LEVIATHAN_HOOK}</p>
+
+          <p className="text-fluid-base text-fg-2">{LEVIATHAN_SUMMARY}</p>
+
+          <ul className="flex flex-col gap-[var(--space-2xs)] text-fluid-sm text-fg-2">
+            {LEVIATHAN_BULLETS.map((bullet) => (
+              <li key={bullet} className="flex gap-[var(--space-2xs)]">
+                <span aria-hidden="true" className="text-accent">
+                  →
+                </span>
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+
+          <div className="mt-auto flex flex-wrap items-end gap-[var(--space-md)] border-t border-line pt-[var(--space-xs)]">
+            {LEVIATHAN_STATS.map((stat) => (
+              <StatCounter key={stat.id} stat={stat} />
+            ))}
+
+            <div className="ml-auto flex gap-[var(--space-sm)]">
+              {LEVIATHAN_LINKS.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="border-b border-line-2 pb-[2px] text-fluid-sm text-fg-2"
+                >
+                  {link.label} ↗
+                </a>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex-1 border-line bg-panel-2 p-[var(--space-sm)] lg:border-l">
+          <InferencePipeline />
+        </div>
+      </div>
     </Section>
   )
 }

--- a/src/components/sections/leviathan/InferencePipeline.test.tsx
+++ b/src/components/sections/leviathan/InferencePipeline.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { InferencePipeline } from './InferencePipeline'
+
+const FRAME_INTERVAL_MS = 120
 
 function mockMatchMedia(reducedMotion: boolean) {
   vi.stubGlobal(
@@ -58,5 +60,33 @@ describe('InferencePipeline', () => {
     // The settled frame is fully resolved: the move stage has an actual
     // move rendered, not the pre-reveal placeholder.
     expect(screen.queryByText('···')).not.toBeInTheDocument()
+    // The policy stage's candidate moves are part of that full resolution.
+    // ("Bb5" is a lower-ranked candidate, distinct from the top move
+    // rendered in the move stage, so this check is unambiguous.)
+    expect(screen.getByText('Bb5')).toBeInTheDocument()
+  })
+
+  it('does not show the policy candidates before the policy stage starts', () => {
+    mockMatchMedia(false)
+    vi.useFakeTimers()
+
+    render(<InferencePipeline />)
+
+    // Frame 0: well before the policy stage starts (frame 54 of 84).
+    expect(screen.queryByText('Nf3')).not.toBeInTheDocument()
+    expect(screen.queryByText('e4')).not.toBeInTheDocument()
+    expect(screen.queryByText('Bb5')).not.toBeInTheDocument()
+
+    // Advance to just before the policy stage starts (frame 53).
+    act(() => {
+      vi.advanceTimersByTime(FRAME_INTERVAL_MS * 53)
+    })
+    expect(screen.queryByText('Nf3')).not.toBeInTheDocument()
+
+    // Advance into the policy stage (frame 54).
+    act(() => {
+      vi.advanceTimersByTime(FRAME_INTERVAL_MS)
+    })
+    expect(screen.getByText('Nf3')).toBeInTheDocument()
   })
 })

--- a/src/components/sections/leviathan/InferencePipeline.test.tsx
+++ b/src/components/sections/leviathan/InferencePipeline.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { InferencePipeline } from './InferencePipeline'
+
+function mockMatchMedia(reducedMotion: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: reducedMotion,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('InferencePipeline', () => {
+  it('renders as a labelled group covering every stage, including the chess position display', () => {
+    render(<InferencePipeline />)
+
+    const panel = screen.getByRole('group', {
+      name: 'Inference pipeline: position to tokens to attention to policy to move',
+    })
+    expect(panel).toBeInTheDocument()
+
+    // Each pipeline stage has a visible row label -- the position display
+    // (the engine's own chess input) is one of them, distinct from the cut
+    // hero chess replay.
+    expect(screen.getByText('position')).toBeInTheDocument()
+    expect(screen.getByText('tokens')).toBeInTheDocument()
+    expect(screen.getByText('attention')).toBeInTheDocument()
+    expect(screen.getByText('policy')).toBeInTheDocument()
+    expect(screen.getByText('move')).toBeInTheDocument()
+  })
+
+  it('starts a timer under normal motion preferences', () => {
+    mockMatchMedia(false)
+    vi.useFakeTimers()
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+    render(<InferencePipeline />)
+
+    expect(setIntervalSpy).toHaveBeenCalled()
+  })
+
+  it('settles on one fully-resolved frame under reduced motion, without starting a timer', () => {
+    mockMatchMedia(true)
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+    render(<InferencePipeline />)
+
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+    // The settled frame is fully resolved: the move stage has an actual
+    // move rendered, not the pre-reveal placeholder.
+    expect(screen.queryByText('···')).not.toBeInTheDocument()
+  })
+})

--- a/src/components/sections/leviathan/InferencePipeline.tsx
+++ b/src/components/sections/leviathan/InferencePipeline.tsx
@@ -1,0 +1,123 @@
+import type { ReactNode } from 'react'
+import { useEffect, useState } from 'react'
+import {
+  PIPELINE_CANDIDATE_SETS,
+  PIPELINE_OUTPUT_META,
+  PIPELINE_POSITION_FEN,
+  PIPELINE_TOKEN_IDS,
+} from '@/data/leviathan'
+import {
+  ATTENTION_ROW_COUNT,
+  candidateSetIndexForCycle,
+  computePipelineFrame,
+  settledPipelineFrame,
+} from '@/lib/leviathan/pipeline'
+import { useReducedMotion } from '@/lib/leviathan/useReducedMotion'
+
+const FRAME_INTERVAL_MS = 120
+
+function PipelineRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="grid grid-cols-[4.5em_minmax(0,1fr)] items-center gap-[var(--space-2xs)]">
+      <span className="text-2xs tracking-[0.18em] text-dim-3">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * The inference-pipeline widget: position → tokens → attention → policy →
+ * move, looping continuously on its own frame counter (issue #317). This
+ * is the visual argument for a searchless engine -- there is no search
+ * tree to show, only one forward pass revealing itself stage by stage.
+ *
+ * Owns its own state and timer, scoped to this component, so a frame tick
+ * re-renders this widget only -- not the section around it. Frame-to-model
+ * logic itself is a pure function (`computePipelineFrame` in
+ * `src/lib/leviathan/pipeline.ts`); this component only owns the ticking
+ * clock and renders whatever that function says is visible this frame.
+ *
+ * Reduced motion: no timer is started at all. `settledPipelineFrame`
+ * renders the loop's *final* frame -- every stage fully resolved -- once,
+ * statically. That is a deliberate choice over the alternative of freezing
+ * on frame 0 (which would show a widget that looks permanently broken) or
+ * reproducing the reference's blanket duration-zeroing (which plays the
+ * loop instantly rather than not at all, the opposite of what the
+ * preference asks for).
+ */
+export function InferencePipeline() {
+  const reducedMotion = useReducedMotion()
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    if (reducedMotion) return
+    const id = setInterval(() => setTick((t) => t + 1), FRAME_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [reducedMotion])
+
+  const frameModel = reducedMotion
+    ? settledPipelineFrame(PIPELINE_POSITION_FEN.length, PIPELINE_TOKEN_IDS.length)
+    : computePipelineFrame(tick, PIPELINE_POSITION_FEN.length, PIPELINE_TOKEN_IDS.length)
+
+  const candidateIndex = candidateSetIndexForCycle(frameModel.cycle, PIPELINE_CANDIDATE_SETS.length)
+  const candidates = PIPELINE_CANDIDATE_SETS[candidateIndex]
+  const topCandidate = candidates[0]
+
+  const positionShown = PIPELINE_POSITION_FEN.slice(0, frameModel.positionRevealCount)
+  const tokensShown = PIPELINE_TOKEN_IDS.slice(0, frameModel.tokensRevealedCount)
+
+  return (
+    <div
+      role="group"
+      aria-label="Inference pipeline: position to tokens to attention to policy to move"
+      className="flex flex-col gap-[var(--space-xs)]"
+    >
+      <PipelineRow label="position">
+        <span aria-hidden="true" className="break-all font-mono text-2xs text-fg-2">
+          {positionShown || ' '}
+        </span>
+      </PipelineRow>
+
+      <PipelineRow label="tokens">
+        <div aria-hidden="true" className="flex flex-wrap gap-[var(--space-3xs)]">
+          {tokensShown.map((id, index) => (
+            <span
+              key={`${id}-${index}`}
+              className="border border-line-2 bg-panel px-2 py-[2px] font-mono text-2xs text-accent-2"
+            >
+              {id}
+            </span>
+          ))}
+        </div>
+      </PipelineRow>
+
+      <PipelineRow label="attention">
+        <div aria-hidden="true" className="text-2xs text-dim-2">
+          {frameModel.attentionRowsRevealed >= ATTENTION_ROW_COUNT
+            ? 'every token reads the ones before it — KV cache compressed 8×'
+            : 'each row = one token deciding which earlier tokens matter'}
+        </div>
+      </PipelineRow>
+
+      <PipelineRow label="policy">
+        <div aria-hidden="true" className="flex flex-col gap-[var(--space-3xs)]">
+          {candidates.map((candidate) => (
+            <div key={candidate.move} className="flex items-center gap-[var(--space-2xs)] text-2xs">
+              <span className="min-w-[3.5em] font-display text-dim-3">{candidate.move}</span>
+              <span className="text-dim-2">{frameModel.policyRevealed ? `${candidate.percent}%` : ''}</span>
+            </div>
+          ))}
+        </div>
+      </PipelineRow>
+
+      <PipelineRow label="move">
+        <div aria-hidden="true" className="flex items-baseline gap-[var(--space-xs)]">
+          <span className="font-display text-fluid-lg text-fg">
+            {frameModel.moveRevealed ? topCandidate.move : '···'}
+          </span>
+          <span className="text-2xs text-dim-2">{frameModel.moveRevealed ? PIPELINE_OUTPUT_META : ''}</span>
+        </div>
+      </PipelineRow>
+    </div>
+  )
+}

--- a/src/components/sections/leviathan/InferencePipeline.tsx
+++ b/src/components/sections/leviathan/InferencePipeline.tsx
@@ -18,10 +18,10 @@ const FRAME_INTERVAL_MS = 120
 
 function PipelineRow({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div className="grid grid-cols-[4.5em_minmax(0,1fr)] items-center gap-[var(--space-2xs)]">
-      <span className="text-2xs tracking-[0.18em] text-dim-3">{label}</span>
+    <>
+      <span className="whitespace-nowrap text-2xs tracking-[0.18em] text-dim-3">{label}</span>
       {children}
-    </div>
+    </>
   )
 }
 
@@ -70,7 +70,7 @@ export function InferencePipeline() {
     <div
       role="group"
       aria-label="Inference pipeline: position to tokens to attention to policy to move"
-      className="flex flex-col gap-[var(--space-xs)]"
+      className="grid grid-cols-[max-content_minmax(0,1fr)] items-center gap-x-[var(--space-2xs)] gap-y-[var(--space-xs)]"
     >
       <PipelineRow label="position">
         <span aria-hidden="true" className="break-all font-mono text-2xs text-fg-2">
@@ -103,7 +103,9 @@ export function InferencePipeline() {
         <div aria-hidden="true" className="flex flex-col gap-[var(--space-3xs)]">
           {candidates.map((candidate) => (
             <div key={candidate.move} className="flex items-center gap-[var(--space-2xs)] text-2xs">
-              <span className="min-w-[3.5em] font-display text-dim-3">{candidate.move}</span>
+              <span className="min-w-[3.5em] font-display text-dim-3">
+                {frameModel.policyRevealed ? candidate.move : ''}
+              </span>
               <span className="text-dim-2">{frameModel.policyRevealed ? `${candidate.percent}%` : ''}</span>
             </div>
           ))}

--- a/src/components/sections/leviathan/StatCounter.test.tsx
+++ b/src/components/sections/leviathan/StatCounter.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { StatCounter } from './StatCounter'
+import type { LeviathanStat } from '@/data/leviathan'
+
+const stat: LeviathanStat = {
+  id: 'latency',
+  target: 19,
+  suffix: 'ms',
+  label: 'PER MOVE',
+  accessibleName: '19 milliseconds per move',
+}
+
+function mockMatchMedia(reducedMotion: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: reducedMotion,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('StatCounter', () => {
+  /**
+   * jsdom has no IntersectionObserver at all (it's `undefined`, not a
+   * stub) -- this is the default test environment, so this case is
+   * covered by every other test in this file too. It is asserted
+   * explicitly here: mounting must not throw, and the accessible name
+   * must carry the real, final figure immediately.
+   */
+  it('shows the full accessible figure immediately when IntersectionObserver is unavailable (the default jsdom environment)', () => {
+    expect(window.IntersectionObserver).toBeUndefined()
+
+    render(<StatCounter stat={stat} />)
+
+    expect(screen.getByRole('group', { name: '19 milliseconds per move' })).toBeInTheDocument()
+  })
+
+  it('shows the target immediately under a reduced-motion preference, without creating an observer', () => {
+    mockMatchMedia(true)
+    const ObserverSpy = vi.fn()
+    vi.stubGlobal('IntersectionObserver', ObserverSpy)
+
+    render(<StatCounter stat={stat} />)
+
+    expect(screen.getByRole('group', { name: '19 milliseconds per move' })).toBeInTheDocument()
+    expect(ObserverSpy).not.toHaveBeenCalled()
+  })
+
+  it('observes the stat element when IntersectionObserver is available and motion is not reduced', () => {
+    mockMatchMedia(false)
+    const observe = vi.fn()
+    const disconnect = vi.fn()
+    class FakeIntersectionObserver {
+      observe = observe
+      unobserve = vi.fn()
+      disconnect = disconnect
+      constructor() {}
+    }
+    vi.stubGlobal('IntersectionObserver', FakeIntersectionObserver)
+
+    const { unmount } = render(<StatCounter stat={stat} />)
+
+    // The accessible name is present immediately regardless of whether the
+    // count-up animation has run -- it never depends on animation state.
+    expect(screen.getByRole('group', { name: '19 milliseconds per move' })).toBeInTheDocument()
+    expect(observe).toHaveBeenCalledTimes(1)
+
+    unmount()
+    expect(disconnect).toHaveBeenCalled()
+  })
+})

--- a/src/components/sections/leviathan/StatCounter.tsx
+++ b/src/components/sections/leviathan/StatCounter.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from 'react'
+import type { LeviathanStat } from '@/data/leviathan'
+import { countUpValue } from '@/lib/leviathan/countUp'
+import { useReducedMotion } from '@/lib/leviathan/useReducedMotion'
+
+const COUNT_DURATION_MS = 900
+
+interface StatCounterProps {
+  stat: LeviathanStat
+}
+
+function targetShown(reducedMotion: boolean): boolean {
+  return reducedMotion || typeof window === 'undefined' || typeof window.IntersectionObserver === 'undefined'
+}
+
+/**
+ * One headline stat (latency, params, or positions trained). Counts up
+ * from 0 to `stat.target` the first time it scrolls into view, via
+ * `IntersectionObserver`.
+ *
+ * The animated digits are `aria-hidden` — the wrapping `group` carries
+ * `stat.accessibleName`, the full final figure, at all times. That means
+ * assistive tech always gets the real number immediately rather than
+ * whatever the count-up happens to be mid-animation, and it is also what
+ * makes this testable without driving rAF: the accessible name is stable
+ * regardless of animation state.
+ *
+ * Reduced motion: the target is shown immediately, no observer is created,
+ * no animation runs. jsdom has no `IntersectionObserver` at all (it is
+ * `undefined`, not a stub) — the same "show the target immediately" path
+ * covers that case too, so its absence never throws.
+ */
+export function StatCounter({ stat }: StatCounterProps) {
+  const reducedMotion = useReducedMotion()
+  const showFinal = targetShown(reducedMotion)
+  const ref = useRef<HTMLDivElement>(null)
+  const [animated, setAnimated] = useState(0)
+  const displayed = showFinal ? stat.target : animated
+
+  useEffect(() => {
+    if (showFinal) return
+
+    const node = ref.current
+    if (!node) return
+
+    let frameId = 0
+
+    const startCountUp = () => {
+      const start = performance.now()
+      const tick = (now: number) => {
+        const elapsed = now - start
+        setAnimated(countUpValue(stat.target, elapsed, COUNT_DURATION_MS))
+        if (elapsed < COUNT_DURATION_MS) {
+          frameId = requestAnimationFrame(tick)
+        }
+      }
+      frameId = requestAnimationFrame(tick)
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            startCountUp()
+            observer.unobserve(entry.target)
+          }
+        }
+      },
+      { threshold: 0 },
+    )
+    observer.observe(node)
+
+    return () => {
+      observer.disconnect()
+      if (frameId) cancelAnimationFrame(frameId)
+    }
+  }, [showFinal, stat])
+
+  return (
+    <div ref={ref} role="group" aria-label={stat.accessibleName} className="flex flex-col">
+      <div aria-hidden="true" className="font-display leading-none text-fluid-xl text-fg">
+        {displayed}
+        <span className="ml-[2px] text-fluid-xs text-dim-2">{stat.suffix}</span>
+      </div>
+      <div className="mt-[var(--space-3xs)] text-2xs tracking-[0.16em] text-dim-2">{stat.label}</div>
+    </div>
+  )
+}

--- a/src/data/leviathan.ts
+++ b/src/data/leviathan.ts
@@ -51,8 +51,8 @@ export const LEVIATHAN_SUMMARY =
 /** Memory, tokenizer, training — the three engineering decisions worth judging. */
 export const LEVIATHAN_BULLETS: readonly string[] = [
   'Multi-Head Latent Attention cuts KV-cache memory 8×, unlocking batched inference.',
-  'A custom tokenizer folds board state and UCI notation into a 4,247-token vocabulary, so one token is one move.',
-  'Trained on 3M+ positions with gradient checkpointing and FP16 to fit a consumer GPU.',
+  'A custom tokenizer folds board state and UCI notation into a 4,247-token vocabulary.',
+  'Gradient checkpointing and FP16 push 3M+ positions through consumer hardware.',
 ]
 
 /**
@@ -127,6 +127,16 @@ export const PIPELINE_CANDIDATE_SETS: readonly (readonly PipelineCandidate[])[] 
     { move: 'O-O', percent: 64 },
     { move: 'd4', percent: 22 },
     { move: 'Nc3', percent: 9 },
+  ],
+  [
+    { move: 'Bb5', percent: 58 },
+    { move: 'Qe2', percent: 27 },
+    { move: 'h3', percent: 11 },
+  ],
+  [
+    { move: 'Rd1', percent: 66 },
+    { move: 'c3', percent: 21 },
+    { move: 'Nf3', percent: 8 },
   ],
 ]
 

--- a/src/data/leviathan.ts
+++ b/src/data/leviathan.ts
@@ -1,0 +1,134 @@
+/**
+ * Leviathan featured-project content: hook, bullets, headline stats, links,
+ * and the illustrative data driving the inference-pipeline widget (issue
+ * #317).
+ *
+ * Every headline figure below is sourced from `public/resume.pdf` (Projects
+ * > Leviathan). Where the design reference (`ideas/Portfolio.html`,
+ * gitignored, local-only) disagreed with the résumé, the résumé would win
+ * — in practice every figure here matched the reference exactly:
+ *
+ *   - 19ms per-move latency  — résumé: "…19ms per-move latency…"
+ *   - 20M parameters         — résumé: "20M-parameter transformer…"
+ *   - 3M+ positions trained  — résumé: "Trained on 3M+ chess positions…"
+ *   - 8x KV-cache reduction  — résumé: "Reduced KV-cache memory footprint
+ *                              by 8× through Multi-Head Latent Attention…"
+ *   - 4,247-token vocabulary — résumé: "…into 4,247-token vocabulary for
+ *                              single-token move prediction."
+ *
+ * The chess position, token ids, and candidate move sets used by the
+ * pipeline widget are illustrative — they demonstrate the *shape* of the
+ * pipeline (a real FEN, plausible token ids, plausible policy candidates),
+ * not a specific factual claim from the résumé.
+ */
+
+export interface LeviathanStat {
+  readonly id: string
+  readonly target: number
+  readonly suffix: string
+  readonly label: string
+  /** Full accessible name, independent of the count-up's current frame. */
+  readonly accessibleName: string
+}
+
+export interface LeviathanLink {
+  readonly label: string
+  readonly href: string
+}
+
+export interface PipelineCandidate {
+  readonly move: string
+  readonly percent: number
+}
+
+export const LEVIATHAN_HOOK = 'It never searches. It just knows.'
+
+export const LEVIATHAN_SUBTITLE = 'searchless transformer chess engine'
+
+export const LEVIATHAN_SUMMARY =
+  'A 20M-parameter transformer that picks its move in one forward pass — no search tree, no opening book. Tuned to run inference on an 8GB RTX 4060, because renting an H100 to play chess felt excessive.'
+
+/** Memory, tokenizer, training — the three engineering decisions worth judging. */
+export const LEVIATHAN_BULLETS: readonly string[] = [
+  'Multi-Head Latent Attention cuts KV-cache memory 8×, unlocking batched inference.',
+  'A custom tokenizer folds board state and UCI notation into a 4,247-token vocabulary, so one token is one move.',
+  'Trained on 3M+ positions with gradient checkpointing and FP16 to fit a consumer GPU.',
+]
+
+/**
+ * Headline stats. `target`/`suffix` drive the count-up display;
+ * `accessibleName` is the full, final figure and is what the DOM exposes
+ * to assistive tech at all times — it never depends on animation state.
+ */
+export const LEVIATHAN_STATS: readonly LeviathanStat[] = [
+  {
+    id: 'latency',
+    target: 19,
+    suffix: 'ms',
+    label: 'PER MOVE',
+    accessibleName: '19 milliseconds per move',
+  },
+  {
+    id: 'params',
+    target: 20,
+    suffix: 'M',
+    label: 'PARAMS',
+    accessibleName: '20 million parameters',
+  },
+  {
+    id: 'positions',
+    target: 3,
+    suffix: 'M+',
+    label: 'POSITIONS',
+    accessibleName: '3 million plus positions trained',
+  },
+]
+
+/**
+ * Source and live demo. The résumé links the "Leviathan" project heading
+ * itself to its HuggingFace Space — that is the only URL the résumé gives
+ * for this project; it does not separately name a source repository (unlike
+ * the MLA project below it, which lists GitHub and PyPI links explicitly).
+ *
+ * A HuggingFace Space is itself a git repository with a browsable Files
+ * tab, so the same Space serves as both the source link and the live demo
+ * here. That is a documented decision reusing the résumé's one real URL,
+ * not an invented one.
+ */
+export const LEVIATHAN_LINKS: readonly LeviathanLink[] = [
+  { label: 'source', href: 'https://huggingface.co/spaces/NemesisTCO/LeviathanChess/tree/main' },
+  { label: 'live demo', href: 'https://huggingface.co/spaces/NemesisTCO/LeviathanChess' },
+]
+
+/** Illustrative input position for the pipeline widget — a legal FEN, not a résumé claim. */
+export const PIPELINE_POSITION_FEN = 'r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R'
+
+/** Illustrative token ids for the tokenizer stage — shape only, not a résumé claim. */
+export const PIPELINE_TOKEN_IDS: readonly string[] = [
+  '1102',
+  '87',
+  '3391',
+  '44',
+  '2210',
+  '918',
+  '76',
+  '4247',
+  '12',
+]
+
+/** Illustrative candidate move sets the policy stage rotates through between loops. */
+export const PIPELINE_CANDIDATE_SETS: readonly (readonly PipelineCandidate[])[] = [
+  [
+    { move: 'Nf3', percent: 71 },
+    { move: 'e4', percent: 18 },
+    { move: 'Bb5', percent: 6 },
+  ],
+  [
+    { move: 'O-O', percent: 64 },
+    { move: 'd4', percent: 22 },
+    { move: 'Nc3', percent: 9 },
+  ],
+]
+
+/** Résumé: "…19ms per-move latency…" — reused as the pipeline's output caption. */
+export const PIPELINE_OUTPUT_META = '19 ms · one forward pass'

--- a/src/lib/leviathan/countUp.test.ts
+++ b/src/lib/leviathan/countUp.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { countUpValue, easeOutCubic } from './countUp'
+
+describe('easeOutCubic', () => {
+  it('starts at 0 and ends at 1', () => {
+    expect(easeOutCubic(0)).toBe(0)
+    expect(easeOutCubic(1)).toBe(1)
+  })
+
+  it('clamps progress outside [0, 1]', () => {
+    expect(easeOutCubic(-1)).toBe(0)
+    expect(easeOutCubic(2)).toBe(1)
+  })
+
+  it('is monotonically non-decreasing', () => {
+    let prev = easeOutCubic(0)
+    for (let p = 0.1; p <= 1; p += 0.1) {
+      const next = easeOutCubic(p)
+      expect(next).toBeGreaterThanOrEqual(prev)
+      prev = next
+    }
+  })
+
+  it('front-loads progress (ease-out): more than half done by the midpoint', () => {
+    expect(easeOutCubic(0.5)).toBeGreaterThan(0.5)
+  })
+})
+
+describe('countUpValue', () => {
+  it('is 0 at the start of the count', () => {
+    expect(countUpValue(19, 0, 900)).toBe(0)
+  })
+
+  it('reaches the target once elapsed time meets the duration', () => {
+    expect(countUpValue(19, 900, 900)).toBe(19)
+  })
+
+  it('clamps to the target past the duration, never overshooting', () => {
+    expect(countUpValue(19, 5000, 900)).toBe(19)
+  })
+
+  it('treats a non-positive duration as already complete', () => {
+    expect(countUpValue(20, 0, 0)).toBe(20)
+    expect(countUpValue(20, 100, -50)).toBe(20)
+  })
+
+  it('is monotonically non-decreasing as elapsed time advances', () => {
+    let prev = countUpValue(100, 0, 900)
+    for (let elapsed = 50; elapsed <= 900; elapsed += 50) {
+      const next = countUpValue(100, elapsed, 900)
+      expect(next).toBeGreaterThanOrEqual(prev)
+      prev = next
+    }
+  })
+
+  it('always returns a whole number', () => {
+    expect(Number.isInteger(countUpValue(19, 333, 900))).toBe(true)
+  })
+})

--- a/src/lib/leviathan/countUp.ts
+++ b/src/lib/leviathan/countUp.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure easing/count-up math for the Leviathan headline stats (issue #317).
+ *
+ * No timers, no DOM — `StatCounter.tsx` supplies the elapsed time (from its
+ * own `requestAnimationFrame` loop) and this module says what number to
+ * display. Kept separate from that component so the numeric behaviour is
+ * testable without mounting React or faking rAF.
+ */
+
+/** Ease-out cubic: fast start, slow settle into the target. */
+export function easeOutCubic(progress: number): number {
+  const clamped = Math.min(1, Math.max(0, progress))
+  return 1 - Math.pow(1 - clamped, 3)
+}
+
+/**
+ * The value to display `elapsedMs` into a `durationMs` count-up toward
+ * `target`, eased and rounded to a whole number. Clamped at both ends: a
+ * non-positive duration or an elapsed time past the duration both resolve
+ * to `target` exactly, so a caller never has to special-case "done".
+ */
+export function countUpValue(target: number, elapsedMs: number, durationMs: number): number {
+  if (durationMs <= 0) return target
+  const progress = easeOutCubic(elapsedMs / durationMs)
+  return Math.round(target * progress)
+}

--- a/src/lib/leviathan/pipeline.test.ts
+++ b/src/lib/leviathan/pipeline.test.ts
@@ -102,6 +102,19 @@ describe('computePipelineFrame', () => {
     expect(late.attentionRowsRevealed).toBe(ATTENTION_ROW_COUNT)
   })
 
+  it('completes the attention reveal a few frames before policy starts, so the full grid dwells', () => {
+    const almostFull = computePipelineFrame(48, positionLength, tokenCount)
+    expect(almostFull.attentionRowsRevealed).toBeLessThan(ATTENTION_ROW_COUNT)
+
+    // Full reveal lands at frame 49 — five frames of dwell before policy
+    // starts at frame 54, matching the design reference's pacing.
+    for (let frame = 49; frame <= 53; frame++) {
+      const model = computePipelineFrame(frame, positionLength, tokenCount)
+      expect(model.attentionRowsRevealed).toBe(ATTENTION_ROW_COUNT)
+      expect(model.policyRevealed).toBe(false)
+    }
+  })
+
   it('reveals policy and move only from their documented frame onward', () => {
     expect(computePipelineFrame(53, positionLength, tokenCount).policyRevealed).toBe(false)
     expect(computePipelineFrame(54, positionLength, tokenCount).policyRevealed).toBe(true)

--- a/src/lib/leviathan/pipeline.test.ts
+++ b/src/lib/leviathan/pipeline.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENTION_ROW_COUNT,
+  PIPELINE_LOOP_LENGTH,
+  candidateSetIndexForCycle,
+  computePipelineFrame,
+  cycleForTick,
+  frameForTick,
+  settledPipelineFrame,
+  stageAtFrame,
+} from './pipeline'
+
+describe('frameForTick', () => {
+  it('returns the tick unchanged within the first loop', () => {
+    expect(frameForTick(0)).toBe(0)
+    expect(frameForTick(40)).toBe(40)
+  })
+
+  it('wraps around at the loop length', () => {
+    expect(frameForTick(PIPELINE_LOOP_LENGTH)).toBe(0)
+    expect(frameForTick(PIPELINE_LOOP_LENGTH + 5)).toBe(5)
+    expect(frameForTick(PIPELINE_LOOP_LENGTH * 3 + 7)).toBe(7)
+  })
+
+  it('never returns a negative frame, even for a negative tick', () => {
+    expect(frameForTick(-1)).toBe(PIPELINE_LOOP_LENGTH - 1)
+    expect(frameForTick(-PIPELINE_LOOP_LENGTH)).toBe(0)
+  })
+
+  it('respects a custom loop length', () => {
+    expect(frameForTick(10, 10)).toBe(0)
+    expect(frameForTick(23, 10)).toBe(3)
+  })
+})
+
+describe('cycleForTick', () => {
+  it('is 0 for the entire first loop', () => {
+    expect(cycleForTick(0)).toBe(0)
+    expect(cycleForTick(PIPELINE_LOOP_LENGTH - 1)).toBe(0)
+  })
+
+  it('increments once per full loop', () => {
+    expect(cycleForTick(PIPELINE_LOOP_LENGTH)).toBe(1)
+    expect(cycleForTick(PIPELINE_LOOP_LENGTH * 2 + 3)).toBe(2)
+  })
+})
+
+describe('stageAtFrame', () => {
+  it('starts at position', () => {
+    expect(stageAtFrame(0)).toBe('position')
+    expect(stageAtFrame(17)).toBe('position')
+  })
+
+  it('moves to tokens, attention, policy, move at their documented boundaries', () => {
+    expect(stageAtFrame(18)).toBe('tokens')
+    expect(stageAtFrame(27)).toBe('tokens')
+    expect(stageAtFrame(28)).toBe('attention')
+    expect(stageAtFrame(53)).toBe('attention')
+    expect(stageAtFrame(54)).toBe('policy')
+    expect(stageAtFrame(63)).toBe('policy')
+    expect(stageAtFrame(64)).toBe('move')
+    expect(stageAtFrame(PIPELINE_LOOP_LENGTH - 1)).toBe('move')
+  })
+})
+
+describe('computePipelineFrame', () => {
+  const positionLength = 56
+  const tokenCount = 9
+
+  it('reveals nothing but the start of the position scan at frame 0', () => {
+    const model = computePipelineFrame(0, positionLength, tokenCount)
+    expect(model.positionRevealCount).toBe(0)
+    expect(model.tokensRevealedCount).toBe(0)
+    expect(model.attentionRowsRevealed).toBe(0)
+    expect(model.policyRevealed).toBe(false)
+    expect(model.moveRevealed).toBe(false)
+  })
+
+  it('reveals the full position by the time tokens start', () => {
+    const model = computePipelineFrame(18, positionLength, tokenCount)
+    expect(model.positionRevealCount).toBe(positionLength)
+    expect(model.tokensRevealedCount).toBeGreaterThan(0)
+  })
+
+  it('reveals tokens one at a time, capped at the token count', () => {
+    const first = computePipelineFrame(18, positionLength, tokenCount)
+    expect(first.tokensRevealedCount).toBe(1)
+
+    const mid = computePipelineFrame(20, positionLength, tokenCount)
+    expect(mid.tokensRevealedCount).toBe(3)
+
+    const past = computePipelineFrame(70, positionLength, tokenCount)
+    expect(past.tokensRevealedCount).toBe(tokenCount)
+  })
+
+  it('reveals attention rows progressively, capped at ATTENTION_ROW_COUNT', () => {
+    const early = computePipelineFrame(28, positionLength, tokenCount)
+    expect(early.attentionRowsRevealed).toBeGreaterThanOrEqual(0)
+    expect(early.attentionRowsRevealed).toBeLessThanOrEqual(ATTENTION_ROW_COUNT)
+
+    const late = computePipelineFrame(53, positionLength, tokenCount)
+    expect(late.attentionRowsRevealed).toBe(ATTENTION_ROW_COUNT)
+  })
+
+  it('reveals policy and move only from their documented frame onward', () => {
+    expect(computePipelineFrame(53, positionLength, tokenCount).policyRevealed).toBe(false)
+    expect(computePipelineFrame(54, positionLength, tokenCount).policyRevealed).toBe(true)
+    expect(computePipelineFrame(63, positionLength, tokenCount).moveRevealed).toBe(false)
+    expect(computePipelineFrame(64, positionLength, tokenCount).moveRevealed).toBe(true)
+  })
+
+  it('never decreases reveal counts as the frame advances within a loop', () => {
+    let prev = computePipelineFrame(0, positionLength, tokenCount)
+    for (let tick = 1; tick < PIPELINE_LOOP_LENGTH; tick++) {
+      const next = computePipelineFrame(tick, positionLength, tokenCount)
+      expect(next.positionRevealCount).toBeGreaterThanOrEqual(prev.positionRevealCount)
+      expect(next.tokensRevealedCount).toBeGreaterThanOrEqual(prev.tokensRevealedCount)
+      expect(next.attentionRowsRevealed).toBeGreaterThanOrEqual(prev.attentionRowsRevealed)
+      prev = next
+    }
+  })
+
+  it('reports the cycle it falls in, alongside the wrapped frame', () => {
+    const model = computePipelineFrame(PIPELINE_LOOP_LENGTH + 10, positionLength, tokenCount)
+    expect(model.frame).toBe(10)
+    expect(model.cycle).toBe(1)
+  })
+})
+
+describe('candidateSetIndexForCycle', () => {
+  it('rotates through the available sets in order', () => {
+    expect(candidateSetIndexForCycle(0, 3)).toBe(0)
+    expect(candidateSetIndexForCycle(1, 3)).toBe(1)
+    expect(candidateSetIndexForCycle(2, 3)).toBe(2)
+    expect(candidateSetIndexForCycle(3, 3)).toBe(0)
+  })
+
+  it('is always 0 when there is only one set', () => {
+    expect(candidateSetIndexForCycle(0, 1)).toBe(0)
+    expect(candidateSetIndexForCycle(5, 1)).toBe(0)
+  })
+
+  it('does not throw or return a negative index for a zero set count', () => {
+    expect(candidateSetIndexForCycle(3, 0)).toBe(0)
+  })
+})
+
+describe('settledPipelineFrame', () => {
+  it('is fully resolved: every stage revealed, nothing left to animate', () => {
+    const model = settledPipelineFrame(56, 9)
+    expect(model.stage).toBe('move')
+    expect(model.positionRevealCount).toBe(56)
+    expect(model.tokensRevealedCount).toBe(9)
+    expect(model.attentionRowsRevealed).toBe(ATTENTION_ROW_COUNT)
+    expect(model.policyRevealed).toBe(true)
+    expect(model.moveRevealed).toBe(true)
+  })
+
+  it('matches computePipelineFrame at the last frame of the loop', () => {
+    const settled = settledPipelineFrame(56, 9)
+    const direct = computePipelineFrame(PIPELINE_LOOP_LENGTH - 1, 56, 9)
+    expect(settled).toEqual(direct)
+  })
+})

--- a/src/lib/leviathan/pipeline.ts
+++ b/src/lib/leviathan/pipeline.ts
@@ -23,6 +23,16 @@ export const PIPELINE_LOOP_LENGTH = 84
 /** Number of attention rows revealed at full reveal (a 10-row grid). */
 export const ATTENTION_ROW_COUNT = 10
 
+/**
+ * Frames-per-row divisor for the attention reveal. Deliberately not derived
+ * from the attention stage's span: the reveal is meant to finish a few
+ * frames before the policy stage starts (frame 49 of 54), leaving the fully
+ * revealed "every token reads..." caption to dwell on screen — the visual
+ * argument for "it never searches" needs a beat to land before the next
+ * stage takes over.
+ */
+const ATTENTION_REVEAL_FRAME_DIVISOR = 2.2
+
 /** The frame at which each stage starts becoming active, within one loop. */
 const STAGE_START_FRAME: Record<PipelineStage, number> = {
   position: 0,
@@ -91,13 +101,12 @@ export function computePipelineFrame(
   const tokensRevealedCount =
     frame < STAGE_START_FRAME.tokens ? 0 : Math.min(tokenCount, frame - STAGE_START_FRAME.tokens + 1)
 
-  const attentionSpan = STAGE_START_FRAME.policy - STAGE_START_FRAME.attention
   const attentionRowsRevealed =
     frame < STAGE_START_FRAME.attention
       ? 0
       : Math.min(
           ATTENTION_ROW_COUNT,
-          Math.floor(((frame - STAGE_START_FRAME.attention + 1) / attentionSpan) * ATTENTION_ROW_COUNT),
+          Math.floor((frame - STAGE_START_FRAME.attention + 1) / ATTENTION_REVEAL_FRAME_DIVISOR),
         )
 
   const policyRevealed = frame >= STAGE_START_FRAME.policy

--- a/src/lib/leviathan/pipeline.ts
+++ b/src/lib/leviathan/pipeline.ts
@@ -1,0 +1,133 @@
+/**
+ * Pure frame-to-model logic for the Leviathan inference-pipeline widget
+ * (issue #317).
+ *
+ * The widget loops a fixed-length frame counter and, at each tick, reveals
+ * more of the position scan, then tokens, then attention rows, then the
+ * policy candidates, then the output move — looping back to the start.
+ * This module has no timer and no DOM: given a tick count and the sizes of
+ * the data being revealed, it returns exactly what should be visible.
+ *
+ * The React component (`InferencePipeline.tsx`) owns the `setInterval`
+ * and feeds its own tick count into `computePipelineFrame` on every
+ * render — that split is what keeps this logic unit-testable in isolation
+ * and keeps a frame tick from re-rendering anything above the widget.
+ */
+
+export const PIPELINE_STAGES = ['position', 'tokens', 'attention', 'policy', 'move'] as const
+export type PipelineStage = (typeof PIPELINE_STAGES)[number]
+
+/** Total frames in one loop of the pipeline animation. */
+export const PIPELINE_LOOP_LENGTH = 84
+
+/** Number of attention rows revealed at full reveal (a 10-row grid). */
+export const ATTENTION_ROW_COUNT = 10
+
+/** The frame at which each stage starts becoming active, within one loop. */
+const STAGE_START_FRAME: Record<PipelineStage, number> = {
+  position: 0,
+  tokens: 18,
+  attention: 28,
+  policy: 54,
+  move: 64,
+}
+
+export interface PipelineFrameModel {
+  readonly frame: number
+  readonly cycle: number
+  readonly stage: PipelineStage
+  readonly positionRevealCount: number
+  readonly tokensRevealedCount: number
+  readonly attentionRowsRevealed: number
+  readonly policyRevealed: boolean
+  readonly moveRevealed: boolean
+}
+
+/**
+ * Wraps an ever-increasing tick count into a frame within one loop.
+ * Always returns a value in `[0, loopLength)`, even for a negative tick.
+ */
+export function frameForTick(tick: number, loopLength: number = PIPELINE_LOOP_LENGTH): number {
+  return ((tick % loopLength) + loopLength) % loopLength
+}
+
+/** Which loop iteration `tick` falls in — used to rotate the policy candidates shown each loop. */
+export function cycleForTick(tick: number, loopLength: number = PIPELINE_LOOP_LENGTH): number {
+  return Math.floor(tick / loopLength)
+}
+
+/** The active stage for a given frame within one loop. */
+export function stageAtFrame(frame: number): PipelineStage {
+  if (frame >= STAGE_START_FRAME.move) return 'move'
+  if (frame >= STAGE_START_FRAME.policy) return 'policy'
+  if (frame >= STAGE_START_FRAME.attention) return 'attention'
+  if (frame >= STAGE_START_FRAME.tokens) return 'tokens'
+  return 'position'
+}
+
+/**
+ * Computes what should be visible at a given tick.
+ *
+ * @param tick ever-increasing frame counter (the component's own state)
+ * @param positionLength number of characters in the position string being scanned
+ * @param tokenCount number of tokens to reveal
+ * @param loopLength frames per loop
+ */
+export function computePipelineFrame(
+  tick: number,
+  positionLength: number,
+  tokenCount: number,
+  loopLength: number = PIPELINE_LOOP_LENGTH,
+): PipelineFrameModel {
+  const frame = frameForTick(tick, loopLength)
+  const cycle = cycleForTick(tick, loopLength)
+  const stage = stageAtFrame(frame)
+
+  const positionRevealCount = Math.min(
+    positionLength,
+    Math.round((Math.min(frame, STAGE_START_FRAME.tokens) / STAGE_START_FRAME.tokens) * positionLength),
+  )
+
+  const tokensRevealedCount =
+    frame < STAGE_START_FRAME.tokens ? 0 : Math.min(tokenCount, frame - STAGE_START_FRAME.tokens + 1)
+
+  const attentionSpan = STAGE_START_FRAME.policy - STAGE_START_FRAME.attention
+  const attentionRowsRevealed =
+    frame < STAGE_START_FRAME.attention
+      ? 0
+      : Math.min(
+          ATTENTION_ROW_COUNT,
+          Math.floor(((frame - STAGE_START_FRAME.attention + 1) / attentionSpan) * ATTENTION_ROW_COUNT),
+        )
+
+  const policyRevealed = frame >= STAGE_START_FRAME.policy
+  const moveRevealed = frame >= STAGE_START_FRAME.move
+
+  return {
+    frame,
+    cycle,
+    stage,
+    positionRevealCount,
+    tokensRevealedCount,
+    attentionRowsRevealed,
+    policyRevealed,
+    moveRevealed,
+  }
+}
+
+/** Picks which candidate move set to show this loop, rotating deterministically by cycle. */
+export function candidateSetIndexForCycle(cycle: number, setCount: number): number {
+  if (setCount <= 0) return 0
+  return ((cycle % setCount) + setCount) % setCount
+}
+
+/**
+ * The single settled frame rendered under a reduced-motion preference: the
+ * loop's final frame, fully resolved (every stage revealed), with no timer
+ * running behind it. Rendering the end state rather than the start state
+ * means a reduced-motion visitor still sees the complete pipeline output —
+ * not a widget stuck perpetually mid-reveal.
+ */
+export function settledPipelineFrame(positionLength: number, tokenCount: number): PipelineFrameModel {
+  return computePipelineFrame(PIPELINE_LOOP_LENGTH - 1, positionLength, tokenCount)
+}

--- a/src/lib/leviathan/useReducedMotion.ts
+++ b/src/lib/leviathan/useReducedMotion.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+function readPreference(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(QUERY).matches
+}
+
+/**
+ * Whether the visitor has requested reduced motion, used by both the
+ * inference-pipeline widget and its headline-stat counters (issue #317).
+ *
+ * jsdom does not implement `window.matchMedia` at all (it is `undefined`,
+ * not a stub) — `readPreference` guards for that and falls back to `false`
+ * rather than throwing at render or import time.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(readPreference)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mql = window.matchMedia(QUERY)
+    const onChange = () => setReduced(mql.matches)
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [])
+
+  return reduced
+}


### PR DESCRIPTION
Refs #317

## Summary
- Replaces the `ProjectsFeatured` placeholder with the full Leviathan featured-project section: one-line hook, three engineering bullets (memory, tokenizer, training), count-up headline stats, source/live-demo links, and a looping inference-pipeline widget (position → tokens → attention → policy → move).
- All copy and figures live in `src/data/leviathan.ts`. Every headline figure (19ms per-move latency, 20M parameters, 3M+ positions trained, 8× KV-cache reduction, 4,247-token vocabulary) is sourced from `public/resume.pdf`; the design reference agreed with the résumé on every figure, so nothing needed to be overridden.
- Frame-to-model logic for the pipeline widget (`src/lib/leviathan/pipeline.ts`) and the count-up easing (`src/lib/leviathan/countUp.ts`) are pure functions, following the `src/lib/go/board.ts` pattern, with the real test weight there (headless, no DOM/timers).
- The pipeline widget (`InferencePipeline.tsx`) and each stat counter (`StatCounter.tsx`) own their own timer/`IntersectionObserver`, scoped to themselves, so a frame or count-up tick re-renders only that leaf.
- Reduced motion, handled per-widget: the pipeline renders one settled, fully-resolved frame (the loop's last frame) with no timer started at all; stat counters show their final value immediately with no animation and no observer created.

## Source/demo link decision
The résumé links the "Leviathan" project heading itself to its HuggingFace Space — that's the only URL the résumé gives for this project (unlike MLA below it, which lists GitHub + PyPI separately). A HuggingFace Space is itself a git repo with a browsable Files tab, so the same Space is used for both the "source" and "live demo" links rather than inventing a separate GitHub repo URL that isn't in the résumé.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` (86 tests passing, including new pure-function suites for `pipeline.ts` and `countUp.ts`, and component smoke tests mocking `IntersectionObserver`/`matchMedia`)
- [x] `npm run build`
- [ ] Manual browser check of viewport fit / animation appearance (out of scope for jsdom, per repo testing decisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)