### PR TITLE
mochi: hero section with animated Go board

### DIFF
--- a/src/components/hero/GoBoardReplay.test.tsx
+++ b/src/components/hero/GoBoardReplay.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mockMatchMedia } from '@/test/mockMatchMedia'
+import { GoBoardReplay } from './GoBoardReplay'
+
+/**
+ * Seam: what jsdom can honestly observe about the hero board (issue #316).
+ * Frame-by-frame appearance and animation smoothness are browser-only and
+ * are not asserted here -- the real correctness weight sits on the pure
+ * `goTiming`/`goFrameModel` modules' headless tests. This file only checks
+ * the public, observable contract: both player names and the move number
+ * render, and reduced motion means no timer is ever started.
+ */
+describe('GoBoardReplay', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders both player names and the final move number under reduced motion, starting no timer', () => {
+    mockMatchMedia(true)
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
+
+    render(<GoBoardReplay />)
+
+    expect(screen.getByText(/LEE SEDOL/)).toBeInTheDocument()
+    expect(screen.getByText(/ALPHAGO/)).toBeInTheDocument()
+    expect(screen.getByText('MOVE 180')).toBeInTheDocument()
+    expect(rafSpy).not.toHaveBeenCalled()
+  })
+
+  it('renders the final position as an accessible image labelled with move 180 of 180', () => {
+    mockMatchMedia(true)
+
+    render(<GoBoardReplay />)
+
+    expect(screen.getByRole('img', { name: /move 180 of 180/i })).toBeInTheDocument()
+  })
+
+  it('starts an animation timer when motion is not reduced', () => {
+    mockMatchMedia(false)
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
+
+    render(<GoBoardReplay />)
+
+    expect(rafSpy).toHaveBeenCalled()
+  })
+
+  it('shows the game caption alongside the board', () => {
+    mockMatchMedia(true)
+
+    render(<GoBoardReplay />)
+
+    expect(screen.getByText(/GAME 4.*2016.*WHITE WINS BY RESIGNATION/)).toBeInTheDocument()
+  })
+})

--- a/src/components/hero/GoBoardReplay.tsx
+++ b/src/components/hero/GoBoardReplay.tsx
@@ -41,6 +41,12 @@ function BoardGrid({ frame }: { frame: BoardFrame }) {
           backgroundImage:
             'linear-gradient(to right, rgb(var(--line)) 1px, transparent 1px), linear-gradient(to bottom, rgb(var(--line)) 1px, transparent 1px)',
           backgroundSize: `calc(100% / ${BOARD_SIZE - 1}) calc(100% / ${BOARD_SIZE - 1})`,
+          // The repeating gradient above only paints a line at each tile's
+          // *start* edge, so it draws 18 of the 19 lines per axis (0/18
+          // through 17/18) and never the one at 100%. Paint that last line
+          // explicitly as an inset box-shadow on the right/bottom edges so
+          // all 19 lines land, matching the same token color.
+          boxShadow: 'inset -1px 0 0 0 rgb(var(--line)), inset 0 -1px 0 0 rgb(var(--line))',
         }}
       >
         {frame.move78Marker ? (

--- a/src/components/hero/GoBoardReplay.tsx
+++ b/src/components/hero/GoBoardReplay.tsx
@@ -2,7 +2,12 @@ import { useEffect, useRef, useState } from 'react'
 import { GAME4_BLACK_LABEL, GAME4_CAPTION, GAME4_WHITE_LABEL } from '@/data/hero'
 import { cn } from '@/lib/cn'
 import { BOARD_SIZE } from '@/lib/go/board'
-import { frameForMove, staticFinalFrame, type BoardFrame } from '@/lib/hero/goFrameModel'
+import {
+  frameForMove,
+  hasActiveCaptureFade,
+  staticFinalFrame,
+  type BoardFrame,
+} from '@/lib/hero/goFrameModel'
 import { FADE_MS, TOTAL_MOVES, frameAtElapsed } from '@/lib/hero/goTiming'
 import { useReducedMotion } from '@/lib/hero/useReducedMotion'
 
@@ -100,10 +105,31 @@ export function GoBoardReplay() {
 
     startRef.current = null
     let frameId: number
+    // Signature of "what would render" (move number, phase, whether a
+    // capture is mid-fade) for the most recent tick that actually
+    // triggered a re-render. Ticks that would produce an identical
+    // signature skip `setElapsed` entirely -- see SHOULD-FIX #4: without
+    // this, the hold phase alone re-renders and rebuilds the 361-cell
+    // stone array ~60x/sec for ~2.6s doing nothing visible. A capture
+    // fade starting or ending always changes the signature (entry rides
+    // on the move-number bump that caused it; exit is caught by
+    // `hasActiveCaptureFade` flipping false), so this cannot skip a frame
+    // that fix #1's exit animations depend on. The 'fading' phase is
+    // exempted outright because its container-opacity animation is driven
+    // by JS every tick, not CSS, so it must never skip.
+    let lastSignature: string | null = null
 
     const tick = (timestamp: number) => {
       if (startRef.current === null) startRef.current = timestamp
-      setElapsed(timestamp - startRef.current)
+      const nextElapsed = timestamp - startRef.current
+      const timing = frameAtElapsed(nextElapsed)
+      const signature = `${timing.moveNumber}|${timing.phase}|${hasActiveCaptureFade(timing.loopElapsed)}`
+
+      if (timing.phase === 'fading' || signature !== lastSignature) {
+        lastSignature = signature
+        setElapsed(nextElapsed)
+      }
+
       frameId = requestAnimationFrame(tick)
     }
     frameId = requestAnimationFrame(tick)
@@ -120,7 +146,7 @@ export function GoBoardReplay() {
     moveNumber = TOTAL_MOVES
   } else {
     const timing = frameAtElapsed(elapsed)
-    frame = frameForMove(timing.moveNumber, timing.elapsedSinceMove)
+    frame = frameForMove(timing.moveNumber, timing.loopElapsed)
     moveNumber = timing.moveNumber
     if (timing.phase === 'fading') {
       containerOpacity = Math.max(0, 1 - timing.elapsedSinceMove / FADE_MS)

--- a/src/components/hero/GoBoardReplay.tsx
+++ b/src/components/hero/GoBoardReplay.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState } from 'react'
+import { GAME4_BLACK_LABEL, GAME4_CAPTION, GAME4_WHITE_LABEL } from '@/data/hero'
+import { cn } from '@/lib/cn'
+import { BOARD_SIZE } from '@/lib/go/board'
+import { frameForMove, staticFinalFrame, type BoardFrame } from '@/lib/hero/goFrameModel'
+import { FADE_MS, TOTAL_MOVES, frameAtElapsed } from '@/lib/hero/goTiming'
+import { useReducedMotion } from '@/lib/hero/useReducedMotion'
+
+/** `0..1` position along one axis of a 19-line grid, as a CSS percentage. */
+function percentFor(index: number): string {
+  return `${(index / (BOARD_SIZE - 1)) * 100}%`
+}
+
+function moveLabelFor(moveNumber: number): string {
+  return `MOVE ${String(moveNumber).padStart(3, '0')}`
+}
+
+/**
+ * The 19x19 board itself: pure presentation of a `BoardFrame`. Stones are
+ * keyed by board position, so React reuses the same DOM node across
+ * frames for a stone that is already on the board (letting the mount
+ * animation fire only once) while a captured stone leaving the `stones`
+ * array unmounts and lets its own exit animation (`.hero-stone-leaving`,
+ * driven purely by CSS, see src/styles/hero.css) play out.
+ */
+function BoardGrid({ frame }: { frame: BoardFrame }) {
+  return (
+    <div
+      className="relative aspect-square w-full border border-line-2 bg-panel p-[4.5%]"
+      role="img"
+      aria-label={`Go board, move ${frame.moveNumber} of ${TOTAL_MOVES}`}
+    >
+      <div
+        className="relative h-full w-full"
+        style={{
+          backgroundImage:
+            'linear-gradient(to right, rgb(var(--line)) 1px, transparent 1px), linear-gradient(to bottom, rgb(var(--line)) 1px, transparent 1px)',
+          backgroundSize: `calc(100% / ${BOARD_SIZE - 1}) calc(100% / ${BOARD_SIZE - 1})`,
+        }}
+      >
+        {frame.move78Marker ? (
+          <span
+            aria-hidden="true"
+            className="absolute rounded-full border-2 border-accent"
+            style={{
+              left: percentFor(frame.move78Marker.col),
+              top: percentFor(frame.move78Marker.row),
+              width: '7.2%',
+              aspectRatio: '1',
+              transform: 'translate(-50%, -50%)',
+            }}
+          />
+        ) : null}
+        {frame.stones.map((stone) => (
+          <span
+            key={stone.key}
+            aria-hidden="true"
+            className={cn(
+              'absolute rounded-full',
+              stone.variant === 'leaving' ? 'hero-stone hero-stone-leaving' : 'hero-stone',
+              stone.variant === 'move78'
+                ? 'bg-accent'
+                : stone.color === 'B'
+                  ? 'bg-stone'
+                  : 'bg-fg',
+            )}
+            style={{
+              left: percentFor(stone.col),
+              top: percentFor(stone.row),
+              width: stone.variant === 'move78' ? '6.4%' : '5%',
+              aspectRatio: '1',
+              transform: 'translate(-50%, -50%)',
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Owns the animation timer for the hero Go board replay. Scoped to this
+ * leaf component (not `Hero.tsx`) so a ~60fps frame tick re-renders only
+ * this board, not the whole hero section.
+ *
+ * Under `prefers-reduced-motion: reduce`, no timer is started at all --
+ * the final position renders once, statically, with move 78 marked. This
+ * is the fix for the reference implementation's defect: zeroing every
+ * animation's duration still *plays* the sequence, just instantly,
+ * flashing all 180 stones on at once. Not animating in the first place is
+ * the only way to honour the preference.
+ */
+export function GoBoardReplay() {
+  const reducedMotion = useReducedMotion()
+  const [elapsed, setElapsed] = useState(0)
+  const startRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (reducedMotion) return undefined
+
+    startRef.current = null
+    let frameId: number
+
+    const tick = (timestamp: number) => {
+      if (startRef.current === null) startRef.current = timestamp
+      setElapsed(timestamp - startRef.current)
+      frameId = requestAnimationFrame(tick)
+    }
+    frameId = requestAnimationFrame(tick)
+
+    return () => cancelAnimationFrame(frameId)
+  }, [reducedMotion])
+
+  let frame: BoardFrame
+  let moveNumber: number
+  let containerOpacity = 1
+
+  if (reducedMotion) {
+    frame = staticFinalFrame()
+    moveNumber = TOTAL_MOVES
+  } else {
+    const timing = frameAtElapsed(elapsed)
+    frame = frameForMove(timing.moveNumber, timing.elapsedSinceMove)
+    moveNumber = timing.moveNumber
+    if (timing.phase === 'fading') {
+      containerOpacity = Math.max(0, 1 - timing.elapsedSinceMove / FADE_MS)
+    }
+  }
+
+  return (
+    <div
+      className="flex min-w-0 w-full max-w-[min(100%,58vh)] flex-col gap-[var(--space-2xs)]"
+      style={{ opacity: containerOpacity }}
+    >
+      <div className="flex items-center justify-between gap-[var(--space-xs)] text-2xs font-mono tracking-[0.14em] text-dim">
+        <span className="flex items-center gap-2">
+          <span aria-hidden="true" className="h-[9px] w-[9px] rounded-full bg-fg" />
+          {GAME4_WHITE_LABEL}
+        </span>
+        <span className="flex items-center gap-2">
+          {GAME4_BLACK_LABEL}
+          <span
+            aria-hidden="true"
+            className="h-[9px] w-[9px] rounded-full border border-dim-3 bg-stone"
+          />
+        </span>
+      </div>
+
+      <BoardGrid frame={frame} />
+
+      <div className="flex flex-wrap items-center justify-between gap-[var(--space-xs)] text-2xs font-mono tracking-[0.16em] text-dim-3">
+        <span>{GAME4_CAPTION}</span>
+        <span className="text-dim">{moveLabelFor(moveNumber)}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/hero/HeroTagline.test.tsx
+++ b/src/components/hero/HeroTagline.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mockMatchMedia } from '@/test/mockMatchMedia'
+import { HeroTagline } from './HeroTagline'
+
+const TEXT = 'I build things that are fun.'
+
+describe('HeroTagline', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the full tagline immediately under reduced motion, starting no reveal timer', () => {
+    mockMatchMedia(true)
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
+
+    render(<HeroTagline text={TEXT} />)
+
+    expect(screen.getByText(TEXT)).toBeInTheDocument()
+    expect(rafSpy).not.toHaveBeenCalled()
+  })
+
+  it('starts a reveal timer when motion is not reduced', () => {
+    mockMatchMedia(false)
+    const rafSpy = vi.spyOn(window, 'requestAnimationFrame')
+
+    render(<HeroTagline text={TEXT} />)
+
+    expect(rafSpy).toHaveBeenCalled()
+  })
+})

--- a/src/components/hero/HeroTagline.tsx
+++ b/src/components/hero/HeroTagline.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/cn'
+import { isTypingDone, typedText } from '@/lib/hero/typewriter'
+import { useReducedMotion } from '@/lib/hero/useReducedMotion'
+
+interface HeroTaglineProps {
+  text: string
+  className?: string
+}
+
+/**
+ * The one-shot tagline typer (issue #316): types `text` once on mount,
+ * then stops. Replaces the old site's rotating role typewriter.
+ *
+ * Under reduced motion, the full text renders immediately -- no timer, no
+ * partial reveal -- and the cursor after it holds steady rather than
+ * blinking (the blink keyframe itself is scoped to `prefers-reduced-
+ * motion: no-preference` in src/styles/hero.css, so it simply doesn't run
+ * here; this component doesn't need to know the mechanism, only that it
+ * shouldn't start a reveal timer).
+ */
+export function HeroTagline({ text, className }: HeroTaglineProps) {
+  const reducedMotion = useReducedMotion()
+  const [elapsed, setElapsed] = useState(0)
+  const startRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (reducedMotion) return undefined
+    if (isTypingDone(text, 0)) return undefined
+
+    startRef.current = null
+    let frameId: number
+
+    const tick = (timestamp: number) => {
+      if (startRef.current === null) startRef.current = timestamp
+      const next = timestamp - startRef.current
+      setElapsed(next)
+      if (!isTypingDone(text, next)) {
+        frameId = requestAnimationFrame(tick)
+      }
+    }
+    frameId = requestAnimationFrame(tick)
+
+    return () => cancelAnimationFrame(frameId)
+    // Runs once per mount / per reduced-motion change; `text` is static content.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reducedMotion])
+
+  const visible = reducedMotion ? text : typedText(text, elapsed)
+
+  return (
+    <p className={cn('min-h-[1.6em]', className)}>
+      {visible}
+      <span aria-hidden="true" className="hero-cursor ml-[0.12em] inline-block h-[1em] w-[0.5em] translate-y-[0.12em] bg-accent align-text-bottom" />
+    </p>
+  )
+}

--- a/src/components/sections/Hero.test.tsx
+++ b/src/components/sections/Hero.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mockMatchMedia } from '@/test/mockMatchMedia'
+import { HERO_ROLE, HERO_TAGLINE } from '@/data/hero'
+import { Hero } from './Hero'
+
+/**
+ * Public-interface coverage for the hero (issue #316): the role, the
+ * name, and the tagline all render, and under reduced motion the board's
+ * caption/move-number information is present with no animation running.
+ * The board's own timing/model correctness is covered exhaustively by
+ * src/lib/hero/*.test.ts; this only checks the section composes them.
+ */
+describe('Hero', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows the role, the name, and the tagline', () => {
+    mockMatchMedia(true)
+
+    render(<Hero />)
+
+    expect(screen.getByText(HERO_ROLE)).toBeInTheDocument()
+    expect(screen.getByText('FARHAN')).toBeInTheDocument()
+    expect(screen.getByText('MOHAMMED')).toBeInTheDocument()
+    expect(screen.getByText(HERO_TAGLINE)).toBeInTheDocument()
+  })
+
+  it('shows the Go board with both player names and a move number', () => {
+    mockMatchMedia(true)
+
+    render(<Hero />)
+
+    expect(screen.getByText(/LEE SEDOL/)).toBeInTheDocument()
+    expect(screen.getByText(/ALPHAGO/)).toBeInTheDocument()
+    expect(screen.getByText(/^MOVE \d+$/)).toBeInTheDocument()
+  })
+})

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,22 +1,43 @@
+import { GoBoardReplay } from '@/components/hero/GoBoardReplay'
+import { HeroTagline } from '@/components/hero/HeroTagline'
 import { Section } from '@/components/layout/Section'
+import { HERO_NAME_FIRST, HERO_NAME_LAST, HERO_ROLE, HERO_TAGLINE } from '@/data/hero'
 import { sections } from '@/data/sections'
 import { cn } from '@/lib/cn'
 
 const meta = sections[0]
 
 /**
- * Hero placeholder. The real Go board replay (#316) replaces the body
- * below; the display heading uses the hero step of the fluid type scale
- * (`--text-hero`, documented in `src/styles/layout.css`) since it is the
- * largest text on the page.
+ * The hero (issue #316): states the role and name, types a one-shot
+ * tagline, and replays all 180 real moves of AlphaGo vs. Lee Sedol Game 4
+ * beside it via `GoBoardReplay`. The heading uses the hero step of the
+ * fluid type scale (`--text-hero`, documented in src/styles/layout.css)
+ * since it is the largest text on the page.
+ *
+ * `GoBoardReplay` owns its own animation timer (scoped to that leaf
+ * component, not here) and checks `prefers-reduced-motion` itself, so
+ * this component stays a plain, non-re-rendering shell.
  */
 export function Hero() {
   return (
     <Section id={meta.id} label={meta.label}>
-      <div className="flex max-w-3xl flex-col gap-[var(--space-sm)]">
-        <p className={cn('text-fluid-xs font-mono tracking-[0.2em] text-dim')}>{meta.eyebrow}</p>
-        <h1 className={cn('font-display text-fluid-hero leading-tight text-fg')}>{meta.title}</h1>
-        <p className={cn('text-fluid-lg font-mono text-fg-2')}>{meta.blurb}</p>
+      <div className="grid w-full items-center gap-[var(--space-lg)] [grid-template-columns:repeat(auto-fit,minmax(330px,1fr))]">
+        <div className="flex min-w-0 flex-col gap-[var(--space-sm)]">
+          <p className="flex items-center gap-[var(--space-2xs)] font-mono text-fluid-xs tracking-[0.2em] text-dim">
+            <span aria-hidden="true" className="h-[9px] w-[9px] rounded-full bg-accent" />
+            {HERO_ROLE}
+          </p>
+          <h1 className={cn('font-display text-fluid-hero leading-tight text-fg')}>
+            <span className="block">{HERO_NAME_FIRST}</span>
+            <span className="block bg-accent px-[0.05em] text-bg">{HERO_NAME_LAST}</span>
+          </h1>
+          <HeroTagline
+            text={HERO_TAGLINE}
+            className="max-w-[26ch] text-fluid-lg font-mono text-fg-2"
+          />
+        </div>
+
+        <GoBoardReplay />
       </div>
     </Section>
   )

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -29,7 +29,7 @@ export function Hero() {
           </p>
           <h1 className={cn('font-display text-fluid-hero leading-tight text-fg')}>
             <span className="block">{HERO_NAME_FIRST}</span>
-            <span className="block bg-accent px-[0.05em] text-bg">{HERO_NAME_LAST}</span>
+            <span className="inline-block bg-accent px-[0.05em] text-bg">{HERO_NAME_LAST}</span>
           </h1>
           <HeroTagline
             text={HERO_TAGLINE}

--- a/src/data/hero.ts
+++ b/src/data/hero.ts
@@ -1,0 +1,22 @@
+/**
+ * Hero-specific content (issue #316). Kept separate from the placeholder
+ * eyebrow/title/blurb in `src/data/sections.ts` -- that module is the
+ * generic six-section shell's data (#311), while this is the real hero
+ * copy and the Game 4 caption, per "content lives in data modules, not
+ * inside render components."
+ *
+ * Facts (name) are traceable to `public/resume.pdf`. The role line and
+ * tagline are copy, not facts, and follow the design reference
+ * (`ideas/Portfolio.html`) where the résumé has no equivalent to
+ * contradict.
+ */
+
+export const HERO_NAME_FIRST = 'FARHAN'
+export const HERO_NAME_LAST = 'MOHAMMED'
+export const HERO_ROLE = 'ML + SYSTEMS ENGINEER'
+export const HERO_TAGLINE = 'I build things that are fun.'
+
+/** Caption labels shown alongside the board -- must stay true of what plays. */
+export const GAME4_WHITE_LABEL = 'LEE SEDOL · WHITE'
+export const GAME4_BLACK_LABEL = 'ALPHAGO · BLACK'
+export const GAME4_CAPTION = 'GAME 4 · 2016 · WHITE WINS BY RESIGNATION'

--- a/src/data/hero.ts
+++ b/src/data/hero.ts
@@ -5,15 +5,16 @@
  * copy and the Game 4 caption, per "content lives in data modules, not
  * inside render components."
  *
- * Facts (name) are traceable to `public/resume.pdf`. The role line and
- * tagline are copy, not facts, and follow the design reference
- * (`ideas/Portfolio.html`) where the résumé has no equivalent to
- * contradict.
+ * Facts (name) are traceable to `public/resume.pdf`. The tagline is copy,
+ * not fact, and follows the design reference (`ideas/Portfolio.html`)
+ * where the résumé has no equivalent to contradict. The role line is the
+ * project owner's explicit wording choice and deliberately departs from
+ * the reference -- it is not meant to track it.
  */
 
 export const HERO_NAME_FIRST = 'FARHAN'
 export const HERO_NAME_LAST = 'MOHAMMED'
-export const HERO_ROLE = 'ML + SYSTEMS ENGINEER'
+export const HERO_ROLE = 'ASPIRING ML + SYSTEMS + SOFTWARE ENGINEER'
 export const HERO_TAGLINE = 'I build things that are fun.'
 
 /** Caption labels shown alongside the board -- must stay true of what plays. */

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
 @import './styles/fonts.css';
 @import './styles/themes.css';
 @import './styles/layout.css';
+@import './styles/hero.css';
 
 /*
  * Tailwind's theme keys are mapped onto the swappable custom properties

--- a/src/lib/hero/goFrameModel.test.ts
+++ b/src/lib/hero/goFrameModel.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { GAME4_MOVES } from '@/data/game4Moves'
+import { TOTAL_MOVES } from './goTiming'
+import { GAME4_BOARD_STATES, MOVE_78_POSITION, frameForMove, staticFinalFrame } from './goFrameModel'
+
+describe('MOVE_78_POSITION', () => {
+  it('matches the real move 78 coordinate (W ki, row 8 col 10)', () => {
+    expect(MOVE_78_POSITION).toEqual({ row: 8, col: 10 })
+  })
+})
+
+describe('frameForMove', () => {
+  it('is empty at move 0', () => {
+    expect(frameForMove(0).stones).toHaveLength(0)
+    expect(frameForMove(0).move78Marker).toBeNull()
+  })
+
+  it('has exactly one stone on the board after move 1', () => {
+    const frame = frameForMove(1)
+    expect(frame.stones).toHaveLength(1)
+    expect(frame.stones[0]).toMatchObject({ row: 3, col: 15, color: 'B' })
+  })
+
+  it('has no move78Marker before move 78', () => {
+    expect(frameForMove(77).move78Marker).toBeNull()
+  })
+
+  it('marks move78Marker at the move-78 coordinate from move 78 onward', () => {
+    expect(frameForMove(78).move78Marker).toEqual(MOVE_78_POSITION)
+    expect(frameForMove(180).move78Marker).toEqual(MOVE_78_POSITION)
+  })
+
+  it('renders the move-78 stone with the move78 variant while it is on the board', () => {
+    const frame = frameForMove(78)
+    const stone = frame.stones.find((s) => s.row === MOVE_78_POSITION.row && s.col === MOVE_78_POSITION.col)
+    expect(stone?.variant).toBe('move78')
+  })
+
+  it('the number of stones on the board never exceeds the move number (captures only remove)', () => {
+    for (let n = 1; n <= TOTAL_MOVES; n++) {
+      expect(frameForMove(n).stones.filter((s) => s.variant !== 'leaving').length).toBeLessThanOrEqual(n)
+    }
+  })
+
+  it('the board reflects real captures: a move exists where the stone count drops', () => {
+    const counts = Array.from({ length: TOTAL_MOVES }, (_, i) =>
+      frameForMove(i + 1).stones.filter((s) => s.variant !== 'leaving').length,
+    )
+    const hasCaptureDrop = counts.some((count, i) => i > 0 && count < counts[i - 1])
+    expect(hasCaptureDrop).toBe(true)
+  })
+
+  it('the move-78 stone is itself captured later in the game (move 91) -- real, not a bug', () => {
+    const move90 = frameForMove(90).stones.find(
+      (s) => s.row === MOVE_78_POSITION.row && s.col === MOVE_78_POSITION.col,
+    )
+    const move91 = frameForMove(91).stones.find(
+      (s) => s.row === MOVE_78_POSITION.row && s.col === MOVE_78_POSITION.col && s.variant !== 'leaving',
+    )
+    expect(move90).toBeDefined()
+    expect(move91).toBeUndefined()
+  })
+
+  it('marks stones captured at a given move as "leaving" within the capture-fade window', () => {
+    // Find a move that captures at least one stone.
+    const captureMove = GAME4_BOARD_STATES.findIndex((state) => state.captured.length > 0) + 1
+    expect(captureMove).toBeGreaterThan(0)
+
+    const midFade = frameForMove(captureMove, 100)
+    const leaving = midFade.stones.filter((s) => s.variant === 'leaving')
+    expect(leaving.length).toBeGreaterThan(0)
+  })
+
+  it('does not report "leaving" stones once the capture-fade window has passed', () => {
+    const captureMove = GAME4_BOARD_STATES.findIndex((state) => state.captured.length > 0) + 1
+    const afterFade = frameForMove(captureMove, 10_000)
+    expect(afterFade.stones.some((s) => s.variant === 'leaving')).toBe(false)
+  })
+
+  it('clamps to the final position for move numbers beyond 180', () => {
+    expect(frameForMove(500)).toEqual(frameForMove(TOTAL_MOVES))
+  })
+})
+
+describe('staticFinalFrame', () => {
+  it('shows the final position with move 78 marked and nothing mid-animation', () => {
+    const frame = staticFinalFrame()
+    expect(frame.moveNumber).toBe(TOTAL_MOVES)
+    expect(frame.move78Marker).toEqual(MOVE_78_POSITION)
+    expect(frame.stones.some((s) => s.variant === 'leaving')).toBe(false)
+  })
+
+  it('matches the real board state after all 180 moves', () => {
+    const frame = staticFinalFrame()
+    const finalBoard = GAME4_BOARD_STATES[TOTAL_MOVES - 1].board
+    let expectedCount = 0
+    for (const row of finalBoard) for (const cell of row) if (cell !== null) expectedCount++
+    expect(frame.stones).toHaveLength(expectedCount)
+  })
+})
+
+describe('GAME4_MOVES sanity (already covered by data/game4Moves.test.ts, spot-checked here too)', () => {
+  it('has exactly 180 moves', () => {
+    expect(GAME4_MOVES).toHaveLength(180)
+  })
+})

--- a/src/lib/hero/goFrameModel.test.ts
+++ b/src/lib/hero/goFrameModel.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import { GAME4_MOVES } from '@/data/game4Moves'
-import { TOTAL_MOVES } from './goTiming'
-import { GAME4_BOARD_STATES, MOVE_78_POSITION, frameForMove, staticFinalFrame } from './goFrameModel'
+import { CAPTURE_FADE_MS, TOTAL_MOVES, moveTimestampMs } from './goTiming'
+import {
+  GAME4_BOARD_STATES,
+  MOVE_78_POSITION,
+  frameForMove,
+  hasActiveCaptureFade,
+  staticFinalFrame,
+} from './goFrameModel'
 
 describe('MOVE_78_POSITION', () => {
   it('matches the real move 78 coordinate (W ki, row 8 col 10)', () => {
@@ -61,24 +67,132 @@ describe('frameForMove', () => {
     expect(move91).toBeUndefined()
   })
 
-  it('marks stones captured at a given move as "leaving" within the capture-fade window', () => {
+  it('marks stones captured at a given move as "leaving" while that move is still current', () => {
     // Find a move that captures at least one stone.
     const captureMove = GAME4_BOARD_STATES.findIndex((state) => state.captured.length > 0) + 1
     expect(captureMove).toBeGreaterThan(0)
 
-    const midFade = frameForMove(captureMove, 100)
+    const midFade = frameForMove(captureMove, moveTimestampMs(captureMove) + 100)
     const leaving = midFade.stones.filter((s) => s.variant === 'leaving')
     expect(leaving.length).toBeGreaterThan(0)
   })
 
   it('does not report "leaving" stones once the capture-fade window has passed', () => {
     const captureMove = GAME4_BOARD_STATES.findIndex((state) => state.captured.length > 0) + 1
-    const afterFade = frameForMove(captureMove, 10_000)
+    const afterFade = frameForMove(captureMove, moveTimestampMs(captureMove) + 10_000)
     expect(afterFade.stones.some((s) => s.variant === 'leaving')).toBe(false)
   })
 
   it('clamps to the final position for move numbers beyond 180', () => {
     expect(frameForMove(500)).toEqual(frameForMove(TOTAL_MOVES))
+  })
+
+  describe('capture fades survive the next move arriving (the exit-animation-truncation bug)', () => {
+    // Real Game 4 data: move 176 captures an 8-stone group, and the very
+    // next move (177) appears just 50ms later -- far inside the 550ms
+    // CAPTURE_FADE_MS window. A correct model must keep reporting those 8
+    // stones as "leaving" at move 177's own frame, not drop them the
+    // instant move 177 becomes current. Move 178 captures again 50ms after
+    // that, so its fade window overlaps move 176's.
+    const MOVE_176 = 176
+    const MOVE_178 = 178
+
+    it('move 176 really captures 8 stones and move 178 really captures 1 (sanity, matches the issue data)', () => {
+      expect(GAME4_BOARD_STATES[MOVE_176 - 1].captured).toHaveLength(8)
+      expect(GAME4_BOARD_STATES[MOVE_178 - 1].captured).toHaveLength(1)
+    })
+
+    it('all 8 of move 176\'s captured stones are still "leaving" once move 177 is current', () => {
+      const captured = GAME4_BOARD_STATES[MOVE_176 - 1].captured
+      const frame = frameForMove(MOVE_176 + 1, moveTimestampMs(MOVE_176 + 1))
+
+      for (const position of captured) {
+        const stone = frame.stones.find(
+          (s) => s.row === position.row && s.col === position.col && s.variant === 'leaving',
+        )
+        expect(stone).toBeDefined()
+      }
+      expect(frame.moveNumber).toBe(MOVE_176 + 1)
+    })
+
+    it('move 176\'s fade is still present at move 178, and move 178\'s own capture is fading too (overlapping fades)', () => {
+      const move176Captured = GAME4_BOARD_STATES[MOVE_176 - 1].captured
+      const move178Captured = GAME4_BOARD_STATES[MOVE_178 - 1].captured
+      const frame = frameForMove(MOVE_178, moveTimestampMs(MOVE_178))
+
+      for (const position of move176Captured) {
+        expect(
+          frame.stones.some(
+            (s) => s.row === position.row && s.col === position.col && s.variant === 'leaving',
+          ),
+        ).toBe(true)
+      }
+      for (const position of move178Captured) {
+        expect(
+          frame.stones.some(
+            (s) => s.row === position.row && s.col === position.col && s.variant === 'leaving',
+          ),
+        ).toBe(true)
+      }
+    })
+
+    it('the leaving stone keeps the same React key across the moves it survives', () => {
+      const [firstCaptured] = GAME4_BOARD_STATES[MOVE_176 - 1].captured
+      const keyAt177 = frameForMove(MOVE_176 + 1, moveTimestampMs(MOVE_176 + 1)).stones.find(
+        (s) => s.row === firstCaptured.row && s.col === firstCaptured.col && s.variant === 'leaving',
+      )?.key
+      const keyAt178 = frameForMove(MOVE_178, moveTimestampMs(MOVE_178)).stones.find(
+        (s) => s.row === firstCaptured.row && s.col === firstCaptured.col && s.variant === 'leaving',
+      )?.key
+
+      expect(keyAt177).toBeDefined()
+      expect(keyAt178).toBeDefined()
+      expect(keyAt177).toBe(keyAt178)
+    })
+
+    it("move 176's fade has fully expired well past its own CAPTURE_FADE_MS deadline", () => {
+      // Checked by key, not position: one of move 176's 8 points is played
+      // back into and re-captured at move 178 (a real snapback in the
+      // game), so by this time the *position* can legitimately host a
+      // fresh, still-fading move-178 "leaving" stone even though move
+      // 176's own fade for that key is long gone.
+      const captured = GAME4_BOARD_STATES[MOVE_176 - 1].captured
+      const longAfter = moveTimestampMs(MOVE_176) + CAPTURE_FADE_MS + 1
+      const frame = frameForMove(TOTAL_MOVES, longAfter)
+
+      for (const position of captured) {
+        const expiredKey = `leaving-${position.row}-${position.col}-${MOVE_176}`
+        expect(frame.stones.some((s) => s.key === expiredKey)).toBe(false)
+      }
+    })
+
+    it('a fade in flight at the end of one loop does not bleed into a fresh loop after wraparound', () => {
+      // If the sequence has just restarted (loopElapsed near zero) but a
+      // stale frame still asks about a late move number, the move-176
+      // capture -- which happened tens of seconds into the *previous*
+      // loop -- must not be reported as still fading.
+      const frame = frameForMove(MOVE_178, 10)
+      const captured = GAME4_BOARD_STATES[MOVE_176 - 1].captured
+      for (const position of captured) {
+        expect(
+          frame.stones.some(
+            (s) => s.row === position.row && s.col === position.col && s.variant === 'leaving',
+          ),
+        ).toBe(false)
+      }
+    })
+  })
+
+  describe('hasActiveCaptureFade', () => {
+    it('is true immediately after move 176\'s capture and false long after it', () => {
+      expect(hasActiveCaptureFade(moveTimestampMs(176) + 10)).toBe(true)
+      expect(hasActiveCaptureFade(moveTimestampMs(176) + CAPTURE_FADE_MS + 1)).toBe(true) // move 178 overlaps
+      expect(hasActiveCaptureFade(moveTimestampMs(178) + CAPTURE_FADE_MS + 1)).toBe(false)
+    })
+
+    it('is false before any capture has happened', () => {
+      expect(hasActiveCaptureFade(0)).toBe(false)
+    })
   })
 })
 

--- a/src/lib/hero/goFrameModel.ts
+++ b/src/lib/hero/goFrameModel.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure frame-to-model logic for the hero Go board (issue #316): given a
+ * move number (and how long ago it appeared), produces the set of stones
+ * to render and their visual state.
+ *
+ * This is the "model" half of the frame-to-model split: `goTiming.ts`
+ * turns elapsed time into a move number, and this module turns a move
+ * number into what the board actually looks like. The board states
+ * themselves come from the real Go rules engine (`@/lib/go/board`) applied
+ * to the real Game 4 move list -- captures are resolved once, here, by
+ * that engine, not re-derived or approximated.
+ *
+ * No DOM, no React, no timers.
+ */
+import { GAME4_MOVES } from '@/data/game4Moves'
+import {
+  BOARD_SIZE,
+  computeBoardStates,
+  createEmptyBoard,
+  type Board,
+  type BoardState,
+  type Color,
+  type Position,
+} from '@/lib/go/board'
+import { CAPTURE_FADE_MS, MOVE_78, TOTAL_MOVES } from './goTiming'
+
+/** The board state after each of the 180 real Game 4 moves, captures resolved. */
+export const GAME4_BOARD_STATES: readonly BoardState[] = computeBoardStates(
+  GAME4_MOVES.map((move) => ({ color: move.color, position: move.position })),
+)
+
+/** Where move 78 -- Lee Sedol's wedge, the move the game turns on -- was played. */
+export const MOVE_78_POSITION: Position = GAME4_MOVES[MOVE_78 - 1].position
+
+export type StoneVariant = 'stone' | 'move78' | 'leaving'
+
+export interface StoneView {
+  /** Stable per-position key so React can key stones across frames. */
+  readonly key: string
+  readonly row: number
+  readonly col: number
+  readonly color: Color
+  readonly variant: StoneVariant
+}
+
+export interface BoardFrame {
+  /** 0..TOTAL_MOVES; 0 means the board is still empty. */
+  readonly moveNumber: number
+  readonly stones: readonly StoneView[]
+  /**
+   * Where move 78 was played, once it has happened -- present even after
+   * that stone is captured (move 91, in the real game), so the point that
+   * decided the game stays marked. `null` before move 78.
+   */
+  readonly move78Marker: Position | null
+}
+
+function boardAt(moveNumber: number): Board {
+  if (moveNumber <= 0) return createEmptyBoard()
+  const clamped = Math.min(moveNumber, TOTAL_MOVES)
+  return GAME4_BOARD_STATES[clamped - 1].board
+}
+
+function stateAt(moveNumber: number): BoardState | null {
+  if (moveNumber <= 0 || moveNumber > TOTAL_MOVES) return null
+  return GAME4_BOARD_STATES[moveNumber - 1]
+}
+
+function isMove78Position(row: number, col: number): boolean {
+  return row === MOVE_78_POSITION.row && col === MOVE_78_POSITION.col
+}
+
+/**
+ * The board frame for `moveNumber`, including any just-captured stones
+ * still within their exit-animation window (`elapsedSinceMoveMs` since
+ * that move appeared, from `goTiming.frameAtElapsed`).
+ *
+ * Pass a large `elapsedSinceMoveMs` (or omit it) for a frame with no
+ * "leaving" stones -- e.g. the static final frame shown under reduced
+ * motion, where nothing should be mid-animation.
+ */
+export function frameForMove(
+  moveNumber: number,
+  elapsedSinceMoveMs = Number.POSITIVE_INFINITY,
+): BoardFrame {
+  const clamped = Math.max(0, Math.min(moveNumber, TOTAL_MOVES))
+  const board = boardAt(clamped)
+
+  const stones: StoneView[] = []
+  for (let row = 0; row < BOARD_SIZE; row++) {
+    for (let col = 0; col < BOARD_SIZE; col++) {
+      const color = board[row][col]
+      if (color === null) continue
+      const variant: StoneVariant =
+        clamped >= MOVE_78 && isMove78Position(row, col) ? 'move78' : 'stone'
+      stones.push({ key: `${row}-${col}`, row, col, color, variant })
+    }
+  }
+
+  const currentState = stateAt(clamped)
+  if (currentState && currentState.captured.length > 0 && elapsedSinceMoveMs < CAPTURE_FADE_MS) {
+    const previousBoard = boardAt(clamped - 1)
+    for (const position of currentState.captured) {
+      const color = previousBoard[position.row][position.col]
+      if (color === null) continue
+      stones.push({
+        key: `leaving-${position.row}-${position.col}-${clamped}`,
+        row: position.row,
+        col: position.col,
+        color,
+        variant: 'leaving',
+      })
+    }
+  }
+
+  return {
+    moveNumber: clamped,
+    stones,
+    move78Marker: clamped >= MOVE_78 ? MOVE_78_POSITION : null,
+  }
+}
+
+/**
+ * The final position, drawn with no animation in progress -- used for the
+ * reduced-motion static board (move 78 marked, nothing mid-capture-fade).
+ */
+export function staticFinalFrame(): BoardFrame {
+  return frameForMove(TOTAL_MOVES)
+}

--- a/src/lib/hero/goFrameModel.ts
+++ b/src/lib/hero/goFrameModel.ts
@@ -1,7 +1,7 @@
 /**
  * Pure frame-to-model logic for the hero Go board (issue #316): given a
- * move number (and how long ago it appeared), produces the set of stones
- * to render and their visual state.
+ * move number and the loop's wall-clock elapsed time, produces the set of
+ * stones to render and their visual state.
  *
  * This is the "model" half of the frame-to-model split: `goTiming.ts`
  * turns elapsed time into a move number, and this module turns a move
@@ -9,6 +9,12 @@
  * themselves come from the real Go rules engine (`@/lib/go/board`) applied
  * to the real Game 4 move list -- captures are resolved once, here, by
  * that engine, not re-derived or approximated.
+ *
+ * Capture exit-fades are keyed to wall-clock `loopElapsed`, not to "time
+ * since the current move appeared": a fade started on one move must keep
+ * rendering while later moves arrive, so it is tracked against its own
+ * capture timestamp rather than against whatever move is current. See
+ * `CAPTURE_EVENTS` / `activeFadeAt`.
  *
  * No DOM, no React, no timers.
  */
@@ -22,7 +28,7 @@ import {
   type Color,
   type Position,
 } from '@/lib/go/board'
-import { CAPTURE_FADE_MS, MOVE_78, TOTAL_MOVES } from './goTiming'
+import { CAPTURE_FADE_MS, MOVE_78, TOTAL_MOVES, moveTimestampMs } from './goTiming'
 
 /** The board state after each of the 180 real Game 4 moves, captures resolved. */
 export const GAME4_BOARD_STATES: readonly BoardState[] = computeBoardStates(
@@ -31,6 +37,27 @@ export const GAME4_BOARD_STATES: readonly BoardState[] = computeBoardStates(
 
 /** Where move 78 -- Lee Sedol's wedge, the move the game turns on -- was played. */
 export const MOVE_78_POSITION: Position = GAME4_MOVES[MOVE_78 - 1].position
+
+/**
+ * The most recent move number, as of move `n`, that placed a stone at the
+ * move-78 point. Tracked separately from board occupancy so the move-78
+ * emphasis can be keyed to *that specific stone*, not to "whatever is
+ * currently sitting on that coordinate" -- the point is captured (move 91)
+ * and, in principle, could be played into again later by either colour.
+ * Index `n - 1` holds the value as of move `n`; `0` means never played.
+ */
+const LATEST_PLAY_AT_MOVE_78_POSITION: readonly number[] = (() => {
+  const result: number[] = []
+  let latest = 0
+  for (let n = 1; n <= TOTAL_MOVES; n++) {
+    const move = GAME4_MOVES[n - 1]
+    if (move.position.row === MOVE_78_POSITION.row && move.position.col === MOVE_78_POSITION.col) {
+      latest = n
+    }
+    result.push(latest)
+  }
+  return result
+})()
 
 export type StoneVariant = 'stone' | 'move78' | 'leaving'
 
@@ -61,27 +88,86 @@ function boardAt(moveNumber: number): Board {
   return GAME4_BOARD_STATES[clamped - 1].board
 }
 
-function stateAt(moveNumber: number): BoardState | null {
-  if (moveNumber <= 0 || moveNumber > TOTAL_MOVES) return null
-  return GAME4_BOARD_STATES[moveNumber - 1]
+/**
+ * True if the stone currently occupying the move-78 point is *the* move-78
+ * stone -- i.e. no later move has been played onto that coordinate since
+ * (which would only be possible after it was captured). Keys the emphasis
+ * to the specific stone's identity rather than to the coordinate, so a
+ * hypothetical future replay onto that point would not be mistaken for it.
+ */
+function isCurrentMove78Stone(clamped: number, row: number, col: number): boolean {
+  if (row !== MOVE_78_POSITION.row || col !== MOVE_78_POSITION.col) return false
+  return LATEST_PLAY_AT_MOVE_78_POSITION[clamped - 1] === MOVE_78
 }
 
-function isMove78Position(row: number, col: number): boolean {
-  return row === MOVE_78_POSITION.row && col === MOVE_78_POSITION.col
+interface CaptureEvent {
+  readonly moveNumber: number
+  readonly row: number
+  readonly col: number
+  readonly color: Color
 }
 
 /**
- * The board frame for `moveNumber`, including any just-captured stones
- * still within their exit-animation window (`elapsedSinceMoveMs` since
- * that move appeared, from `goTiming.frameAtElapsed`).
+ * Every stone capture across the real Game 4 replay, flattened into a
+ * single ordered list, each tagged with the move number it happened on and
+ * the colour that was removed. Precomputed once so `frameForMove` (called
+ * every animation frame) doesn't re-derive capture history per call.
+ */
+const CAPTURE_EVENTS: readonly CaptureEvent[] = (() => {
+  const events: CaptureEvent[] = []
+  for (let moveNumber = 1; moveNumber <= TOTAL_MOVES; moveNumber++) {
+    const state = GAME4_BOARD_STATES[moveNumber - 1]
+    if (state.captured.length === 0) continue
+    const previousBoard = boardAt(moveNumber - 1)
+    for (const position of state.captured) {
+      const color = previousBoard[position.row][position.col]
+      if (color === null) continue
+      events.push({ moveNumber, row: position.row, col: position.col, color })
+    }
+  }
+  return events
+})()
+
+/**
+ * Whether a capture event is still within its exit-animation window at
+ * `loopElapsedMs` (wall-clock time since the loop began, from
+ * `goTiming.frameAtElapsed`'s `loopElapsed`) -- i.e. `0 <= elapsed <
+ * CAPTURE_FADE_MS` measured from *that event's own* move timestamp, not
+ * from whatever move happens to be current. This is what lets a fade
+ * started at, say, move 176 keep rendering while moves 177-179 arrive:
+ * each fade's clock is independent of the "current move" concept.
+ */
+function activeFadeAt(event: CaptureEvent, loopElapsedMs: number): boolean {
+  const elapsed = loopElapsedMs - moveTimestampMs(event.moveNumber)
+  return elapsed >= 0 && elapsed < CAPTURE_FADE_MS
+}
+
+/**
+ * True if any capture anywhere in the replay is currently mid-fade at
+ * `loopElapsedMs`. Exposed so the component can skip redundant re-renders
+ * (SHOULD-FIX #4) without ever skipping one that would actually change
+ * what's on screen -- a currently-open fade is exactly the case where
+ * "nothing new happened" can still mean "something is still animating".
+ */
+export function hasActiveCaptureFade(loopElapsedMs: number): boolean {
+  return CAPTURE_EVENTS.some((event) => activeFadeAt(event, loopElapsedMs))
+}
+
+/**
+ * The board frame for `moveNumber`, including any captured stones -- from
+ * this move or any earlier one in the same loop -- still within their own
+ * exit-animation window. `loopElapsedMs` is wall-clock time since the loop
+ * began (`goTiming.frameAtElapsed`'s `loopElapsed`), which is what lets a
+ * fade started several moves back keep rendering as 'leaving' right up to
+ * its own `CAPTURE_FADE_MS` deadline, independent of the current move.
  *
- * Pass a large `elapsedSinceMoveMs` (or omit it) for a frame with no
- * "leaving" stones -- e.g. the static final frame shown under reduced
- * motion, where nothing should be mid-animation.
+ * Pass a large `loopElapsedMs` (or omit it) for a frame with no "leaving"
+ * stones -- e.g. the static final frame shown under reduced motion, where
+ * nothing should be mid-animation.
  */
 export function frameForMove(
   moveNumber: number,
-  elapsedSinceMoveMs = Number.POSITIVE_INFINITY,
+  loopElapsedMs = Number.POSITIVE_INFINITY,
 ): BoardFrame {
   const clamped = Math.max(0, Math.min(moveNumber, TOTAL_MOVES))
   const board = boardAt(clamped)
@@ -92,25 +178,23 @@ export function frameForMove(
       const color = board[row][col]
       if (color === null) continue
       const variant: StoneVariant =
-        clamped >= MOVE_78 && isMove78Position(row, col) ? 'move78' : 'stone'
+        clamped >= MOVE_78 && isCurrentMove78Stone(clamped, row, col) ? 'move78' : 'stone'
       stones.push({ key: `${row}-${col}`, row, col, color, variant })
     }
   }
 
-  const currentState = stateAt(clamped)
-  if (currentState && currentState.captured.length > 0 && elapsedSinceMoveMs < CAPTURE_FADE_MS) {
-    const previousBoard = boardAt(clamped - 1)
-    for (const position of currentState.captured) {
-      const color = previousBoard[position.row][position.col]
-      if (color === null) continue
-      stones.push({
-        key: `leaving-${position.row}-${position.col}-${clamped}`,
-        row: position.row,
-        col: position.col,
-        color,
-        variant: 'leaving',
-      })
-    }
+  for (const event of CAPTURE_EVENTS) {
+    if (!activeFadeAt(event, loopElapsedMs)) continue
+    // Stable key for the event's whole fade window -- not the current
+    // move -- so React keeps the same DOM node (and its CSS transition)
+    // alive across the moves that arrive while it fades out.
+    stones.push({
+      key: `leaving-${event.row}-${event.col}-${event.moveNumber}`,
+      row: event.row,
+      col: event.col,
+      color: event.color,
+      variant: 'leaving',
+    })
   }
 
   return {

--- a/src/lib/hero/goTiming.test.ts
+++ b/src/lib/hero/goTiming.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CAPTURE_FADE_MS,
+  FADE_MS,
+  HOLD_MS,
+  LOOP_MS,
+  MOVE_78,
+  SEQUENCE_MS,
+  TOTAL_MOVES,
+  frameAtElapsed,
+  moveDelayMs,
+  moveTimestampMs,
+} from './goTiming'
+
+describe('moveTimestampMs', () => {
+  it('is strictly increasing across all 180 moves', () => {
+    for (let n = 2; n <= TOTAL_MOVES; n++) {
+      expect(moveTimestampMs(n)).toBeGreaterThan(moveTimestampMs(n - 1))
+    }
+  })
+
+  it('places move 1 after a short initial delay, not instantly', () => {
+    expect(moveTimestampMs(1)).toBeGreaterThan(0)
+  })
+})
+
+describe('moveDelayMs', () => {
+  it('is slow in the opening (first 10 moves)', () => {
+    for (let n = 2; n <= 10; n++) {
+      expect(moveDelayMs(n)).toBeGreaterThanOrEqual(390)
+    }
+  })
+
+  it('generally trends faster from the opening into the middlegame', () => {
+    expect(moveDelayMs(15)).toBeLessThan(moveDelayMs(2))
+    expect(moveDelayMs(50)).toBeLessThan(moveDelayMs(15))
+  })
+
+  it('is fast immediately before move 78', () => {
+    expect(moveDelayMs(MOVE_78 - 1)).toBeLessThan(150)
+  })
+
+  it('gives move 78 the single longest delay of the whole game -- the deliberate pause', () => {
+    const delays = Array.from({ length: TOTAL_MOVES }, (_, i) => moveDelayMs(i + 1))
+    const max = Math.max(...delays)
+    expect(moveDelayMs(MOVE_78)).toBe(max)
+    // The pause is dramatically longer than its neighbours, not just the max by a hair.
+    expect(moveDelayMs(MOVE_78)).toBeGreaterThan(moveDelayMs(MOVE_78 - 1) * 5)
+    expect(moveDelayMs(MOVE_78)).toBeGreaterThan(moveDelayMs(MOVE_78 + 1) * 5)
+  })
+
+  it('is fast again through the endgame after move 78', () => {
+    expect(moveDelayMs(160)).toBeLessThan(moveDelayMs(MOVE_78 + 2))
+  })
+
+  it('reaches its fastest pace by the final moves', () => {
+    expect(moveDelayMs(TOTAL_MOVES)).toBeLessThanOrEqual(moveDelayMs(100))
+  })
+})
+
+describe('LOOP_MS', () => {
+  it('lands close to the ~30s target from the spec', () => {
+    expect(LOOP_MS).toBeGreaterThan(25_000)
+    expect(LOOP_MS).toBeLessThan(35_000)
+  })
+
+  it('is the sequence plus the hold plus the fade', () => {
+    expect(LOOP_MS).toBe(SEQUENCE_MS + HOLD_MS + FADE_MS)
+  })
+})
+
+describe('frameAtElapsed', () => {
+  it('shows no moves at t=0', () => {
+    expect(frameAtElapsed(0).moveNumber).toBe(0)
+  })
+
+  it('reports "playing" and advances the move number as time passes', () => {
+    const early = frameAtElapsed(moveTimestampMs(5))
+    const later = frameAtElapsed(moveTimestampMs(50))
+    expect(early.phase).toBe('playing')
+    expect(later.moveNumber).toBeGreaterThan(early.moveNumber)
+  })
+
+  it('shows exactly move 78 right as its timestamp is crossed', () => {
+    const frame = frameAtElapsed(moveTimestampMs(78))
+    expect(frame.moveNumber).toBe(78)
+    expect(frame.elapsedSinceMove).toBe(0)
+  })
+
+  it('holds at the final move once the sequence completes', () => {
+    const frame = frameAtElapsed(SEQUENCE_MS + HOLD_MS / 2)
+    expect(frame.moveNumber).toBe(TOTAL_MOVES)
+    expect(frame.phase).toBe('holding')
+  })
+
+  it('fades after the hold, before the loop restarts', () => {
+    const frame = frameAtElapsed(SEQUENCE_MS + HOLD_MS + FADE_MS / 2)
+    expect(frame.moveNumber).toBe(TOTAL_MOVES)
+    expect(frame.phase).toBe('fading')
+  })
+
+  it('loops back to the start after LOOP_MS', () => {
+    const first = frameAtElapsed(moveTimestampMs(30))
+    const looped = frameAtElapsed(moveTimestampMs(30) + LOOP_MS)
+    expect(looped.moveNumber).toBe(first.moveNumber)
+    expect(looped.phase).toBe(first.phase)
+  })
+
+  it('reports elapsedSinceMove counting up from zero right after any move appears', () => {
+    const justAfter = frameAtElapsed(moveTimestampMs(50) + 10)
+    expect(justAfter.moveNumber).toBe(50)
+    expect(justAfter.elapsedSinceMove).toBeCloseTo(10, 5)
+    expect(justAfter.elapsedSinceMove).toBeLessThan(CAPTURE_FADE_MS)
+  })
+})

--- a/src/lib/hero/goTiming.ts
+++ b/src/lib/hero/goTiming.ts
@@ -1,0 +1,167 @@
+/**
+ * Pure timing curve for the hero Go board replay (issue #316).
+ *
+ * Maps elapsed wall-clock time to "what move should be on screen right
+ * now" with a deliberate rhythm: slow through the opening, accelerating
+ * through the middlegame, a full pause before move 78 (the move the game
+ * turns on), fast through the endgame, then a hold at the final position
+ * before fading out and looping.
+ *
+ * No DOM, no React, no timers -- this module only computes numbers. The
+ * component subscribes to a single `requestAnimationFrame` loop and calls
+ * `frameAtElapsed` on every tick; everything about *when* a move appears
+ * lives here, not scattered across `setTimeout` chains.
+ *
+ * These constants are a tuned starting point (see docs/spec-portfolio-
+ * rewrite.md), not a measured result -- `LOOP_MS` lands close to the
+ * spec's ~30s target but the true feel can only be judged in a browser.
+ */
+
+export const TOTAL_MOVES = 180
+export const MOVE_78 = 78
+
+/** Opening: the first 10 moves are placed slowly, one every 400ms. */
+const OPENING_END = 10
+const OPENING_DELAY_MS = 400
+
+/** Middlegame: a linear ramp from the opening pace down to a fast pace. */
+const MIDGAME_END = 60
+const MIDGAME_START_DELAY_MS = 380
+const MIDGAME_END_DELAY_MS = 95
+
+/** Fast run-up to move 78. */
+const FAST_MIDGAME_END = MOVE_78 - 1
+const FAST_MIDGAME_DELAY_MS = 85
+
+/** The deliberate pause before move 78 itself appears. */
+const PRE_78_PAUSE_MS = 1300
+
+/** Endgame: ramps from just after move 78 down to the fastest pace. */
+const ENDGAME_RAMP_END = 140
+const ENDGAME_START_DELAY_MS = 140
+const ENDGAME_END_DELAY_MS = 65
+
+/** The final, fastest stretch to move 180. */
+const FINAL_DELAY_MS = 50
+
+/** How long the finished position holds before the fade-out begins. */
+export const HOLD_MS = 2600
+
+/** How long the fade-out takes before the sequence loops. */
+export const FADE_MS = 700
+
+/**
+ * How long a captured stone's exit animation takes. Matches the CSS
+ * transition duration on a stone element (~550ms per the spec) so the
+ * frame model knows how long to keep reporting a captured stone as
+ * "leaving" rather than simply gone.
+ */
+export const CAPTURE_FADE_MS = 550
+
+function lerp(from: number, to: number, t: number): number {
+  return from + (to - from) * t
+}
+
+/**
+ * The delay (ms) between the previous move appearing and `moveNumber`
+ * appearing. `moveNumber` is 1-indexed (1..TOTAL_MOVES).
+ */
+export function moveDelayMs(moveNumber: number): number {
+  if (moveNumber === MOVE_78) return PRE_78_PAUSE_MS
+  if (moveNumber <= OPENING_END) return OPENING_DELAY_MS
+  if (moveNumber <= MIDGAME_END) {
+    const t = (moveNumber - OPENING_END) / (MIDGAME_END - OPENING_END)
+    return lerp(MIDGAME_START_DELAY_MS, MIDGAME_END_DELAY_MS, t)
+  }
+  if (moveNumber <= FAST_MIDGAME_END) return FAST_MIDGAME_DELAY_MS
+  if (moveNumber <= ENDGAME_RAMP_END) {
+    const t = (moveNumber - (MOVE_78 + 1)) / (ENDGAME_RAMP_END - (MOVE_78 + 1))
+    return lerp(ENDGAME_START_DELAY_MS, ENDGAME_END_DELAY_MS, Math.max(0, t))
+  }
+  return FINAL_DELAY_MS
+}
+
+/** Precomputed cumulative timestamp (ms) at which each move appears. */
+const MOVE_TIMESTAMPS: readonly number[] = (() => {
+  const timestamps: number[] = []
+  let cumulative = 0
+  for (let moveNumber = 1; moveNumber <= TOTAL_MOVES; moveNumber++) {
+    cumulative += moveDelayMs(moveNumber)
+    timestamps.push(cumulative)
+  }
+  return timestamps
+})()
+
+/** The elapsed time (ms) at which `moveNumber` appears, from a cold start. */
+export function moveTimestampMs(moveNumber: number): number {
+  const clamped = Math.max(1, Math.min(TOTAL_MOVES, moveNumber))
+  return MOVE_TIMESTAMPS[clamped - 1]
+}
+
+/** Total time (ms) to place all 180 moves, from a cold start. */
+export const SEQUENCE_MS = moveTimestampMs(TOTAL_MOVES)
+
+/** Total loop length (ms): the sequence, plus the hold, plus the fade. */
+export const LOOP_MS = SEQUENCE_MS + HOLD_MS + FADE_MS
+
+export type SequencePhase = 'playing' | 'holding' | 'fading'
+
+export interface TimingFrame {
+  /**
+   * The move currently on screen: 0..TOTAL_MOVES. 0 means the board is
+   * still empty -- the sequence has started but the first move's initial
+   * delay has not yet elapsed.
+   */
+  readonly moveNumber: number
+  readonly phase: SequencePhase
+  /** Time (ms) since `moveNumber` appeared -- drives the capture fade. */
+  readonly elapsedSinceMove: number
+  /** Elapsed time (ms), wrapped to a single loop -- drives the fade-out. */
+  readonly loopElapsed: number
+}
+
+/** Counts how many moves have appeared by time `t` (ms), 0..TOTAL_MOVES. */
+function moveNumberAtTime(t: number): number {
+  let moveNumber = 0
+  for (let n = 1; n <= TOTAL_MOVES; n++) {
+    if (MOVE_TIMESTAMPS[n - 1] > t) break
+    moveNumber = n
+  }
+  return moveNumber
+}
+
+/**
+ * The single entry point the component calls every animation frame: given
+ * total elapsed time since the sequence started (which may exceed one
+ * loop), returns what should be on screen right now.
+ */
+export function frameAtElapsed(elapsedMs: number): TimingFrame {
+  const wrapped = ((elapsedMs % LOOP_MS) + LOOP_MS) % LOOP_MS
+
+  if (wrapped < SEQUENCE_MS) {
+    const moveNumber = moveNumberAtTime(wrapped)
+    const previousTimestamp = moveNumber > 0 ? MOVE_TIMESTAMPS[moveNumber - 1] : 0
+    return {
+      moveNumber,
+      phase: 'playing',
+      elapsedSinceMove: wrapped - previousTimestamp,
+      loopElapsed: wrapped,
+    }
+  }
+
+  if (wrapped < SEQUENCE_MS + HOLD_MS) {
+    return {
+      moveNumber: TOTAL_MOVES,
+      phase: 'holding',
+      elapsedSinceMove: wrapped - SEQUENCE_MS,
+      loopElapsed: wrapped,
+    }
+  }
+
+  return {
+    moveNumber: TOTAL_MOVES,
+    phase: 'fading',
+    elapsedSinceMove: wrapped - SEQUENCE_MS - HOLD_MS,
+    loopElapsed: wrapped,
+  }
+}

--- a/src/lib/hero/typewriter.test.ts
+++ b/src/lib/hero/typewriter.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { isTypingDone, typedLength, typedText } from './typewriter'
+
+describe('typedLength', () => {
+  it('is 0 before any time has passed', () => {
+    expect(typedLength('hello', 0)).toBe(0)
+  })
+
+  it('grows monotonically with elapsed time', () => {
+    const text = 'a short tagline'
+    expect(typedLength(text, 100)).toBeLessThanOrEqual(typedLength(text, 500))
+  })
+
+  it('never exceeds the text length', () => {
+    expect(typedLength('hi', 100_000)).toBe(2)
+  })
+})
+
+describe('typedText', () => {
+  it('reveals a prefix of the string', () => {
+    const text = 'I build things that are fun.'
+    const partial = typedText(text, 45 * 5)
+    expect(text.startsWith(partial)).toBe(true)
+    expect(partial.length).toBe(5)
+  })
+
+  it('reveals the full string once enough time has passed', () => {
+    const text = 'I build things that are fun.'
+    expect(typedText(text, 100_000)).toBe(text)
+  })
+})
+
+describe('isTypingDone', () => {
+  it('is false partway through', () => {
+    expect(isTypingDone('hello world', 45)).toBe(false)
+  })
+
+  it('is true once the full text has appeared', () => {
+    expect(isTypingDone('hi', 1_000)).toBe(true)
+  })
+})

--- a/src/lib/hero/typewriter.ts
+++ b/src/lib/hero/typewriter.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure one-shot typewriter timing for the hero tagline (issue #316).
+ *
+ * Replaces the old site's rotating role typewriter: this types a single
+ * line once, then stops -- no deletion, no looping. Deliberately tiny and
+ * separated from `goTiming`/`goFrameModel` (which drive the board) so the
+ * tagline's timing can be reasoned about and tested on its own.
+ */
+
+export const DEFAULT_MS_PER_CHAR = 45
+
+/** How many characters of `text` should be visible after `elapsedMs`. */
+export function typedLength(text: string, elapsedMs: number, msPerChar = DEFAULT_MS_PER_CHAR): number {
+  if (elapsedMs <= 0) return 0
+  const chars = Math.floor(elapsedMs / msPerChar)
+  return Math.max(0, Math.min(text.length, chars))
+}
+
+/** The visible substring of `text` after `elapsedMs`. */
+export function typedText(text: string, elapsedMs: number, msPerChar = DEFAULT_MS_PER_CHAR): string {
+  return text.slice(0, typedLength(text, elapsedMs, msPerChar))
+}
+
+/** Whether the whole line has finished typing by `elapsedMs`. */
+export function isTypingDone(text: string, elapsedMs: number, msPerChar = DEFAULT_MS_PER_CHAR): boolean {
+  return typedLength(text, elapsedMs, msPerChar) >= text.length
+}

--- a/src/lib/hero/useReducedMotion.ts
+++ b/src/lib/hero/useReducedMotion.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+function readPreference(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(QUERY).matches
+}
+
+/**
+ * Whether the visitor has asked for reduced motion. Read live (not cached
+ * at module scope) and kept in sync if the OS-level setting changes while
+ * the page is open.
+ *
+ * This is the one thing the hero's board and tagline check before
+ * starting any timer at all -- per the spec, reduced motion is handled by
+ * not animating in the first place, not by zeroing CSS durations after
+ * the fact.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(readPreference)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const media = window.matchMedia(QUERY)
+    const onChange = () => setReduced(media.matches)
+    onChange()
+    media.addEventListener('change', onChange)
+    return () => media.removeEventListener('change', onChange)
+  }, [])
+
+  return reduced
+}

--- a/src/styles/hero.css
+++ b/src/styles/hero.css
@@ -1,0 +1,76 @@
+/*
+ * Hero animation keyframes (issue #316): stone mount/exit and the tagline
+ * cursor blink.
+ *
+ * All three are wrapped in `@media (prefers-reduced-motion: no-preference)`
+ * rather than the reference implementation's approach of zeroing every
+ * duration to near-0ms. That trick still *plays* the animation, just
+ * instantly (180 stones flashing onto the board at once) -- the opposite
+ * of what the preference asks for. Scoping the keyframe application itself
+ * to "no preference" means a reduced-motion visitor's stones and cursor
+ * simply render at their resting state (opacity 1, scale 1) with no
+ * animation ever applied, belt-and-braces alongside the board component
+ * not starting a timer under reduced motion in the first place.
+ */
+
+.hero-stone {
+  opacity: 1;
+  scale: 1;
+}
+
+.hero-stone-leaving {
+  opacity: 0;
+  scale: 0.55;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .hero-stone {
+    animation: hero-stone-in 550ms cubic-bezier(0.22, 0.9, 0.3, 1) both;
+  }
+
+  .hero-stone-leaving {
+    animation: hero-stone-out 550ms ease both;
+  }
+}
+
+@keyframes hero-stone-in {
+  from {
+    opacity: 0;
+    scale: 0.55;
+  }
+  to {
+    opacity: 1;
+    scale: 1;
+  }
+}
+
+@keyframes hero-stone-out {
+  from {
+    opacity: 1;
+    scale: 1;
+  }
+  to {
+    opacity: 0;
+    scale: 0.55;
+  }
+}
+
+.hero-cursor {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .hero-cursor {
+    animation: hero-cursor-blink 1.05s step-end infinite;
+  }
+}
+
+@keyframes hero-cursor-blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}

--- a/src/test/mockMatchMedia.ts
+++ b/src/test/mockMatchMedia.ts
@@ -1,0 +1,20 @@
+import { vi } from 'vitest'
+
+/**
+ * Installs a `window.matchMedia` stub that reports `reduced` for
+ * `(prefers-reduced-motion: reduce)` and `false` for anything else --
+ * enough for components that branch on `useReducedMotion()` without
+ * pulling in a full media-query engine.
+ */
+export function mockMatchMedia(reduced: boolean): void {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: reduced && query.includes('prefers-reduced-motion'),
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia
+}


### PR DESCRIPTION
## Summary

Refs #316

Replaces the hero placeholder with the real headline visual: the role, the name, and a one-shot typed tagline, beside a 19×19 board that replays all 180 real moves of AlphaGo vs. Lee Sedol Game 4. Board positions come from the existing pure Go engine (`src/lib/go/board.ts`) applied to the committed Game 4 move data, so captures resolve exactly as they were actually played -- nothing is appended without capture resolution.

### Architecture

Frame-to-model logic is extracted as pure, headlessly-tested modules (no DOM, no React, no timers):

- `src/lib/hero/goTiming.ts` -- `frameAtElapsed(elapsedMs)`: elapsed time → `{ moveNumber, phase, elapsedSinceMove, loopElapsed }`. Encodes the rhythm: slow opening (first 10 moves, 400ms), a linear ramp through the middlegame down to ~85-95ms, a full ~1.3s pause before move 78, a fast endgame ramp, a 2.6s hold at the final position, and a 700ms fade before looping. `LOOP_MS` (measured) is **30,132.5ms** -- within the spec's "about thirty seconds" target.
- `src/lib/hero/goFrameModel.ts` -- `frameForMove(moveNumber, elapsedSinceMoveMs)`: move number → the stones to render, each tagged `'stone' | 'move78' | 'leaving'`. Captured stones are marked `'leaving'` only within the 550ms capture-fade window (`CAPTURE_FADE_MS`, matching the CSS transition length so fast placement never looks like flickering) and then disappear entirely, matching the position that was actually played. Move 78's coordinate gets a persistent marker from move 78 onward -- including after that very stone is captured at move 91 (real, per the game record; not "fixed").
- `src/lib/hero/typewriter.ts` -- `typedText(text, elapsedMs)`: elapsed time → revealed tagline substring, for the one-shot tagline typer.

`GoBoardReplay` and `HeroTagline` each own their own `requestAnimationFrame` loop, scoped to themselves (not `Hero.tsx`), so a ~60fps tick re-renders only that leaf, not the whole section.

### Reduced motion

`useReducedMotion()` (`src/lib/hero/useReducedMotion.ts`) checks `prefers-reduced-motion` live via `matchMedia`. Under `reduce`, **no timer is started at all** in either component -- the board renders `staticFinalFrame()` (the real final position, move 78 marked) once, and the tagline renders in full immediately. The stone mount/exit keyframes and the tagline cursor blink (`src/styles/hero.css`) are themselves scoped inside `@media (prefers-reduced-motion: no-preference)`, rather than the reference's approach of zeroing every duration -- that trick still plays all 180 stones at once, just instantly, which is the opposite of the setting's intent. The cursor's resting state under reduced motion is steady, not flickering.

No `document.querySelector` or direct DOM mutation drives any of this -- state in, JSX out.

The chess replay sequence from the design reference is not ported.

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `npm run lint` -- clean
- [x] `npm run test` -- 92 tests passed (12 files), including new `goTiming.test.ts` (timing monotonicity, the move-78 pause, loop duration), `goFrameModel.test.ts` (captures marked as leaving, move 78 marker persisting past its own capture at move 91), `typewriter.test.ts`, and component-level tests asserting move number / player names render and that reduced motion starts no `requestAnimationFrame` timer
- [x] `npm run build` -- clean
- [ ] Human, in a browser: actual visual smoothness/rhythm of the sequence, whether ~30s *feels* right, viewport fit alongside the board, dark/light theme recolouring of stones

🤖 Generated with [Claude Code](https://claude.com/claude-code)