### PR TITLE
mochi: ignore LaTeX sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ dist-ssr
 .env
 ideas/
 HANDOFF.md
+public/resume.tex


### PR DESCRIPTION
LaTeX sources are local-only; built output stays tracked.