### PR TITLE
mochi: fix color tokens for Tailwind v4

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,26 +5,28 @@
 
 /*
  * Tailwind's theme keys are mapped onto the swappable custom properties
- * from ./styles/themes.css indirectly, via rgb(var(...) / <alpha-value>).
- * That indirection is what makes `data-theme` switches recolour utilities
- * live at runtime, rather than Tailwind compiling each utility to a literal
- * hex value that can never change.
+ * from ./styles/themes.css indirectly, via rgb(var(...)). That indirection
+ * is what makes `data-theme` switches recolour utilities live at runtime,
+ * rather than Tailwind compiling each utility to a literal hex value that
+ * can never change. Tailwind v4 applies opacity modifiers (e.g. `/92`)
+ * on top of the resolved color via color-mix(), so they keep working
+ * without the v3 `<alpha-value>` placeholder.
  */
 @theme inline {
-  --color-bg: rgb(var(--bg) / <alpha-value>);
-  --color-bg-glass: rgb(var(--bg-glass) / <alpha-value>);
-  --color-panel: rgb(var(--panel) / <alpha-value>);
-  --color-panel-2: rgb(var(--panel-2) / <alpha-value>);
-  --color-line: rgb(var(--line) / <alpha-value>);
-  --color-line-2: rgb(var(--line-2) / <alpha-value>);
-  --color-fg: rgb(var(--fg) / <alpha-value>);
-  --color-fg-2: rgb(var(--fg-2) / <alpha-value>);
-  --color-dim: rgb(var(--dim) / <alpha-value>);
-  --color-dim-2: rgb(var(--dim-2) / <alpha-value>);
-  --color-dim-3: rgb(var(--dim-3) / <alpha-value>);
-  --color-stone: rgb(var(--stone) / <alpha-value>);
-  --color-accent: rgb(var(--accent) / <alpha-value>);
-  --color-accent-2: rgb(var(--accent-2) / <alpha-value>);
+  --color-bg: rgb(var(--bg));
+  --color-bg-glass: rgb(var(--bg-glass));
+  --color-panel: rgb(var(--panel));
+  --color-panel-2: rgb(var(--panel-2));
+  --color-line: rgb(var(--line));
+  --color-line-2: rgb(var(--line-2));
+  --color-fg: rgb(var(--fg));
+  --color-fg-2: rgb(var(--fg-2));
+  --color-dim: rgb(var(--dim));
+  --color-dim-2: rgb(var(--dim-2));
+  --color-dim-3: rgb(var(--dim-3));
+  --color-stone: rgb(var(--stone));
+  --color-accent: rgb(var(--accent));
+  --color-accent-2: rgb(var(--accent-2));
 
   --font-display: 'Press Start 2P', system-ui, sans-serif;
   --font-mono: 'IBM Plex Mono', ui-monospace, monospace;


### PR DESCRIPTION
## Summary
- `src/index.css` defined 14 `--color-*` tokens in `@theme inline` using the Tailwind v3 `rgb(var(...) / <alpha-value>)` pattern. Tailwind v4 does not substitute `<alpha-value>`, so it shipped literally into compiled CSS (e.g. `.bg-stone{background-color:rgb(var(--stone) / <alpha-value>)}`), making every color utility resolve to transparent.
- Dropped `/ <alpha-value>` from all 14 tokens so each is `rgb(var(--x))`. Tailwind v4 applies opacity modifiers (e.g. `bg-bg-glass/92`, used by the header) automatically via `color-mix()` against the resolved value, so those keep working.
- Updated the explanatory comment above the block, which referenced the old v3 mechanism.
- No changes to `src/styles/themes.css` or any component.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 45/45 tests pass across 6 files
- [x] `npm run build`, then grepped the built CSS — no `<alpha-value>` anywhere; real declarations e.g. `.bg-accent{background-color:rgb(var(--accent))}`, `.bg-bg-glass\/92{background-color:color-mix(in oklab, rgb(var(--bg-glass)) 92%, transparent)}`
- [x] Runtime check in headless Chromium against `vite preview`: computed `backgroundColor` for elements using `bg-fg`/`bg-accent` is a real opaque color (`rgb(239, 233, 219)` / `rgb(84, 104, 255)`), and `bg-bg-glass/92` resolves to `oklab(... / 0.92)` with real alpha. Screenshot confirms correct dim/bright text hierarchy is now visible.

Note: `bg-stone`/`bg-accent`/`bg-bg-glass` aren't used by any component yet (Go board `#316` and header/nav `#312` are separate, out-of-scope tickets per `App.tsx`'s own comment), so these utility classes don't normally exist in the compiled CSS. Verified by temporarily wiring them into a scratch element, confirming the fix, then reverting before committing — the committed diff touches only `src/index.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)