### PR TITLE
Add closing statement and direct links to the contact section

### DIFF
--- a/src/components/sections/Contact.test.tsx
+++ b/src/components/sections/Contact.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { Contact } from './Contact'
+import { CONTACT_LINKS, CONTACT_STATEMENT } from '@/data/contact'
+import { sections } from '@/data/sections'
+
+/**
+ * Behaviour-only coverage for issue #321: the section landmark, the
+ * closing statement, and each link's accessible name, href, and
+ * new-tab/external behaviour. No assertions on class names or layout --
+ * per repo test philosophy, public interfaces only.
+ */
+describe('Contact', () => {
+  it('renders the contact section with its documented id and label', () => {
+    render(<Contact />)
+
+    const region = screen.getByRole('region', { name: sections[5].label })
+    expect(region).toHaveAttribute('id', sections[5].id)
+  })
+
+  it('states what work is being sought', () => {
+    render(<Contact />)
+
+    expect(screen.getByText(CONTACT_STATEMENT)).toBeInTheDocument()
+  })
+
+  it('links to email, GitHub, LinkedIn, and the résumé with correct hrefs', () => {
+    render(<Contact />)
+
+    for (const link of CONTACT_LINKS) {
+      const anchor = screen.getByRole('link', { name: new RegExp(link.label, 'i') })
+      expect(anchor).toHaveAttribute('href', link.href)
+    }
+  })
+
+  it('opens external destinations in a new tab, and keeps email in-page', () => {
+    render(<Contact />)
+
+    const email = screen.getByRole('link', { name: /email/i })
+    expect(email).not.toHaveAttribute('target')
+
+    for (const link of CONTACT_LINKS.filter((l) => l.external)) {
+      const anchor = screen.getByRole('link', { name: new RegExp(link.label, 'i') })
+      expect(anchor).toHaveAttribute('target', '_blank')
+      expect(anchor).toHaveAttribute('rel', 'noreferrer')
+    }
+  })
+
+  it('opens the résumé link at the tracked PDF served from public/', () => {
+    render(<Contact />)
+
+    const resume = screen.getByRole('link', { name: /résumé/i })
+    expect(resume).toHaveAttribute('href', '/resume.pdf')
+  })
+})

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,14 +1,48 @@
 import { Section } from '@/components/layout/Section'
-import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
+import { CONTACT_LINKS, CONTACT_STATEMENT } from '@/data/contact'
 import { sections } from '@/data/sections'
 
 const meta = sections[5]
 
-/** Contact placeholder. Real content lands in #321. */
+/**
+ * Closing section (issue #321): a one-line statement of what work is being
+ * sought, then direct, labelled links to email, GitHub, LinkedIn, and the
+ * résumé. All copy and hrefs live in `src/data/contact.ts` -- this
+ * component is pure presentation over that module.
+ *
+ * This is the last section and the page's densest run of links, so tab
+ * order (document order, top to bottom) and the global `:focus-visible`
+ * ring (`src/index.css`) matter more here than anywhere else -- no link
+ * suppresses or replaces that ring.
+ */
 export function Contact() {
   return (
     <Section id={meta.id} label={meta.label}>
-      <SectionPlaceholder {...meta} />
+      <div className="flex h-full max-w-3xl flex-col justify-center gap-[var(--space-lg)]">
+        <div className="flex flex-col gap-[var(--space-sm)]">
+          <p className="font-mono text-fluid-xs tracking-[0.2em] text-dim">{meta.eyebrow}</p>
+          <h2 className="font-display text-fluid-2xl leading-tight text-fg">{meta.title}</h2>
+          <p className="max-w-[52ch] text-fluid-base text-fg-2">{CONTACT_STATEMENT}</p>
+        </div>
+
+        <ul className="flex flex-col border-t border-line">
+          {CONTACT_LINKS.map((link) => (
+            <li key={link.id} className="border-b border-line">
+              <a
+                href={link.href}
+                target={link.external ? '_blank' : undefined}
+                rel={link.external ? 'noreferrer' : undefined}
+                className="flex items-baseline justify-between gap-[var(--space-sm)] py-[var(--space-xs)] text-fluid-sm text-fg-2 transition-colors hover:text-accent-2"
+              >
+                <span className="font-display text-fg">{link.label}</span>
+                <span className="text-2xs tracking-[0.16em] text-dim">
+                  {link.detail} <span aria-hidden="true">↗</span>
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
     </Section>
   )
 }

--- a/src/data/contact.ts
+++ b/src/data/contact.ts
@@ -1,0 +1,69 @@
+/**
+ * Contact content: closing statement and the labelled links, issue #321.
+ * Copy and link targets live here; `Contact.tsx` is pure presentation over
+ * this module, matching the pattern established by `src/data/leviathan.ts`.
+ *
+ * The email address, GitHub destination, and LinkedIn destination are all
+ * sourced from `public/resume.pdf`. The PDF's visible header text names
+ * "Portfolio · LinkedIn · GitHub" without printing their URLs, but the
+ * header text is itself hyperlinked -- the underlying link targets were
+ * read from the PDF's link annotations (via `pdftohtml`), not guessed:
+ *
+ *   - Email:    famohammed@shockers.wichita.edu (résumé header, printed)
+ *   - GitHub:   https://github.com/Nemesis-12 (résumé header hyperlink)
+ *   - LinkedIn: https://linkedin.com/in/fa-mohammed/ (résumé header hyperlink)
+ *
+ * The résumé link below points at `/resume.pdf`, the copy of this same PDF
+ * tracked at `public/resume.pdf` and served from the site root -- the one
+ * document that is the source of truth for every other fact on the page,
+ * so it can never disagree with itself.
+ *
+ * `CONTACT_STATEMENT` is copy, not a résumé fact. It stays consistent with
+ * `HERO_ROLE` in `src/data/hero.ts` ("ASPIRING ML + SYSTEMS + SOFTWARE
+ * ENGINEER") rather than narrowing to ML alone.
+ */
+
+export interface ContactLink {
+  readonly id: string
+  /** What the link actually is, e.g. "Email" -- the accessible name leads with this. */
+  readonly label: string
+  /** Supporting detail shown alongside the label, e.g. the address or a short verb phrase. */
+  readonly detail: string
+  readonly href: string
+  /** Opens in a new tab (external destinations); the résumé PDF and mailto stay same-behaviour as the rest. */
+  readonly external: boolean
+}
+
+export const CONTACT_STATEMENT =
+  'Looking for ML, systems, or software engineering work -- model internals, infrastructure, or anywhere the constraint is one GPU and a deadline.'
+
+export const CONTACT_LINKS: readonly ContactLink[] = [
+  {
+    id: 'email',
+    label: 'Email',
+    detail: 'famohammed@shockers.wichita.edu',
+    href: 'mailto:famohammed@shockers.wichita.edu',
+    external: false,
+  },
+  {
+    id: 'github',
+    label: 'GitHub',
+    detail: 'read the code',
+    href: 'https://github.com/Nemesis-12',
+    external: true,
+  },
+  {
+    id: 'linkedin',
+    label: 'LinkedIn',
+    detail: 'the professional profile',
+    href: 'https://linkedin.com/in/fa-mohammed/',
+    external: true,
+  },
+  {
+    id: 'resume',
+    label: 'Résumé',
+    detail: 'the full write-up, as a PDF',
+    href: '/resume.pdf',
+    external: true,
+  },
+]

--- a/src/data/sections.ts
+++ b/src/data/sections.ts
@@ -68,6 +68,6 @@ export const sections: SectionMeta[] = [
     label: 'Contact',
     eyebrow: '04 · CONTACT',
     title: 'Get in touch',
-    blurb: 'Placeholder contact copy -- full content lands in #321.',
+    blurb: 'What work is being sought, and direct links to reach out.',
   },
 ]


### PR DESCRIPTION
## Summary
- Replaces the `Contact.tsx` placeholder with real content: a closing statement of what work is being sought, and labelled links to email, GitHub, LinkedIn, and the résumé.
- New `src/data/contact.ts` data module holds all copy and link targets; the component stays pure presentation, matching the `leviathan.ts` pattern.
- Email/GitHub/LinkedIn destinations come from `public/resume.pdf`'s link annotations (the PDF text only prints the email; GitHub/LinkedIn are hyperlinked on the header text, extracted via `pdftohtml`, not guessed).
- The résumé link points at `/resume.pdf`, confirmed to resolve (200) at runtime rather than 404.
- Replaced the placeholder `blurb` for the `contact` entry in `src/data/sections.ts`.

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 163/163 passing (added `Contact.test.tsx` asserting the section landmark, the closing statement, and each link's accessible name/href/target behaviour)
- [x] `npm run build` — passes
- [x] Runtime check via Playwright/Chromium: screenshotted `#contact` at 1440x900 and 390x844, tabbed through all four links confirming visible focus rings in document order, and fetched `/resume.pdf` confirming HTTP 200

Refs #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the placeholder contact section with a complete contact statement and direct links.
  * Added email, GitHub, LinkedIn, and résumé PDF links.
  * External links open in a new tab with appropriate security attributes.
  * Added visible focus styling for improved keyboard navigation.

* **Tests**
  * Added coverage for contact content, link destinations, accessibility attributes, and résumé behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->