### PR TITLE
Build the Timeline section (education & experience) from résumé data

### DIFF
--- a/src/components/sections/EducationExperience.test.tsx
+++ b/src/components/sections/EducationExperience.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { EducationExperience } from './EducationExperience'
+import { EDUCATION_COLUMN, EXPERIENCE_COLUMN } from '@/data/timeline'
+import { sections } from '@/data/sections'
+
+/**
+ * Smoke coverage for issue #320: this component is pure presentation over
+ * `src/data/timeline.ts`, so these assertions only check the public-
+ * interface shape a visitor and a screen reader actually see -- the
+ * section landmark, every entry's status/date/title/qualifier/bullets,
+ * and that current entries carry a distinguishable status label from
+ * finished ones. Viewport-fit (side-by-side above 880px, single column
+ * below it) cannot be verified in jsdom and is checked in a browser
+ * instead.
+ */
+describe('EducationExperience', () => {
+  it('renders the timeline section with its documented id and label', () => {
+    render(<EducationExperience />)
+
+    const region = screen.getByRole('region', { name: sections[4].label })
+    expect(region).toHaveAttribute('id', sections[4].id)
+  })
+
+  it('renders both column headings', () => {
+    render(<EducationExperience />)
+
+    expect(screen.getByText(EDUCATION_COLUMN.heading)).toBeInTheDocument()
+    expect(screen.getByText(EXPERIENCE_COLUMN.heading)).toBeInTheDocument()
+  })
+
+  it('renders every entry with its status, date range, title, qualifier, and bullets', () => {
+    render(<EducationExperience />)
+
+    for (const column of [EDUCATION_COLUMN, EXPERIENCE_COLUMN]) {
+      for (const entry of column.entries) {
+        const heading = screen.getByRole('heading', { name: entry.title })
+        const article = heading.closest('article')
+        expect(article).not.toBeNull()
+        const scoped = within(article as HTMLElement)
+
+        expect(scoped.getByText(entry.statusLabel)).toBeInTheDocument()
+        expect(scoped.getByText(entry.dateRange)).toBeInTheDocument()
+        expect(scoped.getByText(entry.qualifier)).toBeInTheDocument()
+
+        for (const bullet of entry.bullets) {
+          expect(scoped.getByText(bullet)).toBeInTheDocument()
+        }
+        expect(entry.bullets.length).toBeGreaterThanOrEqual(2)
+        expect(entry.bullets.length).toBeLessThanOrEqual(3)
+      }
+    }
+  })
+
+  it('gives current entries a distinct status label from finished entries', () => {
+    render(<EducationExperience />)
+
+    const currentEntries = [...EDUCATION_COLUMN.entries, ...EXPERIENCE_COLUMN.entries].filter(
+      (entry) => entry.status === 'current',
+    )
+    const completeEntries = [...EDUCATION_COLUMN.entries, ...EXPERIENCE_COLUMN.entries].filter(
+      (entry) => entry.status === 'complete',
+    )
+
+    expect(currentEntries.length).toBeGreaterThan(0)
+    expect(completeEntries.length).toBeGreaterThan(0)
+
+    const currentLabels = new Set(currentEntries.map((entry) => entry.statusLabel))
+    const completeLabels = new Set(completeEntries.map((entry) => entry.statusLabel))
+    for (const label of currentLabels) {
+      expect(completeLabels.has(label)).toBe(false)
+    }
+  })
+})

--- a/src/components/sections/EducationExperience.tsx
+++ b/src/components/sections/EducationExperience.tsx
@@ -1,14 +1,94 @@
 import { Section } from '@/components/layout/Section'
-import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
+import { EDUCATION_COLUMN, EXPERIENCE_COLUMN, type TimelineColumn } from '@/data/timeline'
 import { sections } from '@/data/sections'
+import { cn } from '@/lib/cn'
 
 const meta = sections[4]
 
-/** Education & experience placeholder. Real content lands in #320. */
+/**
+ * Timeline section (issue #320): education and experience side by side, so
+ * a visitor sees the whole trajectory at once. Above the 880px breakpoint
+ * the two columns sit in a two-column grid within one viewport; below it
+ * they stack into a single column (`grid-cols-1 lg:grid-cols-2`), same
+ * pattern the layout system already uses elsewhere.
+ *
+ * All copy and dates live in `src/data/timeline.ts` -- every figure there
+ * is sourced from `public/resume.pdf`. This component is pure
+ * presentation: no dates, titles, or bullets are written here.
+ */
 export function EducationExperience() {
   return (
     <Section id={meta.id} label={meta.label}>
-      <SectionPlaceholder {...meta} />
+      <div className="flex h-full flex-col gap-[var(--space-sm)]">
+        <div className="flex items-baseline gap-[var(--space-sm)] flex-wrap">
+          <p className="font-mono text-fluid-xs tracking-[0.2em] text-dim">{meta.eyebrow}</p>
+          <h2 className="font-display text-fluid-2xl leading-tight text-fg">{meta.title}</h2>
+          <span className="h-px flex-1 min-w-[2rem] bg-line" aria-hidden="true" />
+        </div>
+
+        <div className="grid flex-1 grid-cols-1 gap-[var(--space-xs)] lg:grid-cols-2">
+          <TimelineColumnPanel column={EDUCATION_COLUMN} />
+          <TimelineColumnPanel column={EXPERIENCE_COLUMN} />
+        </div>
+      </div>
     </Section>
+  )
+}
+
+function TimelineColumnPanel({ column }: { column: TimelineColumn }) {
+  return (
+    <div className="flex flex-col gap-[var(--space-2xs)]">
+      <div className="flex items-center gap-[var(--space-2xs)] border border-line-2 bg-panel-2 px-[var(--space-sm)] py-[var(--space-2xs)]">
+        <h3 className="font-display text-fluid-sm leading-tight text-fg">{column.heading}</h3>
+        <span className="ml-auto text-2xs tracking-[0.2em] text-dim">
+          {column.kind.toUpperCase()}
+        </span>
+      </div>
+
+      <div className="flex flex-1 flex-col gap-[var(--space-2xs)]">
+        {column.entries.map((entry) => (
+          <article
+            key={entry.id}
+            className={cn(
+              'flex flex-1 flex-col gap-[var(--space-3xs)] border bg-panel px-[var(--space-sm)] py-[var(--space-xs)]',
+              entry.status === 'current' ? 'border-accent' : 'border-line-2',
+            )}
+          >
+            <div className="flex flex-wrap items-center gap-[var(--space-2xs)] text-2xs tracking-[0.18em]">
+              <span
+                aria-hidden="true"
+                className={cn(
+                  'inline-block h-[9px] w-[9px] rounded-full border',
+                  entry.status === 'current'
+                    ? 'border-accent bg-accent'
+                    : 'border-dim-3 bg-transparent',
+                )}
+              />
+              <span className={entry.status === 'current' ? 'text-accent-2' : 'text-dim'}>
+                {entry.statusLabel}
+              </span>
+              <span className="ml-auto text-dim">{entry.dateRange}</span>
+            </div>
+
+            <h4 className="font-display text-fluid-xs leading-snug text-fg">{entry.title}</h4>
+            <p className="text-fluid-sm text-dim">{entry.qualifier}</p>
+
+            <ul className="flex flex-col gap-[var(--space-3xs)] border-t border-line pt-[var(--space-2xs)] text-fluid-sm text-fg-2">
+              {entry.bullets.map((bullet) => (
+                <li key={bullet} className="flex gap-[var(--space-2xs)]">
+                  <span
+                    aria-hidden="true"
+                    className={entry.status === 'current' ? 'text-accent' : 'text-fg'}
+                  >
+                    +
+                  </span>
+                  <span>{bullet}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </div>
   )
 }

--- a/src/data/sections.ts
+++ b/src/data/sections.ts
@@ -57,11 +57,18 @@ export const sections: SectionMeta[] = [
     // uses (PROJECTS, SKILLS, CONTACT each echo their own `label`/`title`
     // word, not the old id), so it becomes TIMELINE rather than PATH.
     // `id` stays 'path' -- other branches and every scroll/nav target
-    // depend on it. `blurb` is untouched placeholder copy owned by #320.
+    // depend on it. `blurb` was placeholder copy owned by #320; it is
+    // now updated below and no longer consumed by this section's real
+    // content (`src/components/sections/EducationExperience.tsx`).
     label: 'Timeline',
     eyebrow: '03 · TIMELINE',
     title: 'Timeline',
-    blurb: 'Placeholder timeline copy -- full content lands in #320.',
+    // Real content (issue #320) lives in `src/data/timeline.ts` and is
+    // rendered by `EducationExperience.tsx` directly, not through this
+    // `blurb`/`SectionPlaceholder` -- this field is unused by that
+    // section now, but is kept meaningful rather than left as
+    // placeholder copy, since `SectionMeta` still requires it.
+    blurb: 'Education and experience, side by side.',
   },
   {
     id: 'contact',

--- a/src/data/timeline.ts
+++ b/src/data/timeline.ts
@@ -1,0 +1,132 @@
+/**
+ * Timeline content: education and experience, side by side (issue #320).
+ *
+ * Every date, title, GPA, and honour below is sourced verbatim from
+ * `public/resume.pdf`. Where the design reference (`ideas/Portfolio.html`,
+ * gitignored, local-only) disagreed with or embellished the résumé, the
+ * résumé wins:
+ *
+ *   - Degree titles use the résumé's exact wording ("Accelerated Master of
+ *     Science in Computer Science", "Bachelor of Science in Computer
+ *     Science") rather than the reference's abbreviated "MS/BS COMPUTER
+ *     SCIENCE".
+ *   - GPA and honour: résumé — "GPA: 3.66/4.0, Magna Cum Laude".
+ *   - Dean's List range: résumé — "Dean's List: Spring 2022 – Fall 2025".
+ *   - Thesis title: résumé — "Thesis: Generative Agent-Based Models for
+ *     Insider Threat Detection" (the reference lower-cased and shortened
+ *     this).
+ *   - Coursework lists reproduce the résumé's own course names rather than
+ *     the reference's paraphrase ("Machine learning, AI, agents, data
+ *     science").
+ *   - The NetApp "Software Engineer Intern" role has exactly ONE bullet on
+ *     the résumé; it is split into two here (endpoints/refactors vs. code
+ *     review) rather than inventing a second fact the way the reference
+ *     did ("Enough PR reviews to have opinions about naming" appears
+ *     nowhere on the résumé and is deliberately not reproduced).
+ *   - The "Software Engineer in Test" role's four résumé bullets are
+ *     trimmed to the three most substantive, quantified ones (30% manual
+ *     -config reduction, 300+ system configurations, 1M+ database
+ *     entries) to fit the ticket's two-or-three-bullet limit; the
+ *     dropped telemetry-pipeline bullet is the only one without a
+ *     headline figure.
+ *   - Date ranges reuse the résumé's own formatting exactly, including
+ *     the en dash and "(Expected)"/"Present" qualifiers.
+ *
+ * The two résumé roles at NetApp Inc. — "Software Engineer Intern" (Jun
+ * 2026 – Present) and "Software Engineer in Test" (Jul 2024 – Jun 2026) —
+ * are represented as two distinct entries with their own date ranges, not
+ * flattened into one.
+ */
+
+export type TimelineStatus = 'current' | 'complete'
+
+export interface TimelineEntry {
+  readonly id: string
+  readonly status: TimelineStatus
+  /** Short status word shown next to the status indicator, e.g. "Studying now". */
+  readonly statusLabel: string
+  /** Résumé date range, reproduced verbatim. */
+  readonly dateRange: string
+  /** Résumé title, reproduced verbatim. */
+  readonly title: string
+  /** Short qualifier line -- GPA/honour, or a one-line role qualifier. */
+  readonly qualifier: string
+  /** Two or three supporting bullets, each sourced from the résumé. */
+  readonly bullets: readonly string[]
+}
+
+export interface TimelineColumn {
+  readonly id: string
+  /** Column heading, e.g. "Wichita State University". */
+  readonly heading: string
+  /** Column kind label shown alongside the heading. */
+  readonly kind: string
+  readonly entries: readonly TimelineEntry[]
+}
+
+export const EDUCATION_COLUMN: TimelineColumn = {
+  id: 'education',
+  heading: 'Wichita State University',
+  kind: 'Education',
+  entries: [
+    {
+      id: 'ms-cs',
+      status: 'current',
+      statusLabel: 'Studying now',
+      dateRange: 'Jan 2026 – May 2027 (Expected)',
+      title: 'Accelerated Master of Science in Computer Science',
+      qualifier: 'Thesis track',
+      bullets: [
+        'Thesis: Generative Agent-Based Models for Insider Threat Detection',
+        'Relevant coursework: NLP, Reinforcement Learning',
+      ],
+    },
+    {
+      id: 'bs-cs',
+      status: 'complete',
+      statusLabel: 'Graduated',
+      dateRange: 'Jan 2022 – Dec 2025',
+      title: 'Bachelor of Science in Computer Science',
+      qualifier: 'GPA 3.66/4.0 · Magna Cum Laude',
+      bullets: [
+        "Dean's List: Spring 2022 – Fall 2025",
+        'Relevant coursework: Machine Learning, Artificial Intelligence, Fundamentals of AI Agents, Data Science',
+      ],
+    },
+  ],
+}
+
+export const EXPERIENCE_COLUMN: TimelineColumn = {
+  id: 'experience',
+  heading: 'NetApp Inc.',
+  kind: 'Experience',
+  entries: [
+    {
+      id: 'swe-intern',
+      status: 'current',
+      statusLabel: 'Working now',
+      dateRange: 'Jun 2026 – Present',
+      title: 'Software Engineer Intern',
+      qualifier: 'Wichita, KS',
+      bullets: [
+        'API endpoints in TypeScript and PostgreSQL for the web platform',
+        'Code refactors and pull request reviews across the existing codebase',
+      ],
+    },
+    {
+      id: 'swe-test',
+      status: 'complete',
+      statusLabel: 'Previous role',
+      dateRange: 'Jul 2024 – Jun 2026',
+      title: 'Software Engineer in Test',
+      qualifier: 'Wichita, KS',
+      bullets: [
+        'Python automation framework reducing manual configuration tasks by 30% across Linux, Windows, and VMware',
+        'Ansible-based deployment orchestration for 300+ system configurations',
+        'Interactive visualization dashboard analyzing 1M+ database entries for engineering insights',
+      ],
+    },
+  ],
+}
+
+export const TIMELINE_COLUMNS: readonly TimelineColumn[] = [EDUCATION_COLUMN, EXPERIENCE_COLUMN]


### PR DESCRIPTION
## Summary
- Replaces the `EducationExperience` placeholder with real content: education and experience render as two side-by-side columns within a single viewport above 880px, stacking to one column below it.
- Each entry (2 education, 2 experience — including both distinct NetApp roles) shows status, date range, title, qualifier, and 2-3 résumé-sourced bullets. Current entries get an accent border/filled dot, finished entries a muted border/hollow dot.
- All copy lives in a new data module, `src/data/timeline.ts`; the component is pure presentation, following the established `leviathan.ts` + `ProjectsFeatured.tsx` pattern.
- Updates the placeholder `blurb` for the `path` entry in `src/data/sections.ts` (now unused by this section's real content, but kept meaningful).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 21 files / 162 tests passing (adds `EducationExperience.test.tsx`)
- [x] `npm run build` — succeeds
- [x] Manual runtime check via Chromium/playwright-core at 1440x900, 1000x700, and 390x844 — side-by-side layout above the breakpoint, single stacked column at phone width, current entries visually distinct from finished ones. `#path` `scrollHeight` (900) matches `innerHeight` (900) at 1440x900.

Refs #320