### PR TITLE
mochi: slow the board replay and drop the stale move-78 marker

### DIFF
--- a/src/lib/hero/goFrameModel.test.ts
+++ b/src/lib/hero/goFrameModel.test.ts
@@ -31,9 +31,27 @@ describe('frameForMove', () => {
     expect(frameForMove(77).move78Marker).toBeNull()
   })
 
-  it('marks move78Marker at the move-78 coordinate from move 78 onward', () => {
+  it('marks move78Marker at the move-78 coordinate while that stone is on the board', () => {
     expect(frameForMove(78).move78Marker).toEqual(MOVE_78_POSITION)
-    expect(frameForMove(180).move78Marker).toEqual(MOVE_78_POSITION)
+    expect(frameForMove(90).move78Marker).toEqual(MOVE_78_POSITION)
+  })
+
+  it('clears move78Marker once the move-78 stone is captured (move 91) and never brings it back', () => {
+    expect(frameForMove(91).move78Marker).toBeNull()
+    expect(frameForMove(180).move78Marker).toBeNull()
+  })
+
+  it('clears move78Marker even during the move-91 capture stone\'s own fade-out window', () => {
+    // The ring is tied to stone identity (isCurrentMove78Stone), not to the
+    // capture fade -- it disappears the instant the capturing move lands,
+    // not when the 550ms fade animation finishes.
+    const frame = frameForMove(91, moveTimestampMs(91) + 100)
+    expect(frame.move78Marker).toBeNull()
+  })
+
+  it('has no move78Marker well after move 91, past the fade window entirely', () => {
+    const frame = frameForMove(91, moveTimestampMs(91) + 10_000)
+    expect(frame.move78Marker).toBeNull()
   })
 
   it('renders the move-78 stone with the move78 variant while it is on the board', () => {
@@ -78,9 +96,18 @@ describe('frameForMove', () => {
   })
 
   it('does not report "leaving" stones once the capture-fade window has passed', () => {
+    // Scoped to this move's own captured positions/key, not "no leaving
+    // stone anywhere on the board" -- some other, unrelated capture may
+    // legitimately be mid-fade at this arbitrary future timestamp (e.g.
+    // the real move-176 group capture), which is correct behaviour, not a
+    // regression of this move's own fade having ended.
     const captureMove = GAME4_BOARD_STATES.findIndex((state) => state.captured.length > 0) + 1
+    const captured = GAME4_BOARD_STATES[captureMove - 1].captured
     const afterFade = frameForMove(captureMove, moveTimestampMs(captureMove) + 10_000)
-    expect(afterFade.stones.some((s) => s.variant === 'leaving')).toBe(false)
+    for (const position of captured) {
+      const expiredKey = `leaving-${position.row}-${position.col}-${captureMove}`
+      expect(afterFade.stones.some((s) => s.key === expiredKey)).toBe(false)
+    }
   })
 
   it('clamps to the final position for move numbers beyond 180', () => {
@@ -197,10 +224,10 @@ describe('frameForMove', () => {
 })
 
 describe('staticFinalFrame', () => {
-  it('shows the final position with move 78 marked and nothing mid-animation', () => {
+  it('shows the final position with no move78Marker (the stone was captured at move 91) and nothing mid-animation', () => {
     const frame = staticFinalFrame()
     expect(frame.moveNumber).toBe(TOTAL_MOVES)
-    expect(frame.move78Marker).toEqual(MOVE_78_POSITION)
+    expect(frame.move78Marker).toBeNull()
     expect(frame.stones.some((s) => s.variant === 'leaving')).toBe(false)
   })
 

--- a/src/lib/hero/goFrameModel.ts
+++ b/src/lib/hero/goFrameModel.ts
@@ -75,9 +75,12 @@ export interface BoardFrame {
   readonly moveNumber: number
   readonly stones: readonly StoneView[]
   /**
-   * Where move 78 was played, once it has happened -- present even after
-   * that stone is captured (move 91, in the real game), so the point that
-   * decided the game stays marked. `null` before move 78.
+   * Where move 78 was played, but only while that specific stone is still
+   * on the board. `null` before move 78, and `null` again once the stone
+   * is captured (move 91, in the real game) -- the marker tracks the
+   * stone's identity via `isCurrentMove78Stone`, not the coordinate, so it
+   * disappears the instant the capturing move is applied rather than
+   * lingering at a now-empty (or differently-occupied) point.
    */
   readonly move78Marker: Position | null
 }
@@ -197,16 +200,22 @@ export function frameForMove(
     })
   }
 
+  const move78StoneStillOnBoard =
+    board[MOVE_78_POSITION.row][MOVE_78_POSITION.col] !== null &&
+    isCurrentMove78Stone(clamped, MOVE_78_POSITION.row, MOVE_78_POSITION.col)
+
   return {
     moveNumber: clamped,
     stones,
-    move78Marker: clamped >= MOVE_78 ? MOVE_78_POSITION : null,
+    move78Marker: move78StoneStillOnBoard ? MOVE_78_POSITION : null,
   }
 }
 
 /**
  * The final position, drawn with no animation in progress -- used for the
- * reduced-motion static board (move 78 marked, nothing mid-capture-fade).
+ * reduced-motion static board. Move 78's stone was captured at move 91, so
+ * by move 180 both its `move78` emphasis and the `move78Marker` ring are
+ * correctly absent here; nothing is mid-capture-fade either.
  */
 export function staticFinalFrame(): BoardFrame {
   return frameForMove(TOTAL_MOVES)

--- a/src/lib/hero/goTiming.test.ts
+++ b/src/lib/hero/goTiming.test.ts
@@ -27,7 +27,7 @@ describe('moveTimestampMs', () => {
 describe('moveDelayMs', () => {
   it('is slow in the opening (first 10 moves)', () => {
     for (let n = 2; n <= 10; n++) {
-      expect(moveDelayMs(n)).toBeGreaterThanOrEqual(390)
+      expect(moveDelayMs(n)).toBeGreaterThanOrEqual(390 * 1.5)
     }
   })
 
@@ -37,7 +37,7 @@ describe('moveDelayMs', () => {
   })
 
   it('is fast immediately before move 78', () => {
-    expect(moveDelayMs(MOVE_78 - 1)).toBeLessThan(150)
+    expect(moveDelayMs(MOVE_78 - 1)).toBeLessThan(150 * 1.5)
   })
 
   it('gives move 78 the single longest delay of the whole game -- the deliberate pause', () => {
@@ -59,9 +59,9 @@ describe('moveDelayMs', () => {
 })
 
 describe('LOOP_MS', () => {
-  it('lands close to the ~30s target from the spec', () => {
-    expect(LOOP_MS).toBeGreaterThan(25_000)
-    expect(LOOP_MS).toBeLessThan(35_000)
+  it('lands close to ~43s -- 1.5x the spec\'s original ~30s target, after slowing the pace', () => {
+    expect(LOOP_MS).toBeGreaterThan(40_000)
+    expect(LOOP_MS).toBeLessThan(46_000)
   })
 
   it('is the sequence plus the hold plus the fade', () => {
@@ -84,7 +84,9 @@ describe('frameAtElapsed', () => {
   it('shows exactly move 78 right as its timestamp is crossed', () => {
     const frame = frameAtElapsed(moveTimestampMs(78))
     expect(frame.moveNumber).toBe(78)
-    expect(frame.elapsedSinceMove).toBe(0)
+    // Sub-picosecond float noise from the 1.5x pace multiplier's
+    // fractional-ms cumulative sums; not a real elapsed time.
+    expect(frame.elapsedSinceMove).toBeCloseTo(0, 5)
   })
 
   it('holds at the final move once the sequence completes', () => {

--- a/src/lib/hero/goTiming.ts
+++ b/src/lib/hero/goTiming.ts
@@ -12,37 +12,51 @@
  * `frameAtElapsed` on every tick; everything about *when* a move appears
  * lives here, not scattered across `setTimeout` chains.
  *
- * These constants are a tuned starting point (see docs/spec-portfolio-
- * rewrite.md), not a measured result -- `LOOP_MS` lands close to the
- * spec's ~30s target but the true feel can only be judged in a browser.
+ * These constants were originally tuned to a ~30s spec target (see
+ * docs/spec-portfolio-rewrite.md), then deliberately slowed to 1.5x that
+ * pace (`PACE_MULTIPLIER`) after watching the original timing run in a
+ * browser -- the ~30s pace read as too rushed, especially through the
+ * middlegame and endgame ramps. `LOOP_MS` now lands around ~43s.
  */
 
 export const TOTAL_MOVES = 180
 export const MOVE_78 = 78
 
-/** Opening: the first 10 moves are placed slowly, one every 400ms. */
+/**
+ * Uniform multiplier applied to every per-move delay constant below (but
+ * NOT to `HOLD_MS`, `FADE_MS`, or `CAPTURE_FADE_MS` -- the hold and fade
+ * are deliberate fixed pauses independent of replay pace, and
+ * `CAPTURE_FADE_MS` is pinned to the 550ms CSS transition duration in
+ * src/styles/hero.css and must keep matching it exactly). Bumping this one
+ * number re-tunes the whole replay's pace; the six ms constants below are
+ * written at their original (pre-1.5x) values with this multiplier applied
+ * at use, so a future re-tune stays a single-number change.
+ */
+const PACE_MULTIPLIER = 1.5
+
+/** Opening: the first 10 moves are placed slowly, one every 400ms (pre-scale). */
 const OPENING_END = 10
-const OPENING_DELAY_MS = 400
+const OPENING_DELAY_MS = 400 * PACE_MULTIPLIER
 
 /** Middlegame: a linear ramp from the opening pace down to a fast pace. */
 const MIDGAME_END = 60
-const MIDGAME_START_DELAY_MS = 380
-const MIDGAME_END_DELAY_MS = 95
+const MIDGAME_START_DELAY_MS = 380 * PACE_MULTIPLIER
+const MIDGAME_END_DELAY_MS = 95 * PACE_MULTIPLIER
 
 /** Fast run-up to move 78. */
 const FAST_MIDGAME_END = MOVE_78 - 1
-const FAST_MIDGAME_DELAY_MS = 85
+const FAST_MIDGAME_DELAY_MS = 85 * PACE_MULTIPLIER
 
 /** The deliberate pause before move 78 itself appears. */
-const PRE_78_PAUSE_MS = 1300
+const PRE_78_PAUSE_MS = 1300 * PACE_MULTIPLIER
 
 /** Endgame: ramps from just after move 78 down to the fastest pace. */
 const ENDGAME_RAMP_END = 140
-const ENDGAME_START_DELAY_MS = 140
-const ENDGAME_END_DELAY_MS = 65
+const ENDGAME_START_DELAY_MS = 140 * PACE_MULTIPLIER
+const ENDGAME_END_DELAY_MS = 65 * PACE_MULTIPLIER
 
 /** The final, fastest stretch to move 180. */
-const FINAL_DELAY_MS = 50
+const FINAL_DELAY_MS = 50 * PACE_MULTIPLIER
 
 /** How long the finished position holds before the fade-out begins. */
 export const HOLD_MS = 2600


### PR DESCRIPTION
## Summary

Two owner-requested tuning changes to the hero Go board replay (issue #316 lineage), after watching it run live:

**1. Drop the stale move-78 marker once that stone is captured.**
`frame.move78Marker` used to stay set (`clamped >= MOVE_78`) for the rest of the ~27s/~40s loop even after the move-78 stone was captured at move 91 — it read as a filled accent stone abruptly turning into a hollow ring that just sat there. It now tracks the stone's actual identity: present only while board occupancy at that point *and* `isCurrentMove78Stone` both hold. The ring vanishes the instant move 91 (the capturing move) is applied — the same moment the stone itself starts its 550ms capture fade — not when that fade finishes. I tried the simpler "tied directly to `isCurrentMove78Stone`" approach first and confirmed in a real browser that the ring disappearing in sync with the fade start (rather than riding along for another 550ms) looks correct, not abrupt.

**2. Slow the whole replay to 1.5x its previous duration.**
Added `PACE_MULTIPLIER = 1.5` in `goTiming.ts`, applied uniformly to every per-move delay constant (opening, midgame ramp, fast-midgame, the move-78 pause, endgame ramp, final stretch). `HOLD_MS`, `FADE_MS`, and `CAPTURE_FADE_MS` are deliberately excluded (the last is pinned to the 550ms CSS transition in `src/styles/hero.css` and must keep matching it exactly).

| | old | new |
|---|---|---|
| OPENING_DELAY_MS | 400 | 600 |
| MIDGAME_START_DELAY_MS | 380 | 570 |
| MIDGAME_END_DELAY_MS | 95 | 142.5 |
| FAST_MIDGAME_DELAY_MS | 85 | 127.5 |
| PRE_78_PAUSE_MS | 1300 | 1950 |
| ENDGAME_START_DELAY_MS | 140 | 210 |
| ENDGAME_END_DELAY_MS | 65 | 97.5 |
| FINAL_DELAY_MS | 50 | 75 |
| SEQUENCE_MS | ~26.8s | ~40.25s |
| LOOP_MS | ~30.1s | ~43.55s |

## Test plan
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 161/161 passing (updated `goTiming.test.ts` and `goFrameModel.test.ts` for the new timing values and marker behaviour; added coverage for marker-null before move 78, marker-present while the move-78 stone is on the board, and marker-null immediately at/after move 91's capture, including during and after its fade window)
- [x] `npm run build` — passes
- [x] Verified in a real Chromium browser via Playwright against `vite preview`:
  - A move in the [78, 90] window (sampled at move 85, after the mount animation settles) shows a filled accent stone with the thin accent ring rim around it, as designed.
  - At move 91 itself, the point is visually indistinguishable from any other empty board point — no ring, no dot, no residual indicator.
  - Well past move 91 (move ~104), same empty-point appearance confirmed — nothing lingers.
  - Sampled the aria-label (`Go board, move N of 180`) over time and confirmed the pace matches the new `moveTimestampMs` curve (accounting for ~2.2s of page-load/hydration startup lag before the animation's own clock starts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)