### PR TITLE
Second projects screen: MLA library and thesis

### DIFF
--- a/src/components/sections/ProjectsOther.test.tsx
+++ b/src/components/sections/ProjectsOther.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ProjectsOther } from './ProjectsOther'
+import {
+  MLA_INSTALL_COMMAND,
+  MLA_LINKS,
+  MLA_TAGLINE,
+  THESIS_STATS,
+  THESIS_TAGLINE,
+  THESIS_TITLE,
+} from '@/data/otherProjects'
+import { sections } from '@/data/sections'
+
+/**
+ * Smoke coverage for issue #318: this component is pure presentation over
+ * `src/data/otherProjects.ts`, so the real correctness weight sits in
+ * `src/lib/otherProjects/agentCluster.test.ts` and
+ * `CopyInstallCommand.test.tsx` instead. These assertions check the public
+ * interface: the section landmark, no duplicated eyebrow number, the
+ * install command, the thesis's running indicator and stats, and the
+ * animated cluster mounting.
+ */
+describe('ProjectsOther', () => {
+  it('renders the second projects section with its documented id and label', () => {
+    render(<ProjectsOther />)
+
+    const region = screen.getByRole('region', { name: sections[2].label })
+    expect(region).toHaveAttribute('id', sections[2].id)
+  })
+
+  it('carries no eyebrow section number, unlike the featured screen', () => {
+    render(<ProjectsOther />)
+
+    expect(screen.queryByText(/^01/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/PROJECTS$/)).not.toBeInTheDocument()
+  })
+
+  it('presents the MLA library with its taglines and the corrected install command', () => {
+    render(<ProjectsOther />)
+
+    expect(screen.getByText(MLA_TAGLINE)).toBeInTheDocument()
+    expect(screen.getByText(MLA_INSTALL_COMMAND)).toBeInTheDocument()
+  })
+
+  it('links to the MLA source and package with the correct URLs', () => {
+    render(<ProjectsOther />)
+
+    for (const link of MLA_LINKS) {
+      const anchor = screen.getByRole('link', { name: new RegExp(link.label, 'i') })
+      expect(anchor).toHaveAttribute('href', link.href)
+      expect(anchor).toHaveAttribute('target', '_blank')
+    }
+  })
+
+  it('shows the thesis running indicator, its title, and its stats', () => {
+    render(<ProjectsOther />)
+
+    expect(screen.getByText(THESIS_TAGLINE)).toBeInTheDocument()
+    expect(screen.getByText('RUNNING')).toBeInTheDocument()
+    expect(screen.getByText(THESIS_TITLE)).toBeInTheDocument()
+
+    for (const stat of THESIS_STATS) {
+      expect(screen.getByText(stat.value)).toBeInTheDocument()
+      expect(screen.getByText(stat.label)).toBeInTheDocument()
+    }
+  })
+
+  it('renders the animated agent-dot cluster illustrating the thesis', () => {
+    render(<ProjectsOther />)
+
+    expect(
+      screen.getByRole('group', {
+        name: 'Simulated organization of LLM agents: mostly idle or active, one occasionally flagged as an insider threat',
+      }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/sections/ProjectsOther.tsx
+++ b/src/components/sections/ProjectsOther.tsx
@@ -1,19 +1,124 @@
 import { Section } from '@/components/layout/Section'
-import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
+import { AgentCluster } from '@/components/sections/otherProjects/AgentCluster'
+import { CopyInstallCommand } from '@/components/sections/otherProjects/CopyInstallCommand'
+import {
+  MLA_BADGE,
+  MLA_DESCRIPTION,
+  MLA_INSTALL_COMMAND,
+  MLA_LINKS,
+  MLA_TAGLINE,
+  MLA_TITLE,
+  OTHER_PROJECTS_LEAD,
+  OTHER_PROJECTS_SUBTITLE,
+  OTHER_PROJECTS_TITLE,
+  THESIS_BADGE,
+  THESIS_DESCRIPTION,
+  THESIS_STATS,
+  THESIS_TAGLINE,
+  THESIS_TITLE,
+} from '@/data/otherProjects'
 import { sections } from '@/data/sections'
 
 const meta = sections[2]
 
 /**
- * Secondary projects screen placeholder. Per the spec's fixed defect, this
- * screen deliberately has no eyebrow number -- the reference reused
- * "01 PROJECTS" on both project screens, which reads as a rendering bug.
- * Real content lands in #318.
+ * Second projects screen: the MLA library and the in-progress thesis
+ * (issue #318). This screen follows the featured Leviathan screen (#317)
+ * and is built to read as its continuation rather than a repeat of it:
+ *
+ *   - No eyebrow number (`meta.eyebrow` is `''`) -- the design reference
+ *     reused "01 · PROJECTS" on both project screens, which read as a
+ *     rendering bug on two consecutive full-viewport screens. That
+ *     duplicate is dropped entirely rather than swapped for a different
+ *     number.
+ *   - The heading keeps the same font-display family and the
+ *     heading+subtitle pairing `ProjectsFeatured` uses for "Leviathan" /
+ *     `LEVIATHAN_SUBTITLE`, so the two screens visibly belong together,
+ *     but renders one step down the fluid scale (`text-fluid-xl` here vs
+ *     `text-fluid-2xl` there) -- both stay `<h2>` for a correct landmark
+ *     outline (each top-level section has exactly one top-level heading),
+ *     with size carrying the "this is part two" signal instead of tag
+ *     level.
+ *
+ * Two cards, side by side above 880px: the MLA library (a copyable install
+ * command a visitor can use in one step) and the thesis (a running
+ * indicator, its expected-completion date, and the animated agent-dot
+ * cluster illustrating the thesis's own premise). All copy and figures
+ * live in `src/data/otherProjects.ts`, sourced from `public/resume.pdf`;
+ * this component is pure presentation. `AgentCluster` and
+ * `CopyInstallCommand` each own their own state, scoped to themselves, so
+ * this section never re-renders on their account.
  */
 export function ProjectsOther() {
   return (
     <Section id={meta.id} label={meta.label}>
-      <SectionPlaceholder {...meta} />
+      <div className="flex h-full flex-col gap-[var(--space-sm)]">
+        <div className="flex flex-col gap-[var(--space-2xs)]">
+          <div className="flex items-baseline gap-[var(--space-xs)] flex-wrap">
+            <h2 className="font-display text-fluid-xl leading-tight text-fg">{OTHER_PROJECTS_TITLE}</h2>
+            <span className="text-2xs tracking-[0.18em] text-dim">{OTHER_PROJECTS_SUBTITLE}</span>
+          </div>
+          <p className="max-w-2xl text-fluid-base text-fg-2">{OTHER_PROJECTS_LEAD}</p>
+        </div>
+
+        <div className="grid flex-1 grid-cols-1 gap-[var(--space-sm)] md:grid-cols-2">
+          <article className="flex flex-col gap-[var(--space-xs)] border border-line bg-panel p-[var(--space-sm)]">
+            <div className="flex items-baseline gap-[var(--space-2xs)] flex-wrap">
+              <h3 className="font-display text-fluid-lg text-fg">{MLA_TITLE}</h3>
+              <span className="ml-auto text-2xs tracking-[0.18em] text-dim-2">{MLA_BADGE}</span>
+            </div>
+
+            <p className="text-fluid-base text-accent-2">{MLA_TAGLINE}</p>
+
+            <p className="text-fluid-sm text-fg-2">{MLA_DESCRIPTION}</p>
+
+            <CopyInstallCommand command={MLA_INSTALL_COMMAND} />
+
+            <div className="flex gap-[var(--space-sm)] border-t border-line pt-[var(--space-xs)]">
+              {MLA_LINKS.map((link) => (
+                <a
+                  key={link.label}
+                  href={link.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="border-b border-line-2 pb-[2px] text-fluid-sm text-fg-2"
+                >
+                  {link.label} ↗
+                </a>
+              ))}
+            </div>
+          </article>
+
+          <article className="flex flex-col gap-[var(--space-xs)] border border-line bg-panel p-[var(--space-sm)]">
+            <div className="flex items-baseline gap-[var(--space-2xs)] flex-wrap">
+              <h3 className="font-display text-fluid-lg text-fg">Thesis</h3>
+              <span
+                aria-hidden="true"
+                className="ml-auto flex items-center gap-[var(--space-3xs)] text-2xs tracking-[0.18em] text-accent-2"
+              >
+                <span className="inline-block h-[6px] w-[6px] rounded-full bg-accent-2 motion-safe:animate-pulse" />
+                {THESIS_BADGE}
+              </span>
+            </div>
+
+            <p className="text-fluid-base text-accent-2">{THESIS_TAGLINE}</p>
+
+            <p className="text-fluid-sm text-fg-2">{THESIS_DESCRIPTION}</p>
+            <p className="sr-only">{THESIS_TITLE}</p>
+
+            <AgentCluster />
+
+            <div className="mt-auto flex gap-[var(--space-md)] border-t border-line pt-[var(--space-xs)]">
+              {THESIS_STATS.map((stat) => (
+                <div key={stat.label} className="flex flex-col">
+                  <span className="font-display text-fluid-sm text-fg">{stat.value}</span>
+                  <span className="mt-[var(--space-3xs)] text-2xs tracking-[0.16em] text-dim-2">{stat.label}</span>
+                </div>
+              ))}
+            </div>
+          </article>
+        </div>
+      </div>
     </Section>
   )
 }

--- a/src/components/sections/otherProjects/AgentCluster.test.tsx
+++ b/src/components/sections/otherProjects/AgentCluster.test.tsx
@@ -1,0 +1,84 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AgentCluster } from './AgentCluster'
+import { AGENT_DOT_COUNT } from '@/data/otherProjects'
+
+const FRAME_INTERVAL_MS = 260
+
+function mockMatchMedia(reducedMotion: boolean) {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: reducedMotion,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('AgentCluster', () => {
+  it('renders as a single labelled group, with one dot per modelled agent', () => {
+    render(<AgentCluster />)
+
+    const group = screen.getByRole('group', {
+      name: 'Simulated organization of LLM agents: mostly idle or active, one occasionally flagged as an insider threat',
+    })
+    expect(group).toBeInTheDocument()
+    expect(group.querySelectorAll('[data-agent-state]')).toHaveLength(AGENT_DOT_COUNT)
+  })
+
+  it('starts a timer under normal motion preferences', () => {
+    mockMatchMedia(false)
+    vi.useFakeTimers()
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+    render(<AgentCluster />)
+
+    expect(setIntervalSpy).toHaveBeenCalled()
+  })
+
+  it('settles on one populated frame under reduced motion, without starting a timer', () => {
+    mockMatchMedia(true)
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval')
+
+    render(<AgentCluster />)
+
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+    const group = screen.getByRole('group', {
+      name: 'Simulated organization of LLM agents: mostly idle or active, one occasionally flagged as an insider threat',
+    })
+    const states = Array.from(group.querySelectorAll('[data-agent-state]')).map((el) =>
+      el.getAttribute('data-agent-state'),
+    )
+    expect(states).toContain('flagged')
+    expect(states).toContain('idle')
+  })
+
+  it('advances dot states over time under normal motion', () => {
+    mockMatchMedia(false)
+    vi.useFakeTimers()
+
+    render(<AgentCluster />)
+    const group = screen.getByRole('group', {
+      name: 'Simulated organization of LLM agents: mostly idle or active, one occasionally flagged as an insider threat',
+    })
+    const before = Array.from(group.querySelectorAll('[data-agent-state]')).map((el) =>
+      el.getAttribute('data-agent-state'),
+    )
+
+    act(() => {
+      vi.advanceTimersByTime(FRAME_INTERVAL_MS * 12)
+    })
+
+    const after = Array.from(group.querySelectorAll('[data-agent-state]')).map((el) =>
+      el.getAttribute('data-agent-state'),
+    )
+    expect(after).not.toEqual(before)
+  })
+})

--- a/src/components/sections/otherProjects/AgentCluster.tsx
+++ b/src/components/sections/otherProjects/AgentCluster.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react'
+import { AGENT_DOT_COUNT } from '@/data/otherProjects'
+import { cn } from '@/lib/cn'
+import {
+  type AgentState,
+  computeAgentClusterFrame,
+  settledAgentClusterFrame,
+} from '@/lib/otherProjects/agentCluster'
+import { usePrefersReducedMotion } from '@/lib/usePrefersReducedMotion'
+
+const FRAME_INTERVAL_MS = 260
+
+const STATE_CLASS: Record<AgentState, string> = {
+  idle: 'bg-dim-3',
+  active: 'bg-accent-2',
+  flagged: 'bg-accent',
+}
+
+/**
+ * Illustrates the thesis's own premise — a simulated organization of LLM
+ * agents, most idle or ordinarily active, occasionally one flagged as an
+ * insider threat — without a paragraph of explanation (issue #318).
+ *
+ * Owns its own state and timer, scoped to this widget, so a frame tick
+ * re-renders only this cluster, not the section around it. Frame-to-model
+ * logic is a pure function (`computeAgentClusterFrame` in
+ * `src/lib/otherProjects/agentCluster.ts`); this component only owns the
+ * ticking clock and paints whatever that function says is true this
+ * frame — the same split `InferencePipeline` uses for the featured screen.
+ *
+ * Reduced motion: no timer is started at all. `settledAgentClusterFrame`
+ * renders one fixed, already-varied frame (idle, active, and a flagged dot
+ * all present at once) rather than a blank or frozen-mid-reveal cluster.
+ *
+ * Each dot's state is exposed via `data-agent-state` rather than through
+ * its colour class alone — that is what the tests assert against (a
+ * behavioural, model-driven attribute), never the Tailwind class name
+ * itself.
+ */
+export function AgentCluster() {
+  const reducedMotion = usePrefersReducedMotion()
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    if (reducedMotion) return
+    const id = setInterval(() => setTick((t) => t + 1), FRAME_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [reducedMotion])
+
+  const dots = reducedMotion
+    ? settledAgentClusterFrame(AGENT_DOT_COUNT)
+    : computeAgentClusterFrame(tick, AGENT_DOT_COUNT)
+
+  return (
+    <div
+      role="group"
+      aria-label="Simulated organization of LLM agents: mostly idle or active, one occasionally flagged as an insider threat"
+      className="flex flex-wrap gap-[var(--space-3xs)]"
+    >
+      {dots.map((dot) => (
+        <span
+          key={dot.id}
+          aria-hidden="true"
+          data-agent-state={dot.state}
+          className={cn('h-3 w-3 rounded-full transition-colors duration-300', STATE_CLASS[dot.state])}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/sections/otherProjects/CopyInstallCommand.test.tsx
+++ b/src/components/sections/otherProjects/CopyInstallCommand.test.tsx
@@ -1,0 +1,48 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CopyInstallCommand } from './CopyInstallCommand'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.useRealTimers()
+})
+
+describe('CopyInstallCommand', () => {
+  it('shows the command as plain, readable text', () => {
+    render(<CopyInstallCommand command="pip install multihead-latent-attention" />)
+
+    expect(screen.getByText('pip install multihead-latent-attention')).toBeInTheDocument()
+  })
+
+  it('copies the command to the clipboard and shows a confirmation, then reverts', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+
+    render(<CopyInstallCommand command="pip install multihead-latent-attention" />)
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'copy' }).click()
+    })
+
+    expect(writeText).toHaveBeenCalledWith('pip install multihead-latent-attention')
+    expect(screen.getByRole('button', { name: 'copied' })).toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+    expect(screen.getByRole('button', { name: 'copy' })).toBeInTheDocument()
+  })
+
+  it('does not throw when the Clipboard API is unavailable', async () => {
+    vi.stubGlobal('navigator', { ...navigator, clipboard: undefined })
+
+    render(<CopyInstallCommand command="pip install multihead-latent-attention" />)
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'copy' }).click()
+    })
+
+    expect(screen.getByRole('button', { name: 'copy' })).toBeInTheDocument()
+  })
+})

--- a/src/components/sections/otherProjects/CopyInstallCommand.tsx
+++ b/src/components/sections/otherProjects/CopyInstallCommand.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react'
+
+const COPIED_LABEL_MS = 1500
+
+interface CopyInstallCommandProps {
+  command: string
+}
+
+/**
+ * The MLA library's install command, copyable in one step (issue #318:
+ * "so a visitor can use it in one step"). This is a small UI affordance,
+ * not a decorative animation loop, so it does not go through
+ * `usePrefersReducedMotion` — the only state here is a text label that
+ * reverts after a short delay, cleaned up on unmount.
+ *
+ * Falls back gracefully when the Clipboard API is unavailable (e.g.
+ * insecure contexts, some test environments): the command itself is
+ * always plain selectable text, so a visitor can still copy it by hand.
+ */
+export function CopyInstallCommand({ command }: CopyInstallCommandProps) {
+  const [copied, setCopied] = useState(false)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    }
+  }, [])
+
+  const handleCopy = async () => {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return
+    try {
+      await navigator.clipboard.writeText(command)
+      setCopied(true)
+      if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = setTimeout(() => setCopied(false), COPIED_LABEL_MS)
+    } catch {
+      // Clipboard write can be denied by the browser -- the command text
+      // itself is still visible and selectable, so this is a silent no-op.
+    }
+  }
+
+  return (
+    <div className="mt-auto flex items-center gap-[var(--space-2xs)] bg-panel-2 px-[var(--space-xs)] py-[var(--space-2xs)] font-mono text-2xs text-fg-2">
+      <span aria-hidden="true" className="text-accent-2">
+        $
+      </span>
+      <span className="flex-1 overflow-x-auto whitespace-nowrap">{command}</span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="whitespace-nowrap border border-line-2 px-[var(--space-2xs)] py-[2px] text-2xs text-dim tracking-[0.1em] hover:border-accent hover:text-accent-2"
+      >
+        {copied ? 'copied' : 'copy'}
+      </button>
+    </div>
+  )
+}

--- a/src/data/otherProjects.ts
+++ b/src/data/otherProjects.ts
@@ -1,0 +1,100 @@
+/**
+ * Second projects screen content: the MLA library and the in-progress
+ * thesis (issue #318). This screen follows the featured Leviathan screen
+ * (#317) and deliberately reads as its continuation, not a repeat of it —
+ * see `sections[2].eyebrow` in `src/data/sections.ts`, which is the empty
+ * string on purpose (the design reference reused "01 · PROJECTS" on both
+ * project screens; that duplicate number is the defect this issue fixes).
+ *
+ * Every fact below is sourced from `public/resume.pdf`:
+ *
+ *   - MLA translated from DeepSeek-V2 into a modular PyTorch implementation
+ *     with clean KV-compression/low-rank-projection abstractions — résumé:
+ *     "Translated Multi-Head Latent Attention from DeepSeek-V2 research
+ *     into modular PyTorch implementation, designing clean abstractions
+ *     for KV compression and low-rank projection components."
+ *   - Packaged as a production-ready PyPI library with type hints,
+ *     documentation, and integration examples — résumé: "Packaged
+ *     implementation as production-ready PyPI library with type hints,
+ *     documentation, and integration examples."
+ *   - GitHub + PyPI URLs — taken from the résumé PDF's own link
+ *     annotations (not typed by hand): both point at
+ *     `Nemesis-12/multihead-latent-attention`, confirming the real PyPI
+ *     package name. The design reference advertises `pip install
+ *     mla-pytorch`, which does not match either URL — that is the defect
+ *     this issue also fixes; the correct command is
+ *     `pip install multihead-latent-attention`.
+ *   - Thesis title "Generative Agent-Based Models for Insider Threat
+ *     Detection" — résumé, Education > Wichita State University
+ *     (Accelerated MS in Computer Science).
+ *   - Program dates "Jan 2026 – May 2027 (Expected)" — résumé, same entry.
+ *     The résumé gives no separate thesis-defence date, only the
+ *     program's own expected-completion date, so that expected date is
+ *     what the "defence date" stat below shows — labelled "EXPECTED" to
+ *     stay literally true to the résumé's own qualifier rather than
+ *     implying a defence has been scheduled.
+ *   - Relevant coursework "NLP, Reinforcement Learning" — résumé, same
+ *     entry.
+ *
+ * The agent-dot cluster illustrating the thesis is an illustrative
+ * visualization of the thesis's own premise (simulated organizations of
+ * LLM agents, some behaving as insider threats) — not a claim about a
+ * specific simulation size or result, neither of which the résumé states.
+ */
+
+export interface OtherProjectStat {
+  readonly label: string
+  readonly value: string
+}
+
+export interface OtherProjectLink {
+  readonly label: string
+  readonly href: string
+}
+
+/** Shown next to the section heading, mirroring how the featured screen pairs its h2 with `LEVIATHAN_SUBTITLE`. */
+export const OTHER_PROJECTS_SUBTITLE = 'mla library · thesis in progress'
+
+export const OTHER_PROJECTS_TITLE = 'Beyond Leviathan'
+
+export const OTHER_PROJECTS_LEAD =
+  'The other half of the ledger: a published research library, and the thesis it grew out of.'
+
+// --- MLA library -----------------------------------------------------------
+
+export const MLA_BADGE = 'PUBLISHED'
+
+export const MLA_TITLE = 'Multi-Head Latent Attention'
+
+export const MLA_TAGLINE = 'Read the paper. Wrote the library.'
+
+export const MLA_DESCRIPTION =
+  'Multi-Head Latent Attention from DeepSeek-V2, translated into a modular PyTorch implementation with clean abstractions for KV compression and low-rank projection — packaged as a production-ready PyPI library with type hints, documentation, and integration examples.'
+
+/** The exact command a visitor can copy and run in one step (issue #318 acceptance criteria). */
+export const MLA_INSTALL_COMMAND = 'pip install multihead-latent-attention'
+
+/** Both URLs come from the résumé PDF's own link annotations. */
+export const MLA_LINKS: readonly OtherProjectLink[] = [
+  { label: 'source', href: 'https://github.com/Nemesis-12/multihead-latent-attention' },
+  { label: 'package', href: 'https://pypi.org/project/multihead-latent-attention' },
+]
+
+// --- Thesis ------------------------------------------------------------
+
+export const THESIS_BADGE = 'RUNNING'
+
+export const THESIS_TITLE = 'Generative Agent-Based Models for Insider Threat Detection'
+
+export const THESIS_TAGLINE = 'Fake employees, real behavioural data.'
+
+export const THESIS_DESCRIPTION =
+  'A simulated organization staffed by generative LLM agents, some of them behaving as insider threats, producing the labelled behavioural data real security teams can rarely share.'
+
+export const THESIS_STATS: readonly OtherProjectStat[] = [
+  { label: 'EXPECTED', value: 'MAY 2027' },
+  { label: 'COURSEWORK', value: 'NLP · RL' },
+]
+
+/** Number of dots in the illustrative agent cluster — a display choice, not a résumé figure. */
+export const AGENT_DOT_COUNT = 24

--- a/src/lib/otherProjects/agentCluster.test.ts
+++ b/src/lib/otherProjects/agentCluster.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_CYCLE_LENGTH,
+  computeAgentClusterFrame,
+  settledAgentClusterFrame,
+} from './agentCluster'
+
+describe('computeAgentClusterFrame', () => {
+  it('returns exactly one dot model per requested agent, with stable ids 0..n-1', () => {
+    const dots = computeAgentClusterFrame(0, 6)
+
+    expect(dots).toHaveLength(6)
+    expect(dots.map((dot) => dot.id)).toEqual([0, 1, 2, 3, 4, 5])
+  })
+
+  it('returns an empty cluster for zero agents', () => {
+    expect(computeAgentClusterFrame(0, 0)).toEqual([])
+  })
+
+  it('only ever produces the three documented states', () => {
+    for (let tick = 0; tick < AGENT_CYCLE_LENGTH * 2; tick++) {
+      const dots = computeAgentClusterFrame(tick, 24)
+      for (const dot of dots) {
+        expect(['idle', 'active', 'flagged']).toContain(dot.state)
+      }
+    }
+  })
+
+  it('is deterministic: the same tick and agent count always produce the same states', () => {
+    const first = computeAgentClusterFrame(11, 24)
+    const second = computeAgentClusterFrame(11, 24)
+    expect(second).toEqual(first)
+  })
+
+  it('offsets each agent from its neighbours, so the cluster is not in lockstep', () => {
+    // At tick 0, agents 0 and 1 have different phase offsets (0 vs 5), so
+    // they need not share a state across the whole cycle -- spot-check a
+    // tick where they documented-ly diverge.
+    const dots = computeAgentClusterFrame(10, 24)
+    const states = new Set(dots.map((dot) => dot.state))
+    expect(states.size).toBeGreaterThan(1)
+  })
+
+  it('wraps cleanly across cycle boundaries, matching the frame one cycle later', () => {
+    const first = computeAgentClusterFrame(3, 24)
+    const wrapped = computeAgentClusterFrame(3 + AGENT_CYCLE_LENGTH, 24)
+    expect(wrapped).toEqual(first)
+  })
+
+  it('never throws for a negative tick, and still wraps into a valid state', () => {
+    const dots = computeAgentClusterFrame(-1, 24)
+    expect(dots).toHaveLength(24)
+    for (const dot of dots) {
+      expect(['idle', 'active', 'flagged']).toContain(dot.state)
+    }
+  })
+
+  it('only a fraction of agents are ever capable of being flagged', () => {
+    // Sweep every phase for a 24-agent cluster; only indices 0, 7, 14, 21
+    // (every 7th) are flaggable at all -- the rest must never appear
+    // flagged, no matter the tick.
+    const everFlagged = new Set<number>()
+    for (let tick = 0; tick < AGENT_CYCLE_LENGTH; tick++) {
+      for (const dot of computeAgentClusterFrame(tick, 24)) {
+        if (dot.state === 'flagged') everFlagged.add(dot.id)
+      }
+    }
+    for (const id of everFlagged) {
+      expect(id % 7).toBe(0)
+    }
+    expect(everFlagged.size).toBeGreaterThan(0)
+  })
+})
+
+describe('settledAgentClusterFrame', () => {
+  it('matches computeAgentClusterFrame at the last frame of the cycle', () => {
+    const settled = settledAgentClusterFrame(24)
+    const direct = computeAgentClusterFrame(AGENT_CYCLE_LENGTH - 1, 24)
+    expect(settled).toEqual(direct)
+  })
+
+  it('shows a populated mix, not a blank cluster -- at least one flagged and one idle dot', () => {
+    const dots = settledAgentClusterFrame(24)
+    const states = dots.map((dot) => dot.state)
+    expect(states).toContain('flagged')
+    expect(states).toContain('idle')
+  })
+
+  it('is deterministic across calls', () => {
+    expect(settledAgentClusterFrame(24)).toEqual(settledAgentClusterFrame(24))
+  })
+})

--- a/src/lib/otherProjects/agentCluster.ts
+++ b/src/lib/otherProjects/agentCluster.ts
@@ -1,0 +1,79 @@
+/**
+ * Pure frame-to-model logic for the thesis's agent-dot cluster (issue
+ * #318). The widget illustrates the thesis's own premise — a simulated
+ * organization of LLM agents, most going about ordinary business, one
+ * occasionally standing out as a flagged insider threat — without a
+ * paragraph of explanation.
+ *
+ * No timer and no DOM here: given a tick count and how many agents to
+ * model, this returns exactly which state each agent dot is in this
+ * frame. The React component (`AgentCluster.tsx`) owns the `setInterval`
+ * and feeds its own tick count in on every render, the same split used by
+ * `src/lib/leviathan/pipeline.ts` for the inference-pipeline widget — kept
+ * separate so this logic is unit-testable without mounting React, and so
+ * a frame tick only re-renders this leaf widget.
+ */
+
+export type AgentState = 'idle' | 'active' | 'flagged'
+
+export interface AgentDotModel {
+  readonly id: number
+  readonly state: AgentState
+}
+
+/** Frames in one personal cycle for a single agent dot. */
+export const AGENT_CYCLE_LENGTH = 24
+
+/** Within a cycle, the frame at which an agent moves from idle to active. */
+const ACTIVE_FROM_FRAME = 15
+
+/** Within a cycle, the last few frames a flaggable agent spends flagged. */
+const FLAGGED_FROM_FRAME = AGENT_CYCLE_LENGTH - 3
+
+/** Every Nth agent (by index) is capable of being flagged at all — most agents never are. */
+const FLAGGABLE_STRIDE = 7
+
+/** Spreads each agent's cycle out relative to its neighbours, so the cluster never moves in lockstep. */
+const PHASE_OFFSET_STRIDE = 5
+
+/** Wraps a tick into `[0, AGENT_CYCLE_LENGTH)`, even for a negative tick. */
+function wrapPhase(tick: number): number {
+  return ((tick % AGENT_CYCLE_LENGTH) + AGENT_CYCLE_LENGTH) % AGENT_CYCLE_LENGTH
+}
+
+function isFlaggable(index: number): boolean {
+  return index % FLAGGABLE_STRIDE === 0
+}
+
+function stateForPhase(phase: number, flaggable: boolean): AgentState {
+  if (flaggable && phase >= FLAGGED_FROM_FRAME) return 'flagged'
+  if (phase >= ACTIVE_FROM_FRAME) return 'active'
+  return 'idle'
+}
+
+/**
+ * Computes every agent dot's state at a given tick.
+ *
+ * @param tick ever-increasing frame counter (the component's own state)
+ * @param agentCount number of agent dots to model
+ */
+export function computeAgentClusterFrame(tick: number, agentCount: number): readonly AgentDotModel[] {
+  const dots: AgentDotModel[] = []
+  for (let index = 0; index < agentCount; index++) {
+    const offset = (index * PHASE_OFFSET_STRIDE) % AGENT_CYCLE_LENGTH
+    const phase = wrapPhase(tick + offset)
+    dots.push({ id: index, state: stateForPhase(phase, isFlaggable(index)) })
+  }
+  return dots
+}
+
+/**
+ * The single settled frame rendered under a reduced-motion preference: one
+ * frame from the loop, with no timer running behind it. Because each
+ * agent's phase is offset from its neighbours, a single fixed tick still
+ * shows a mix of idle, active, and (for a flaggable agent) flagged dots —
+ * the cluster reads as "populated," not frozen mid-blank.
+ */
+export function settledAgentClusterFrame(agentCount: number): readonly AgentDotModel[] {
+  return computeAgentClusterFrame(AGENT_CYCLE_LENGTH - 1, agentCount)
+}


### PR DESCRIPTION
## Summary
- Replaces the `ProjectsOther` placeholder with real content: the `multihead-latent-attention` PyPI library (copyable install command, corrected from the design reference's wrong `mla-pytorch` package name) and the in-progress thesis (running indicator, expected-completion date, and an animated agent-dot cluster illustrating its premise).
- No duplicated `01 · PROJECTS` eyebrow — the screen reads as a continuation of the featured Leviathan screen (same type family, accent palette, and panel language) with a distinct, smaller heading rather than a repeated section number.
- All content lives in a data module (`src/data/otherProjects.ts`), sourced from `public/resume.pdf`; components are pure presentation. The agent cluster's frame-to-model logic is a pure, unit-tested function (`src/lib/otherProjects/agentCluster.ts`), mirroring the featured screen's `src/lib/leviathan/pipeline.ts` pattern — it owns its own timer/state and settles to one populated, static frame under `prefers-reduced-motion`.
- Fixed a layout bug found during verification: the two-column card grid now switches at the `md` breakpoint (768px) instead of `lg` (1024px), so it's already two columns before the layout system's 880px fixed-viewport-height threshold kicks in — avoiding content overflow in the 880–1024px width range.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 182 passed (24 files), including new tests for `agentCluster.ts`, `AgentCluster.tsx`, `CopyInstallCommand.tsx`, and `ProjectsOther.tsx`
- [x] `npm run build` — succeeds
- [x] Runtime check via Chromium/playwright-core at 1440×900 and 390×844: no overflow, no duplicated eyebrow, section fits one viewport above 880px width (verified specifically at 900×900 after the grid-breakpoint fix), agent cluster animating
- [x] `reducedMotion: 'reduce'`: agent cluster renders one settled, byte-identical-over-time frame with no timer started (verified via `setInterval` spy and pixel diff)

Refs #318