### PR TITLE
Fix layout breakpoint mismatch and accessibility findings

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -21,13 +21,24 @@ describe('App', () => {
     expect(renderedIds).toEqual(sections.map((section) => section.id))
   })
 
-  it('gives every section its documented id and accessible name, in DOM order', () => {
+  it('gives every section its documented id, and an accessible name sourced from its own visible heading', () => {
     render(<App />)
 
     for (const section of sections) {
       const region = document.getElementById(section.id)
       expect(region).not.toBeNull()
-      expect(region).toHaveAttribute('aria-label', section.label)
+
+      // Each landmark's name comes from `aria-labelledby` pointing at the
+      // section's real, visible heading -- not a separately maintained
+      // `aria-label` string that could drift from what's on screen.
+      const headingId = region!.getAttribute('aria-labelledby')
+      expect(headingId).toBeTruthy()
+
+      const heading = document.getElementById(headingId!)
+      expect(heading).not.toBeNull()
+      expect(heading!.textContent).toBeTruthy()
+
+      expect(screen.getByRole('region', { name: heading!.textContent! })).toBe(region)
     }
   })
 

--- a/src/components/layout/Section.tsx
+++ b/src/components/layout/Section.tsx
@@ -3,7 +3,13 @@ import { cn } from '@/lib/cn'
 
 interface SectionProps {
   id: string
-  label: string
+  /**
+   * DOM id of this section's own visible heading (an `<h1>`/`<h2>` element
+   * rendered somewhere inside `children`). Used as `aria-labelledby` so the
+   * landmark's accessible name is sourced from that real, visible heading
+   * rather than restated separately -- see the note below.
+   */
+  headingId: string
   children: ReactNode
   className?: string
 }
@@ -18,12 +24,19 @@ interface SectionProps {
  * and snap both release and the section is ordinary flow content. The
  * scroll-snap-type/scroll-behavior that drive snapping live on `:root`
  * (the actual document scroll container), not on this class.
+ *
+ * `aria-labelledby` (not `aria-label`) sources the landmark's accessible
+ * name from the section's own visible heading. Every section renders
+ * exactly one top-level heading already; pointing the landmark at it
+ * (via `headingId`) means there is exactly one place the name is written,
+ * instead of a separate `aria-label` string that has to be kept in sync
+ * with a heading assistive tech users can already see and hear.
  */
-export function Section({ id, label, children, className }: SectionProps) {
+export function Section({ id, headingId, children, className }: SectionProps) {
   return (
     <section
       id={id}
-      aria-label={label}
+      aria-labelledby={headingId}
       className={cn('section-shell', className)}
     >
       {children}

--- a/src/components/layout/SectionPlaceholder.tsx
+++ b/src/components/layout/SectionPlaceholder.tsx
@@ -10,13 +10,20 @@ import { cn } from '@/lib/cn'
  * skills graph, etc.) replaces this in #316-#321. This exists only so the
  * shell and layout system have something to fill each screen with now.
  */
-export function SectionPlaceholder({ eyebrow, title, blurb }: SectionMeta) {
+interface SectionPlaceholderProps extends SectionMeta {
+  /** DOM id to put on the rendered `<h2>`, for the section's `aria-labelledby`. */
+  headingId: string
+}
+
+export function SectionPlaceholder({ eyebrow, title, blurb, headingId }: SectionPlaceholderProps) {
   return (
     <div className="flex max-w-3xl flex-col gap-[var(--space-sm)]">
       {eyebrow && (
         <p className={cn('text-fluid-xs font-mono tracking-[0.2em] text-dim')}>{eyebrow}</p>
       )}
-      <h2 className={cn('font-display text-fluid-2xl leading-tight text-fg')}>{title}</h2>
+      <h2 id={headingId} className={cn('font-display text-fluid-2xl leading-tight text-fg')}>
+        {title}
+      </h2>
       <p className={cn('text-fluid-base font-mono text-fg-2')}>{blurb}</p>
     </div>
   )

--- a/src/components/sections/Contact.test.tsx
+++ b/src/components/sections/Contact.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { Contact } from './Contact'
 import { CONTACT_LINKS, CONTACT_STATEMENT } from '@/data/contact'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 
 /**
  * Behaviour-only coverage for issue #321: the section landmark, the
@@ -11,11 +11,12 @@ import { sections } from '@/data/sections'
  * per repo test philosophy, public interfaces only.
  */
 describe('Contact', () => {
-  it('renders the contact section with its documented id and label', () => {
+  it('renders the contact section with its documented id, named by its own heading', () => {
     render(<Contact />)
 
-    const region = screen.getByRole('region', { name: sections[5].label })
-    expect(region).toHaveAttribute('id', sections[5].id)
+    const meta = getSectionMeta('contact')
+    const region = screen.getByRole('region', { name: meta.title })
+    expect(region).toHaveAttribute('id', meta.id)
   })
 
   it('states what work is being sought', () => {
@@ -42,7 +43,7 @@ describe('Contact', () => {
     for (const link of CONTACT_LINKS.filter((l) => l.external)) {
       const anchor = screen.getByRole('link', { name: new RegExp(link.label, 'i') })
       expect(anchor).toHaveAttribute('target', '_blank')
-      expect(anchor).toHaveAttribute('rel', 'noreferrer')
+      expect(anchor).toHaveAttribute('rel', 'noopener noreferrer')
     }
   })
 

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,8 +1,8 @@
 import { Section } from '@/components/layout/Section'
 import { CONTACT_LINKS, CONTACT_STATEMENT } from '@/data/contact'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 
-const meta = sections[5]
+const meta = getSectionMeta('contact')
 
 /**
  * Closing section (issue #321): a one-line statement of what work is being
@@ -17,11 +17,11 @@ const meta = sections[5]
  */
 export function Contact() {
   return (
-    <Section id={meta.id} label={meta.label}>
+    <Section id={meta.id} headingId="contact-heading">
       <div className="flex h-full max-w-3xl flex-col justify-center gap-[var(--space-lg)]">
         <div className="flex flex-col gap-[var(--space-sm)]">
           <p className="font-mono text-fluid-xs tracking-[0.2em] text-dim">{meta.eyebrow}</p>
-          <h2 className="font-display text-fluid-2xl leading-tight text-fg">{meta.title}</h2>
+          <h2 id="contact-heading" className="font-display text-fluid-2xl leading-tight text-fg">{meta.title}</h2>
           <p className="max-w-[52ch] text-fluid-base text-fg-2">{CONTACT_STATEMENT}</p>
         </div>
 
@@ -31,7 +31,7 @@ export function Contact() {
               <a
                 href={link.href}
                 target={link.external ? '_blank' : undefined}
-                rel={link.external ? 'noreferrer' : undefined}
+                rel={link.external ? 'noopener noreferrer' : undefined}
                 className="flex items-baseline justify-between gap-[var(--space-sm)] py-[var(--space-xs)] text-fluid-sm text-fg-2 transition-colors hover:text-accent-2"
               >
                 <span className="font-display text-fg">{link.label}</span>

--- a/src/components/sections/EducationExperience.test.tsx
+++ b/src/components/sections/EducationExperience.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { EducationExperience } from './EducationExperience'
 import { EDUCATION_COLUMN, EXPERIENCE_COLUMN } from '@/data/timeline'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 
 /**
  * Smoke coverage for issue #320: this component is pure presentation over
@@ -15,11 +15,12 @@ import { sections } from '@/data/sections'
  * instead.
  */
 describe('EducationExperience', () => {
-  it('renders the timeline section with its documented id and label', () => {
+  it('renders the timeline section with its documented id, named by its own heading', () => {
     render(<EducationExperience />)
 
-    const region = screen.getByRole('region', { name: sections[4].label })
-    expect(region).toHaveAttribute('id', sections[4].id)
+    const meta = getSectionMeta('path')
+    const region = screen.getByRole('region', { name: meta.title })
+    expect(region).toHaveAttribute('id', meta.id)
   })
 
   it('renders both column headings', () => {

--- a/src/components/sections/EducationExperience.tsx
+++ b/src/components/sections/EducationExperience.tsx
@@ -1,16 +1,19 @@
 import { Section } from '@/components/layout/Section'
 import { EDUCATION_COLUMN, EXPERIENCE_COLUMN, type TimelineColumn } from '@/data/timeline'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 import { cn } from '@/lib/cn'
 
-const meta = sections[4]
+const meta = getSectionMeta('path')
 
 /**
  * Timeline section (issue #320): education and experience side by side, so
  * a visitor sees the whole trajectory at once. Above the 880px breakpoint
  * the two columns sit in a two-column grid within one viewport; below it
- * they stack into a single column (`grid-cols-1 lg:grid-cols-2`), same
- * pattern the layout system already uses elsewhere.
+ * they stack into a single column (`grid-cols-1 panel:grid-cols-2`, where
+ * `panel:` is the 880px breakpoint defined in `src/index.css` -- not
+ * Tailwind's default `lg:`, which is 1024px and would disagree with the
+ * layout shell's own 880px switch), same pattern the layout system already
+ * uses elsewhere.
  *
  * All copy and dates live in `src/data/timeline.ts` -- every figure there
  * is sourced from `public/resume.pdf`. This component is pure
@@ -18,15 +21,15 @@ const meta = sections[4]
  */
 export function EducationExperience() {
   return (
-    <Section id={meta.id} label={meta.label}>
+    <Section id={meta.id} headingId="path-heading">
       <div className="flex h-full flex-col gap-[var(--space-sm)]">
         <div className="flex items-baseline gap-[var(--space-sm)] flex-wrap">
           <p className="font-mono text-fluid-xs tracking-[0.2em] text-dim">{meta.eyebrow}</p>
-          <h2 className="font-display text-fluid-2xl leading-tight text-fg">{meta.title}</h2>
+          <h2 id="path-heading" className="font-display text-fluid-2xl leading-tight text-fg">{meta.title}</h2>
           <span className="h-px flex-1 min-w-[2rem] bg-line" aria-hidden="true" />
         </div>
 
-        <div className="grid flex-1 grid-cols-1 gap-[var(--space-xs)] lg:grid-cols-2">
+        <div className="grid flex-1 grid-cols-1 gap-[var(--space-xs)] panel:grid-cols-2">
           <TimelineColumnPanel column={EDUCATION_COLUMN} />
           <TimelineColumnPanel column={EXPERIENCE_COLUMN} />
         </div>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -2,10 +2,10 @@ import { GoBoardReplay } from '@/components/hero/GoBoardReplay'
 import { HeroTagline } from '@/components/hero/HeroTagline'
 import { Section } from '@/components/layout/Section'
 import { HERO_NAME_FIRST, HERO_NAME_LAST, HERO_ROLE, HERO_TAGLINE } from '@/data/hero'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 import { cn } from '@/lib/cn'
 
-const meta = sections[0]
+const meta = getSectionMeta('top')
 
 /**
  * The hero (issue #316): states the role and name, types a one-shot
@@ -20,14 +20,14 @@ const meta = sections[0]
  */
 export function Hero() {
   return (
-    <Section id={meta.id} label={meta.label}>
+    <Section id={meta.id} headingId="top-heading">
       <div className="grid w-full items-center gap-[var(--space-lg)] [grid-template-columns:repeat(auto-fit,minmax(330px,1fr))]">
         <div className="flex min-w-0 flex-col gap-[var(--space-sm)]">
           <p className="flex items-center gap-[var(--space-2xs)] font-mono text-fluid-xs tracking-[0.2em] text-dim">
             <span aria-hidden="true" className="h-[9px] w-[9px] rounded-full bg-accent" />
             {HERO_ROLE}
           </p>
-          <h1 className={cn('font-display text-fluid-hero leading-tight text-fg')}>
+          <h1 id="top-heading" className={cn('font-display text-fluid-hero leading-tight text-fg')}>
             <span className="block">{HERO_NAME_FIRST}</span>
             <span className="inline-block bg-accent px-[0.05em] text-bg">{HERO_NAME_LAST}</span>
           </h1>

--- a/src/components/sections/ProjectsFeatured.test.tsx
+++ b/src/components/sections/ProjectsFeatured.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { ProjectsFeatured } from './ProjectsFeatured'
 import { LEVIATHAN_HOOK, LEVIATHAN_LINKS, LEVIATHAN_STATS } from '@/data/leviathan'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 
 /**
  * Smoke coverage for issue #317: this component is pure presentation over
@@ -14,11 +14,12 @@ import { sections } from '@/data/sections'
  * the right URLs.
  */
 describe('ProjectsFeatured', () => {
-  it('renders the featured-project section with its documented id and label', () => {
+  it('renders the featured-project section with its documented id, named by its own heading', () => {
     render(<ProjectsFeatured />)
 
-    const region = screen.getByRole('region', { name: sections[1].label })
-    expect(region).toHaveAttribute('id', sections[1].id)
+    const meta = getSectionMeta('projects')
+    const region = screen.getByRole('region', { name: 'Leviathan' })
+    expect(region).toHaveAttribute('id', meta.id)
   })
 
   it('states the one-line hook before any supporting detail', () => {

--- a/src/components/sections/ProjectsFeatured.tsx
+++ b/src/components/sections/ProjectsFeatured.tsx
@@ -9,9 +9,9 @@ import {
   LEVIATHAN_SUBTITLE,
   LEVIATHAN_SUMMARY,
 } from '@/data/leviathan'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 
-const meta = sections[1]
+const meta = getSectionMeta('projects')
 
 /**
  * Featured project: Leviathan gets a full screen to itself (issue #317),
@@ -29,13 +29,13 @@ const meta = sections[1]
  */
 export function ProjectsFeatured() {
   return (
-    <Section id={meta.id} label={meta.label}>
-      <div className="flex h-full flex-col gap-[var(--space-md)] lg:flex-row">
+    <Section id={meta.id} headingId="projects-heading">
+      <div className="flex h-full flex-col gap-[var(--space-md)] panel:flex-row">
         <div className="flex flex-1 flex-col gap-[var(--space-sm)]">
           <p className="font-mono text-fluid-xs tracking-[0.2em] text-dim">{meta.eyebrow}</p>
 
           <div className="flex items-baseline gap-[var(--space-xs)] flex-wrap">
-            <h2 className="font-display text-fluid-2xl leading-tight text-fg">Leviathan</h2>
+            <h2 id="projects-heading" className="font-display text-fluid-2xl leading-tight text-fg">Leviathan</h2>
             <span className="text-2xs tracking-[0.18em] text-dim">{LEVIATHAN_SUBTITLE}</span>
           </div>
 
@@ -75,7 +75,7 @@ export function ProjectsFeatured() {
           </div>
         </div>
 
-        <div className="flex-1 border-line bg-panel-2 p-[var(--space-sm)] lg:border-l">
+        <div className="flex-1 border-line bg-panel-2 p-[var(--space-sm)] panel:border-l">
           <InferencePipeline />
         </div>
       </div>

--- a/src/components/sections/ProjectsOther.test.tsx
+++ b/src/components/sections/ProjectsOther.test.tsx
@@ -5,11 +5,12 @@ import {
   MLA_INSTALL_COMMAND,
   MLA_LINKS,
   MLA_TAGLINE,
+  OTHER_PROJECTS_TITLE,
   THESIS_STATS,
   THESIS_TAGLINE,
   THESIS_TITLE,
 } from '@/data/otherProjects'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 
 /**
  * Smoke coverage for issue #318: this component is pure presentation over
@@ -21,11 +22,12 @@ import { sections } from '@/data/sections'
  * animated cluster mounting.
  */
 describe('ProjectsOther', () => {
-  it('renders the second projects section with its documented id and label', () => {
+  it('renders the second projects section with its documented id, named by its own heading', () => {
     render(<ProjectsOther />)
 
-    const region = screen.getByRole('region', { name: sections[2].label })
-    expect(region).toHaveAttribute('id', sections[2].id)
+    const meta = getSectionMeta('more')
+    const region = screen.getByRole('region', { name: OTHER_PROJECTS_TITLE })
+    expect(region).toHaveAttribute('id', meta.id)
   })
 
   it('carries no eyebrow section number, unlike the featured screen', () => {

--- a/src/components/sections/ProjectsOther.tsx
+++ b/src/components/sections/ProjectsOther.tsx
@@ -17,9 +17,9 @@ import {
   THESIS_TAGLINE,
   THESIS_TITLE,
 } from '@/data/otherProjects'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 
-const meta = sections[2]
+const meta = getSectionMeta('more')
 
 /**
  * Second projects screen: the MLA library and the in-progress thesis
@@ -51,17 +51,17 @@ const meta = sections[2]
  */
 export function ProjectsOther() {
   return (
-    <Section id={meta.id} label={meta.label}>
+    <Section id={meta.id} headingId="more-heading">
       <div className="flex h-full flex-col gap-[var(--space-sm)]">
         <div className="flex flex-col gap-[var(--space-2xs)]">
           <div className="flex items-baseline gap-[var(--space-xs)] flex-wrap">
-            <h2 className="font-display text-fluid-xl leading-tight text-fg">{OTHER_PROJECTS_TITLE}</h2>
+            <h2 id="more-heading" className="font-display text-fluid-xl leading-tight text-fg">{OTHER_PROJECTS_TITLE}</h2>
             <span className="text-2xs tracking-[0.18em] text-dim">{OTHER_PROJECTS_SUBTITLE}</span>
           </div>
           <p className="max-w-2xl text-fluid-base text-fg-2">{OTHER_PROJECTS_LEAD}</p>
         </div>
 
-        <div className="grid flex-1 grid-cols-1 gap-[var(--space-sm)] md:grid-cols-2">
+        <div className="grid flex-1 grid-cols-1 gap-[var(--space-sm)] panel:grid-cols-2">
           <article className="flex flex-col gap-[var(--space-xs)] border border-line bg-panel p-[var(--space-sm)]">
             <div className="flex items-baseline gap-[var(--space-2xs)] flex-wrap">
               <h3 className="font-display text-fluid-lg text-fg">{MLA_TITLE}</h3>

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -1,14 +1,14 @@
 import { Section } from '@/components/layout/Section'
 import { SectionPlaceholder } from '@/components/layout/SectionPlaceholder'
-import { sections } from '@/data/sections'
+import { getSectionMeta } from '@/data/sections'
 
-const meta = sections[3]
+const meta = getSectionMeta('skills')
 
 /** Skills graph placeholder. Real content lands in #319. */
 export function Skills() {
   return (
-    <Section id={meta.id} label={meta.label}>
-      <SectionPlaceholder {...meta} />
+    <Section id={meta.id} headingId="skills-heading">
+      <SectionPlaceholder {...meta} headingId="skills-heading" />
     </Section>
   )
 }

--- a/src/components/sections/otherProjects/CopyInstallCommand.test.tsx
+++ b/src/components/sections/otherProjects/CopyInstallCommand.test.tsx
@@ -34,15 +34,35 @@ describe('CopyInstallCommand', () => {
     expect(screen.getByRole('button', { name: 'copy' })).toBeInTheDocument()
   })
 
-  it('does not throw when the Clipboard API is unavailable', async () => {
-    vi.stubGlobal('navigator', { ...navigator, clipboard: undefined })
+  it('announces the copy confirmation to assistive tech via a polite live region', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
 
     render(<CopyInstallCommand command="pip install multihead-latent-attention" />)
+
+    expect(screen.queryByText('Command copied to clipboard')).not.toBeInTheDocument()
 
     await act(async () => {
       screen.getByRole('button', { name: 'copy' }).click()
     })
 
-    expect(screen.getByRole('button', { name: 'copy' })).toBeInTheDocument()
+    const status = screen.getByText('Command copied to clipboard')
+    expect(status).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('disables the copy button, rather than leaving it non-functional, when the Clipboard API is unavailable', async () => {
+    vi.stubGlobal('navigator', { ...navigator, clipboard: undefined })
+
+    render(<CopyInstallCommand command="pip install multihead-latent-attention" />)
+
+    const button = screen.getByRole('button', { name: /copy/i })
+    expect(button).toBeDisabled()
+
+    await act(async () => {
+      button.click()
+    })
+
+    expect(button).toHaveTextContent('copy')
   })
 })

--- a/src/components/sections/otherProjects/CopyInstallCommand.tsx
+++ b/src/components/sections/otherProjects/CopyInstallCommand.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 const COPIED_LABEL_MS = 1500
 
@@ -13,13 +13,23 @@ interface CopyInstallCommandProps {
  * `usePrefersReducedMotion` — the only state here is a text label that
  * reverts after a short delay, cleaned up on unmount.
  *
- * Falls back gracefully when the Clipboard API is unavailable (e.g.
- * insecure contexts, some test environments): the command itself is
- * always plain selectable text, so a visitor can still copy it by hand.
+ * The button's label swap (copy → copied) is echoed into a visually
+ * hidden `aria-live="polite"` region so assistive tech gets the same
+ * confirmation a sighted visitor sees, rather than a silent text swap.
+ *
+ * When the Clipboard API is unavailable (e.g. insecure contexts, some
+ * test environments) the button is disabled rather than left looking
+ * active while doing nothing on click -- the command itself is always
+ * plain selectable text, so a visitor can still copy it by hand.
  */
 export function CopyInstallCommand({ command }: CopyInstallCommandProps) {
   const [copied, setCopied] = useState(false)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const clipboardAvailable = useMemo(
+    () => typeof navigator !== 'undefined' && !!navigator.clipboard,
+    [],
+  )
 
   useEffect(() => {
     return () => {
@@ -28,7 +38,7 @@ export function CopyInstallCommand({ command }: CopyInstallCommandProps) {
   }, [])
 
   const handleCopy = async () => {
-    if (typeof navigator === 'undefined' || !navigator.clipboard) return
+    if (!clipboardAvailable) return
     try {
       await navigator.clipboard.writeText(command)
       setCopied(true)
@@ -49,10 +59,15 @@ export function CopyInstallCommand({ command }: CopyInstallCommandProps) {
       <button
         type="button"
         onClick={handleCopy}
-        className="whitespace-nowrap border border-line-2 px-[var(--space-2xs)] py-[2px] text-2xs text-dim tracking-[0.1em] hover:border-accent hover:text-accent-2"
+        disabled={!clipboardAvailable}
+        aria-label={clipboardAvailable ? undefined : 'Copy unavailable -- select the command text above instead'}
+        className="whitespace-nowrap border border-line-2 px-[var(--space-2xs)] py-[2px] text-2xs text-dim tracking-[0.1em] hover:border-accent hover:text-accent-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-line-2 disabled:hover:text-dim"
       >
         {copied ? 'copied' : 'copy'}
       </button>
+      <span aria-live="polite" className="sr-only">
+        {copied ? 'Command copied to clipboard' : ''}
+      </span>
     </div>
   )
 }

--- a/src/data/contact.ts
+++ b/src/data/contact.ts
@@ -35,7 +35,7 @@ export interface ContactLink {
 }
 
 export const CONTACT_STATEMENT =
-  'Looking for ML, systems, or software engineering work -- model internals, infrastructure, or anywhere the constraint is one GPU and a deadline.'
+  'Looking for ML, systems, or software engineering work — model internals, infrastructure, or anywhere the constraint is one GPU and a deadline.'
 
 export const CONTACT_LINKS: readonly ContactLink[] = [
   {

--- a/src/data/sections.ts
+++ b/src/data/sections.ts
@@ -24,28 +24,28 @@ export const sections: SectionMeta[] = [
     label: 'Hero',
     eyebrow: '00 · HELLO',
     title: 'Farhan Mohammed',
-    blurb: 'Placeholder hero copy -- the Go board replay lands in #316.',
+    blurb: 'Placeholder hero copy — the Go board replay lands in #316.',
   },
   {
     id: 'projects',
     label: 'Projects — featured',
     eyebrow: '01 · PROJECTS',
     title: 'Leviathan',
-    blurb: 'Placeholder featured-project copy -- full content lands in #317.',
+    blurb: 'Placeholder featured-project copy — full content lands in #317.',
   },
   {
     id: 'more',
     label: 'Projects — other',
     eyebrow: '',
     title: 'Other work',
-    blurb: 'Placeholder secondary-projects copy -- full content lands in #318.',
+    blurb: 'Placeholder secondary-projects copy — full content lands in #318.',
   },
   {
     id: 'skills',
     label: 'Skills',
     eyebrow: '02 · SKILLS',
     title: 'Skills',
-    blurb: 'Placeholder skills-graph copy -- full content lands in #319.',
+    blurb: 'Placeholder skills-graph copy — full content lands in #319.',
   },
   {
     id: 'path',
@@ -78,3 +78,20 @@ export const sections: SectionMeta[] = [
     blurb: 'What work is being sought, and direct links to reach out.',
   },
 ]
+
+/**
+ * Looks up a section's metadata by `id`, not by array position.
+ *
+ * Every section component used to do `sections[N]` -- e.g. `sections[4]`
+ * for Timeline -- which silently renders the wrong eyebrow/title/blurb the
+ * moment this array is reordered, with no error anywhere. `getSectionMeta`
+ * replaces that: it fails loudly (throws) if `id` doesn't match an entry,
+ * instead of failing silently by rendering the wrong section's copy.
+ */
+export function getSectionMeta(id: string): SectionMeta {
+  const meta = sections.find((section) => section.id === id)
+  if (!meta) {
+    throw new Error(`No section in src/data/sections.ts has id "${id}".`)
+  }
+  return meta
+}

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,22 @@
 
   --font-display: 'Press Start 2P', system-ui, sans-serif;
   --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+
+  /*
+   * `panel:` is the ONE hard breakpoint from src/styles/layout.css
+   * (`@media (min-width: 880px)`, where `.section-shell` gains its fixed
+   * one-viewport height and scroll-snap). Any component-level responsive
+   * class that needs to agree with that layout switch -- going side by
+   * side vs. stacked, for example -- must use `panel:`, never Tailwind's
+   * default `md:` (768px) or `lg:` (1024px), or content can still be in
+   * its narrow/stacked layout while the section has already committed to
+   * a fixed one-screen height. Deliberately not named `md`/`lg`: reusing
+   * either of Tailwind's default names here would silently redefine that
+   * name (768px/1024px) for every OTHER `md:`/`lg:` usage in the codebase
+   * too, not just the layout-critical ones -- `panel:` can't collide with
+   * anything.
+   */
+  --breakpoint-panel: 880px;
 }
 
 html {


### PR DESCRIPTION
## Summary

Correctness-and-consistency fix pass from a code review, covering 7 findings. No visual redesign; styling rules (880px breakpoint, theme tokens, fluid type scale, `var(--space-*)`) were followed throughout.

**Finding 1 — layout breakpoint dead zone.** `src/styles/layout.css` keys its one-viewport-tall section + scroll-snap behaviour to `@media (min-width: 880px)`, but no Tailwind breakpoint matched it: components used `lg:` (1024px) or `md:` (768px) instead, creating a dead zone at 880–1024px where a section had already committed to fixed one-screen height while its content was still stacked/narrow. Added `--breakpoint-panel: 880px` to the `@theme inline` block in `src/index.css` (with a comment tying it explicitly to the layout CSS's 880px switch), and swapped it in for `lg:`/`md:` in `ProjectsFeatured.tsx`, `ProjectsOther.tsx`, and `EducationExperience.tsx`. Chose `panel` over reusing `md`/`lg`: grep confirmed `lg:`/`md:` are used *nowhere else* in `src/`, so there was no actual collision risk today, but `panel` rules one out permanently for whoever adds the next `md:`/`lg:` elsewhere later.

**Finding 2** — corrected `EducationExperience.tsx`'s doc comment, which claimed `lg:` (1024px) was the two-column breakpoint; now documents `panel:` (880px) and explains why `lg:` would be wrong.

**Finding 3** — `CopyInstallCommand.tsx`: added a visually hidden `aria-live="polite"` region that echoes "Command copied to clipboard" when the button's label swaps. When `navigator.clipboard` is unavailable, the button is now `disabled` (with an explanatory `aria-label`) instead of looking active while doing nothing — chose disable-over-hide since the button's presence still communicates "this text is meant to be copied," and the command itself remains plain selectable text either way.

**Finding 4** — `Contact.tsx`: `rel="noreferrer"` → `rel="noopener noreferrer"` on external links.

**Finding 5** — `CONTACT_STATEMENT` in `src/data/contact.ts` used a literal `--` where the rest of the site uses a real em dash; fixed. Also fixed the same slip in the placeholder blurb strings in `src/data/sections.ts`, which I touched anyway for Finding 6.

**Finding 6** — replaced every `sections[N]` positional lookup across `src/components/sections` with `getSectionMeta(id)` (new helper in `src/data/sections.ts`), which throws if `id` doesn't match a real entry instead of silently rendering the wrong section's copy on reorder.

**Finding 7** — `Section.tsx` now takes a `headingId` prop and sets `aria-labelledby` instead of a separately maintained `aria-label`, pointing at the `id` added to each section's own `<h1>`/`<h2>` (including via `SectionPlaceholder`, updated to accept the same prop). All six sections have exactly one top-level heading, so this applied uniformly.

## Verification

- `npm run typecheck`, `npm run lint`, `npm test` (195 tests, 26 files), `npm run build` — all pass.
- Runtime-verified in headless Chromium at 1440×900, 1280×800, 1000×700, 900×900, 879×800, 390×844: measured every `<section>`'s `scrollHeight`/`clientHeight`/viewport `innerHeight`, no internal overflow anywhere.
- Screenshotted `#projects`, `#more`, `#path` at 1000×700 and 900×900 (the old dead zone) and visually confirmed all three now render side-by-side/two-column, not stacked.
- Confirmed no console/page errors introduced (two pre-existing Vercel-analytics 404s are unrelated to this branch, present on `main`).
- Confirmed the Go board animates (stones placed over time, move counter advances) and the hero renders correctly — no regression.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run build`
- [x] Manual runtime check across 6 viewports in headless Chromium, including screenshot verification of the former dead zone
- [x] Go board / hero regression check