### PR TITLE
Shorten Timeline degree titles and rewrite Thesis card copy

### DIFF
--- a/src/data/otherProjects.ts
+++ b/src/data/otherProjects.ts
@@ -50,6 +50,14 @@
  * visualization of the thesis's own premise (simulated organizations of
  * LLM agents, some behaving as insider threats) — not a claim about a
  * specific simulation size or result, neither of which the resume states.
+ *
+ * `THESIS_PROJECT`'s `tagline`/`description` were rewritten per an explicit
+ * owner correction (post-#318): the thesis's real aim is studying the
+ * behavioural precursors that might drift someone toward becoming an
+ * insider threat, before any damage occurs — not detecting a breach after
+ * the fact, and not generating an attack dataset. No numbers, dataset
+ * names, accuracy figures, or citations are invented here or in the copy;
+ * this is an unpublished prototype and none exist in the source material.
  */
 
 export interface OtherProjectStat {
@@ -169,9 +177,17 @@ const THESIS_PROJECT: OtherProject = {
    * completion year yet, so this reports the year it started running).
    */
   badge: { label: 'RUNNING', year: 2026, blink: true },
-  tagline: 'Fake employees, real behavioural data.',
+  /**
+   * `tagline`/`description` rewritten per an explicit owner correction: the
+   * thesis studies the behavioural precursors that might drift someone
+   * toward becoming an insider threat, before any damage occurs -- it is
+   * not a post-breach detector and not an attack-log generator. See the
+   * file header for the fuller note; no numbers/datasets/citations are
+   * invented, as none exist yet for this unpublished prototype.
+   */
+  tagline: 'Not the breach. The build-up to it.',
   description:
-    'A simulated organization staffed by generative LLM agents, some of them behaving as insider threats, producing the labelled behavioural data real security teams can rarely share.',
+    'A simulated office of LLM personas layered with OCC appraisal, PAD mood, and JD-R stress — tracing how grievance and strain drift toward insider risk, the precursors, not the breach.',
   interactive: { kind: 'agent-cluster' },
   stats: [
     { label: 'DEFENSE', value: 'SPRING', suffix: '2027' },

--- a/src/data/otherProjects.ts
+++ b/src/data/otherProjects.ts
@@ -51,13 +51,17 @@
  * LLM agents, some behaving as insider threats) — not a claim about a
  * specific simulation size or result, neither of which the resume states.
  *
- * `THESIS_PROJECT`'s `tagline`/`description` were rewritten per an explicit
- * owner correction (post-#318): the thesis's real aim is studying the
- * behavioural precursors that might drift someone toward becoming an
- * insider threat, before any damage occurs — not detecting a breach after
- * the fact, and not generating an attack dataset. No numbers, dataset
- * names, accuracy figures, or citations are invented here or in the copy;
- * this is an unpublished prototype and none exist in the source material.
+ * `THESIS_PROJECT`'s `tagline`/`description` were rewritten twice: first
+ * per an explicit owner correction (post-#318) to state the thesis's real
+ * aim — studying the build-up that might drift someone toward becoming an
+ * insider threat, before any damage occurs, not detecting a breach after
+ * the fact and not generating an attack dataset; then again per a second
+ * owner correction (thesis-copy) to strip the remaining theory jargon
+ * ("LLM personas", "OCC appraisal", "PAD mood", "JD-R stress",
+ * "precursors") so a non-technical reader gets the idea on first read. No
+ * numbers, dataset names, accuracy figures, or citations are invented
+ * here or in the copy; this is an unpublished prototype and none exist in
+ * the source material.
  */
 
 export interface OtherProjectStat {
@@ -179,15 +183,18 @@ const THESIS_PROJECT: OtherProject = {
   badge: { label: 'RUNNING', year: 2026, blink: true },
   /**
    * `tagline`/`description` rewritten per an explicit owner correction: the
-   * thesis studies the behavioural precursors that might drift someone
-   * toward becoming an insider threat, before any damage occurs -- it is
-   * not a post-breach detector and not an attack-log generator. See the
-   * file header for the fuller note; no numbers/datasets/citations are
-   * invented, as none exist yet for this unpublished prototype.
+   * thesis studies the slow build-up — stress, resentment, feeling
+   * treated unfairly — that might drift someone toward becoming an
+   * insider threat, before any damage occurs -- it is not a post-breach
+   * detector and not an attack-log generator. A second owner correction
+   * (thesis-copy) then stripped the remaining theory jargon so the copy
+   * reads in plain words on first pass. See the file header for the
+   * fuller note; no numbers/datasets/citations are invented, as none
+   * exist yet for this unpublished prototype.
    */
-  tagline: 'Not the breach. The build-up to it.',
+  tagline: 'Not the breach. The build-up.',
   description:
-    'A simulated office of LLM personas layered with OCC appraisal, PAD mood, and JD-R stress — tracing how grievance and strain drift toward insider risk, the precursors, not the breach.',
+    'A simulated office of AI workers with their own moods and feelings, tracking how stress and unfair treatment build up over time — the warning signs before someone turns against their employer.',
   interactive: { kind: 'agent-cluster' },
   stats: [
     { label: 'DEFENSE', value: 'SPRING', suffix: '2027' },

--- a/src/data/timeline.ts
+++ b/src/data/timeline.ts
@@ -6,10 +6,12 @@
  * gitignored, local-only) disagreed with or embellished the resume, the
  * resume wins:
  *
- *   - Degree titles use the resume's exact wording ("Accelerated Master of
- *     Science in Computer Science", "Bachelor of Science in Computer
- *     Science") rather than the reference's abbreviated "MS/BS COMPUTER
- *     SCIENCE".
+ *   - Degree titles are the owner's shortened display wording
+ *     ("Accelerated MS Computer Science", "BS Computer Science") -- an
+ *     explicit owner override of the resume's fuller phrasing ("Accelerated
+ *     Master of Science in Computer Science", "Bachelor of Science in
+ *     Computer Science"), not an error, and also distinct from the
+ *     reference's own abbreviated "MS/BS COMPUTER SCIENCE".
  *   - GPA and honour: resume — "GPA: 3.66/4.0, Magna Cum Laude".
  *   - Dean's List range: resume — "Dean's List: Spring 2022 – Fall 2025".
  *   - Thesis title: resume — "Thesis: Generative Agent-Based Models for
@@ -74,7 +76,7 @@ export const EDUCATION_COLUMN: TimelineColumn = {
       status: 'current',
       statusLabel: 'Studying now',
       dateRange: 'Jan 2026 – May 2027 (Expected)',
-      title: 'Accelerated Master of Science in Computer Science',
+      title: 'Accelerated MS Computer Science',
       qualifier: 'Thesis track',
       bullets: [
         'Thesis: Generative Agent-Based Models for Insider Threat Detection',
@@ -86,7 +88,7 @@ export const EDUCATION_COLUMN: TimelineColumn = {
       status: 'complete',
       statusLabel: 'Graduated',
       dateRange: 'Jan 2022 – Dec 2025',
-      title: 'Bachelor of Science in Computer Science',
+      title: 'BS Computer Science',
       qualifier: 'GPA 3.66/4.0 · Magna Cum Laude',
       bullets: [
         "Dean's List: Spring 2022 – Fall 2025",


### PR DESCRIPTION
## Summary
- Timeline: shortened the two degree titles to the owner's preferred display wording (an explicit deviation from the résumé's fuller phrasing, now documented as such).
- Thesis project card: rewrote the tagline and description to reflect the project's actual framing -- studying the behavioural precursors that drift toward insider risk, not detecting a breach after the fact or generating an attack dataset.

Pure copy changes -- no layout, spacing, or component structure touched.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] Rendered both sections at 1440x900 and 1440x700 via a throwaway Playwright script: no section overflow, the two other-projects cards remain equal height, Timeline hairline row-mates still pair up, screenshots checked visually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified thesis project copy to better explain the gradual buildup of stress and unfair treatment preceding insider-threat behavior.
  * Simplified project descriptions for non-technical readers.
  * Updated education entries with shorter, clearer degree titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->