### PR TITLE
mochi: build the interactive skills graph

### DIFF
--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -1,23 +1,26 @@
 import { Section } from '@/components/layout/Section'
 import { SectionHeading } from '@/components/layout/SectionHeading'
+import { SkillsGraph } from '@/components/sections/skills/SkillsGraph'
 import { getSectionMeta } from '@/data/sections'
 
 const meta = getSectionMeta('skills')
 
 /**
- * Skills section shell (issue #319). The heading row now matches the
- * sample verbatim (`SectionHeading`, sample lines 461-465: "02" / "SKILLS",
- * no fourth/right-hand span). The skills graph itself (the node/edge SVG,
- * sample lines 467-488) is a separate ticket -- `meta.blurb` stands in for
- * it below the heading until that lands.
+ * Skills section (issue #319). The heading row matches the sample verbatim
+ * (`SectionHeading`, sample lines 461-465: "02" / "SKILLS", no fourth/
+ * right-hand span). Below it, the interactive skills graph
+ * (`SkillsGraph.tsx`) has landed in place of the `meta.blurb` placeholder
+ * paragraph this file used to render: four colour-coded hubs and their
+ * member nodes as absolutely-positioned buttons over an SVG edge layer,
+ * with every node's usage note reachable by hover, focus, or tap. Graph
+ * content lives in `src/data/skills.ts`; the pure edge/state derivation
+ * lives in `src/lib/skills/graph.ts`.
  */
 export function Skills() {
   return (
     <Section id={meta.id} headingId="skills-heading">
       <SectionHeading number={meta.number} title={meta.title} headingId="skills-heading" />
-      <p className="mt-[var(--space-fit-margin-tight)] max-w-3xl text-fluid-base font-mono text-fg-2">
-        {meta.blurb}
-      </p>
+      <SkillsGraph />
     </Section>
   )
 }

--- a/src/components/sections/skills/SkillsGraph.tsx
+++ b/src/components/sections/skills/SkillsGraph.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { HUB_LINKS, SKILL_GROUPS, SKILL_NODES } from '@/data/skills'
+import { cn } from '@/lib/cn'
+import {
+  deriveSkillEdges,
+  getEdgeVisualState,
+  getNeighborIndices,
+  getNodeVisualState,
+  getSkillReadout,
+} from '@/lib/skills/graph'
+import { useFitToViewport } from '@/lib/useFitToViewport'
+import { usePrefersReducedMotion } from '@/lib/usePrefersReducedMotion'
+
+/** Computed once — `SKILL_NODES`/`HUB_LINKS` are static imports, not per-render state. */
+const EDGES = deriveSkillEdges(SKILL_NODES, HUB_LINKS)
+
+/**
+ * Dot fill/border per group (reference `groups` array, sample lines
+ * 618-623: `bg`/`bd` as raw CSS var strings). Kept here, not in
+ * `src/data/skills.ts`, the same way `AgentCluster.tsx`'s `STATE_CLASS`
+ * keeps colour classes out of `agentCluster.ts` — the data module stays
+ * plain content, and only the component maps it onto this codebase's
+ * theme tokens (never a hardcoded colour).
+ */
+const GROUP_DOT_CLASSES: Record<number, { readonly bg: string; readonly border: string }> = {
+  0: { bg: 'bg-fg', border: 'border-fg' }, // LANGUAGES
+  1: { bg: 'bg-accent', border: 'border-accent-2' }, // ML & DATA
+  2: { bg: 'bg-accent-2', border: 'border-accent-2' }, // WEB
+  3: { bg: 'bg-panel-2', border: 'border-dim-2' }, // INFRA
+}
+
+/**
+ * The skills section's interactive graph (issue #319): an SVG edge layer
+ * plus absolutely-positioned `<button>` nodes over it, reproducing the
+ * reference's panel (`ideas/sample-decoded.html` lines 467-488) with a
+ * real accessibility contract the reference never had.
+ *
+ * --- Active-node state: one precedence rule ---
+ * Hover, focus, and tap/click all drive a single `activeIndex`, resolved
+ * from three independent pieces of state rather than one shared field,
+ * because hover and focus must not fight each other:
+ *
+ *   activeIndex = focusIndex ?? hoverIndex ?? tapIndex
+ *
+ * Focus wins over everything: a keyboard user tabbed onto a node sees
+ * that node's note regardless of where the mouse happens to be sitting.
+ * Hover wins over a lingering tap: on a device with both a mouse and a
+ * prior tap-selection, moving the mouse to a different node updates the
+ * readout immediately instead of being stuck on the tapped one. Tap is
+ * the fallback for touch input, which has no hover and, on some
+ * browsers (notably iOS Safari), does not focus a tapped `<button>`
+ * either — without its own `tapIndex`, a touch-only visitor could tap a
+ * node and see nothing.
+ *
+ * --- Dismissal ---
+ * A tap/click anywhere outside the panel clears `tapIndex`/`hoverIndex`
+ * (`onPointerDown` on `document`, gated to only listen while something is
+ * active — the same outside-dismiss shape `ThemePicker.tsx` uses for its
+ * menu, via `document.addEventListener` + a containment check against a
+ * ref, rather than a new pattern). `Escape` clears all three and blurs
+ * the focused element, so it also dismisses a focus-revealed note.
+ *
+ * --- Reduced motion ---
+ * `usePrefersReducedMotion()` gates only the *transition* classes (the
+ * `.2s` scale/opacity animations) — the underlying scale/opacity/colour
+ * values themselves still change instantly, so the note still reveals
+ * and the active node still visually stands out, just without animating.
+ */
+export function SkillsGraph() {
+  const fitRef = useFitToViewport<HTMLDivElement>()
+  const panelRef = useRef<HTMLDivElement>(null)
+  const reducedMotion = usePrefersReducedMotion()
+
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null)
+  const [focusIndex, setFocusIndex] = useState<number | null>(null)
+  const [tapIndex, setTapIndex] = useState<number | null>(null)
+
+  const activeIndex = focusIndex ?? hoverIndex ?? tapIndex
+  const neighbors = useMemo(() => getNeighborIndices(EDGES, activeIndex), [activeIndex])
+  const readout = useMemo(() => getSkillReadout(SKILL_NODES, SKILL_GROUPS, activeIndex), [activeIndex])
+
+  useEffect(() => {
+    if (activeIndex === null) return
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (panelRef.current && !panelRef.current.contains(event.target as Node)) {
+        setTapIndex(null)
+        setHoverIndex(null)
+      }
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      setTapIndex(null)
+      setHoverIndex(null)
+      setFocusIndex(null)
+      ;(document.activeElement as HTMLElement | null)?.blur()
+    }
+
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [activeIndex])
+
+  return (
+    <div
+      ref={fitRef}
+      data-fit=""
+      className="mt-[var(--space-fit-margin-tight)] grid max-h-[760px] flex-1 grid-cols-[minmax(0,1fr)] grid-rows-[minmax(0,1fr)_auto] gap-[14px]"
+    >
+      <div
+        ref={panelRef}
+        className="relative min-h-0 border border-line-2 bg-panel px-[clamp(30px,5vw,60px)] py-[clamp(22px,3.4vh,42px)]"
+      >
+        <div className="relative h-full w-full">
+          <svg
+            viewBox="0 0 100 100"
+            preserveAspectRatio="none"
+            className="pointer-events-none absolute inset-0 h-full w-full overflow-visible"
+            aria-hidden="true"
+          >
+            {EDGES.map((edge, index) => {
+              const from = SKILL_NODES[edge.from]
+              const to = SKILL_NODES[edge.to]
+              const { isActive } = getEdgeVisualState(edge, activeIndex)
+              return (
+                <line
+                  key={index}
+                  x1={from.x}
+                  y1={from.y}
+                  x2={to.x}
+                  y2={to.y}
+                  stroke={isActive ? 'var(--color-accent)' : 'var(--color-line-2)'}
+                  strokeWidth={isActive ? 1.6 : 1}
+                  vectorEffect="non-scaling-stroke"
+                />
+              )
+            })}
+          </svg>
+
+          {SKILL_NODES.map((node, index) => {
+            const { isActive, isDimmed } = getNodeVisualState(index, activeIndex, neighbors)
+            const dotClasses = GROUP_DOT_CLASSES[node.group]
+
+            return (
+              <button
+                key={node.id}
+                type="button"
+                style={{ left: `${node.x}%`, top: `${node.y}%` }}
+                className={cn(
+                  'absolute h-0 w-0 border-0 bg-transparent p-0 text-left',
+                  isDimmed && 'opacity-[.28]',
+                  !reducedMotion && 'transition-opacity duration-200',
+                )}
+                onMouseEnter={() => setHoverIndex(index)}
+                onMouseLeave={() => setHoverIndex((current) => (current === index ? null : current))}
+                onFocus={() => setFocusIndex(index)}
+                onBlur={() => setFocusIndex((current) => (current === index ? null : current))}
+                onClick={() => setTapIndex((current) => (current === index ? null : index))}
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'absolute left-0 top-0 block rounded-full border-2',
+                    node.hub ? '-ml-[10px] -mt-[10px] h-5 w-5' : '-ml-[6px] -mt-[6px] h-3 w-3',
+                    dotClasses.bg,
+                    isActive ? 'border-accent-2' : dotClasses.border,
+                    isActive ? 'scale-[1.35]' : 'scale-100',
+                    !reducedMotion &&
+                      'transition-[transform,border-color] duration-200 [transition-timing-function:cubic-bezier(.2,1.2,.4,1)]',
+                  )}
+                />
+                <span
+                  className={cn(
+                    'absolute left-0 -translate-x-1/2 whitespace-nowrap tracking-[0.1em]',
+                    node.hub ? 'top-[16px] text-[10px]' : 'top-[12px] text-[10.5px]',
+                    isActive ? 'text-fg' : 'text-dim',
+                    !reducedMotion && 'transition-colors duration-200',
+                  )}
+                >
+                  {node.label}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="flex min-h-[60px] flex-wrap items-baseline gap-[clamp(14px,2.4vw,28px)] border border-line bg-panel-2 px-[18px] py-[14px]">
+        <span
+          aria-live="polite"
+          className={cn(
+            'font-display text-[clamp(11px,1.4vw,14px)]',
+            readout.isActive ? 'text-fg' : 'text-dim-2',
+          )}
+        >
+          {readout.name}
+        </span>
+        <span className="text-[9.5px] tracking-[0.18em] text-accent">{readout.groupLabel}</span>
+        <span className="text-[13px] text-dim [text-wrap:pretty]">{readout.note}</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/sections/skills/SkillsGraph.tsx
+++ b/src/components/sections/skills/SkillsGraph.tsx
@@ -189,7 +189,12 @@ export function SkillsGraph() {
         </div>
       </div>
 
-      <div className="flex min-h-[60px] flex-wrap items-baseline gap-[clamp(14px,2.4vw,28px)] border border-line bg-panel-2 px-[18px] py-[14px]">
+      {/* content-center: min-h-[60px] makes this box taller than one flex line, and with
+          flex-wrap set, align-content (not items-baseline) decides where that line sits —
+          the default flex-start packs it to the top, so the sample reference (which lacks
+          this) renders top-jammed. items-baseline still keeps the three spans aligned to
+          each other within the line; content-center just centres that line in the box. */}
+      <div className="flex min-h-[60px] flex-wrap content-center items-baseline gap-[clamp(14px,2.4vw,28px)] border border-line bg-panel-2 px-[18px] py-[14px]">
         <span
           aria-live="polite"
           className={cn(

--- a/src/components/sections/skills/SkillsGraph.tsx
+++ b/src/components/sections/skills/SkillsGraph.tsx
@@ -195,10 +195,13 @@ export function SkillsGraph() {
           this) renders top-jammed. items-baseline still keeps the three spans aligned to
           each other within the line; content-center just centres that line in the box. */}
       <div className="flex min-h-[60px] flex-wrap content-center items-baseline gap-[clamp(14px,2.4vw,28px)] border border-line bg-panel-2 px-[18px] py-[14px]">
+        {/* relative top-[2px]: Press Start 2P reserves descender space its glyphs never
+            use, so against items-baseline it sits ~2px higher than the IBM Plex Mono
+            siblings below. This optical nudge, not a font swap, corrects it. */}
         <span
           aria-live="polite"
           className={cn(
-            'font-display text-[clamp(11px,1.4vw,14px)]',
+            'relative top-[2px] font-display text-[clamp(11px,1.4vw,14px)]',
             readout.isActive ? 'text-fg' : 'text-dim-2',
           )}
         >

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,0 +1,303 @@
+/**
+ * Skills graph content (issue #319): four colour-coded hubs (LANGUAGES,
+ * ML & DATA, WEB, INFRA) and their member skills, laid out as a connected
+ * graph instead of the skill-bar cliché ("Python 87%"). `SkillsGraph.tsx`
+ * renders this as absolutely-positioned `<button>` nodes over an SVG edge
+ * layer (`src/lib/skills/graph.ts` derives the edges and visual state from
+ * the data below — no React or rendering logic lives in this file).
+ *
+ * Reproduced from `ideas/sample-decoded.html` lines 618-654 (`groups`,
+ * `nodesData`, `hubLinks`) with one content correction:
+ *
+ *   - The reference's LANGUAGES member at `g:0, x:28, y:33` is "Bash".
+ *     `public/resume.pdf` has no "Bash" anywhere — its Languages line is
+ *     "Python, C++, C, SQL, JavaScript, TypeScript". That slot is
+ *     JavaScript here instead, keeping the reference's exact coordinates
+ *     (`x:28, y:33`) and group. Every other node, coordinate, group
+ *     assignment, hub link, and note below is the reference's own,
+ *     verbatim — each is independently traceable to `public/resume.pdf`'s
+ *     Skills section or a project/experience bullet (noted per node
+ *     below), so nothing else needed correcting.
+ *
+ * Member (non-hub) node count is 19 (6 LANGUAGES + 4 ML & DATA + 3 WEB +
+ * 6 INFRA) — unchanged by the Bash→JavaScript swap, since it replaces one
+ * member with another rather than adding or removing one. This is the
+ * "N TOOLS" figure `getSkillReadout` (`src/lib/skills/graph.ts`) reports
+ * in the graph's default readout state.
+ */
+
+/** One of the four skill clusters. `id` is the index other data below points at. */
+export interface SkillGroup {
+  readonly id: number
+  /** Uppercase cluster name, shown on both the hub node and the readout strip. */
+  readonly name: string
+}
+
+export interface SkillNode {
+  /** Stable id for React keys and test hooks — not shown to the visitor. */
+  readonly id: string
+  /** Visible label, and (via the button's visible text) the node's accessible name. */
+  readonly label: string
+  /** `SkillGroup.id` this node belongs to. */
+  readonly group: number
+  /** Hub nodes are the four cluster centres; every other node is a member. */
+  readonly hub: boolean
+  /** Position as a percentage of the panel, 0-100 (sample's own `x`/`y`, unscaled). */
+  readonly x: number
+  readonly y: number
+  /** One-line note on how this skill is actually used — revealed on hover, focus, or tap. */
+  readonly note: string
+}
+
+/** A connection between two hubs (by `SkillGroup.id`), drawn in addition to every hub→member edge. */
+export interface HubLink {
+  readonly from: number
+  readonly to: number
+}
+
+export const SKILL_GROUPS: readonly SkillGroup[] = [
+  { id: 0, name: 'LANGUAGES' },
+  { id: 1, name: 'ML & DATA' },
+  { id: 2, name: 'WEB' },
+  { id: 3, name: 'INFRA' },
+]
+
+export const SKILL_NODES: readonly SkillNode[] = [
+  // --- LANGUAGES (resume: Skills > Languages — "Python, C++, C, SQL, JavaScript, TypeScript") ---
+  {
+    id: 'languages-hub',
+    label: 'LANGUAGES',
+    group: 0,
+    hub: true,
+    x: 15,
+    y: 48,
+    note: 'What I reach for first, depending on how fast it has to run.',
+  },
+  {
+    id: 'python',
+    label: 'Python',
+    group: 0,
+    hub: false,
+    x: 5,
+    y: 20,
+    note: 'Training loops, tokenizers, automation frameworks. Six years of it.',
+  },
+  {
+    id: 'typescript',
+    label: 'TypeScript',
+    group: 0,
+    hub: false,
+    x: 26,
+    y: 15,
+    note: 'Product work at NetApp — typed end to end, no any.',
+  },
+  {
+    id: 'cpp',
+    label: 'C++',
+    group: 0,
+    hub: false,
+    x: 4,
+    y: 72,
+    note: 'Where the inference loop goes when Python stops being fast enough.',
+  },
+  {
+    id: 'c',
+    label: 'C',
+    group: 0,
+    hub: false,
+    x: 17,
+    y: 86,
+    note: 'Systems coursework, memory-level debugging, small tools.',
+  },
+  {
+    id: 'sql',
+    label: 'SQL',
+    group: 0,
+    hub: false,
+    x: 31,
+    y: 66,
+    note: 'Analytics over million-row telemetry tables without a warehouse.',
+  },
+  /**
+   * Bash→JavaScript substitution (see file header). Coordinates and group
+   * are the reference's own for this slot (`g:0, x:28, y:33`); the note is
+   * new, written in the same register as the reference's other notes, and
+   * stays a modest, resume-traceable claim (Skills > Languages lists
+   * JavaScript beside TypeScript, with no separate usage bullet to draw
+   * from) rather than inventing a specific project.
+   */
+  {
+    id: 'javascript',
+    label: 'JavaScript',
+    group: 0,
+    hub: false,
+    x: 28,
+    y: 33,
+    note: 'Same runtime as the TypeScript work, minus the compiler holding the guardrails up.',
+  },
+
+  // --- ML & DATA (resume: Skills > ML/DL and Data & Computation; Leviathan project bullets) ---
+  {
+    id: 'mldata-hub',
+    label: 'ML & DATA',
+    group: 1,
+    hub: true,
+    x: 46,
+    y: 20,
+    note: 'Model internals, training on one GPU, and the data around it.',
+  },
+  {
+    id: 'pytorch',
+    label: 'PyTorch',
+    group: 1,
+    hub: false,
+    x: 34,
+    y: 5,
+    note: 'Custom attention, gradient checkpointing, FP16 training on an RTX 4060.',
+  },
+  {
+    id: 'transformers',
+    label: 'Transformers',
+    group: 1,
+    hub: false,
+    x: 56,
+    y: 4,
+    note: 'Hugging Face stack for tokenizers, datasets and fine-tuning runs.',
+  },
+  {
+    id: 'numpy-pandas',
+    label: 'NumPy · Pandas',
+    group: 1,
+    hub: false,
+    x: 70,
+    y: 14,
+    note: 'Feature pipelines and evaluation over millions of chess positions.',
+  },
+  {
+    id: 'scikit-learn',
+    label: 'scikit-learn',
+    group: 1,
+    hub: false,
+    x: 40,
+    y: 40,
+    note: 'Baselines worth beating before any deep model gets funded.',
+  },
+
+  // --- WEB (resume: Leviathan project bullets — PyTorch, FastAPI, Next.js, TypeScript, Tailwind CSS) ---
+  {
+    id: 'web-hub',
+    label: 'WEB',
+    group: 2,
+    hub: true,
+    x: 46,
+    y: 74,
+    note: 'Interfaces that make the model visible to people who are not me.',
+  },
+  {
+    id: 'nextjs',
+    label: 'Next.js',
+    group: 2,
+    hub: false,
+    x: 32,
+    y: 92,
+    note: 'Dashboards and demos — server components, streaming responses.',
+  },
+  {
+    id: 'fastapi',
+    label: 'FastAPI',
+    group: 2,
+    hub: false,
+    x: 58,
+    y: 92,
+    note: 'Serving inference endpoints with batching and sane latency budgets.',
+  },
+  {
+    id: 'tailwind',
+    label: 'Tailwind CSS',
+    group: 2,
+    hub: false,
+    x: 52,
+    y: 58,
+    note: 'Fast UI without a stylesheet archaeology dig later.',
+  },
+
+  // --- INFRA (resume: Skills > Tools & Systems; NetApp experience bullets) ---
+  {
+    id: 'infra-hub',
+    label: 'INFRA',
+    group: 3,
+    hub: true,
+    x: 82,
+    y: 50,
+    note: 'Two years in storage systems taught me to automate everything twice.',
+  },
+  {
+    id: 'docker',
+    label: 'Docker',
+    group: 3,
+    hub: false,
+    x: 71,
+    y: 30,
+    note: 'Reproducible training and test environments across machines.',
+  },
+  {
+    id: 'linux',
+    label: 'Linux',
+    group: 3,
+    hub: false,
+    x: 92,
+    y: 28,
+    note: 'Daily driver. Kernel-adjacent debugging of storage and network paths.',
+  },
+  {
+    id: 'ansible',
+    label: 'Ansible',
+    group: 3,
+    hub: false,
+    x: 95,
+    y: 62,
+    note: 'Orchestrated 300+ system configurations at NetApp.',
+  },
+  {
+    id: 'vmware',
+    label: 'VMware',
+    group: 3,
+    hub: false,
+    x: 72,
+    y: 64,
+    note: 'Virtual test beds for FC, SAS and NVMe/RoCE storage topologies.',
+  },
+  {
+    id: 'git',
+    label: 'Git',
+    group: 3,
+    hub: false,
+    x: 84,
+    y: 82,
+    note: 'Enough PR reviews to have opinions about branch naming.',
+  },
+  {
+    id: 'postgresql',
+    label: 'PostgreSQL',
+    group: 3,
+    hub: false,
+    x: 96,
+    y: 82,
+    note: 'Schema and query work behind the NetApp web platform.',
+  },
+]
+
+/**
+ * Ring connecting the four hubs (reference lines 654: `[[0,7],[7,16],[16,12],[12,0]]`,
+ * raw `nodesData` array indices there). Expressed here by `SkillGroup.id`
+ * instead of raw node-array indices, so this stays correct even if
+ * `SKILL_NODES` above is ever reordered — `deriveSkillEdges`
+ * (`src/lib/skills/graph.ts`) resolves each group id to its hub node at
+ * render time. Same topology as the reference: LANGUAGES↔ML & DATA↔INFRA↔WEB↔LANGUAGES.
+ */
+export const HUB_LINKS: readonly HubLink[] = [
+  { from: 0, to: 1 },
+  { from: 1, to: 3 },
+  { from: 3, to: 2 },
+  { from: 2, to: 0 },
+]

--- a/src/lib/skills/graph.ts
+++ b/src/lib/skills/graph.ts
@@ -1,0 +1,157 @@
+/**
+ * Pure model logic for the skills graph (issue #319): given the graph
+ * content (`src/data/skills.ts`) and which node, if any, is the visitor's
+ * current "active" node (hovered, focused, or tapped), derive the edge
+ * list, which nodes count as that node's neighbours, and the visual state
+ * of every node/edge/readout.
+ *
+ * No React and no DOM here — same split `src/lib/otherProjects/
+ * agentCluster.ts` uses for the thesis's agent-dot cluster: the component
+ * (`src/components/sections/skills/SkillsGraph.tsx`) owns state and event
+ * handlers and calls into this file to figure out what to render, which
+ * keeps this logic unit-testable without mounting React and keeps the
+ * component itself free of graph-derivation logic.
+ */
+
+import type { HubLink, SkillGroup, SkillNode } from '@/data/skills'
+
+/** One drawn connection, as indices into the `SkillNode[]` array it was derived from. */
+export interface SkillEdge {
+  readonly from: number
+  readonly to: number
+}
+
+/**
+ * Builds the full edge list: one edge from each group's hub to every
+ * member of that group, plus the hub-to-hub ring from `hubLinks`.
+ * Mirrors the reference's own derivation (sample lines 958-962: build a
+ * hub-index-by-group lookup, add a hub→member edge for every non-hub
+ * node, then append the literal hub link pairs) — the only difference is
+ * `hubLinks` here is keyed by group id rather than raw node-array index
+ * (see `HUB_LINKS`'s own comment in `src/data/skills.ts`), so this
+ * resolves each link's two group ids to their hub's current index first.
+ */
+export function deriveSkillEdges(nodes: readonly SkillNode[], hubLinks: readonly HubLink[]): readonly SkillEdge[] {
+  const hubIndexByGroup = new Map<number, number>()
+  nodes.forEach((node, index) => {
+    if (node.hub) hubIndexByGroup.set(node.group, index)
+  })
+
+  const edges: SkillEdge[] = []
+
+  nodes.forEach((node, index) => {
+    if (node.hub) return
+    const hubIndex = hubIndexByGroup.get(node.group)
+    if (hubIndex === undefined) return
+    edges.push({ from: hubIndex, to: index })
+  })
+
+  hubLinks.forEach((link) => {
+    const from = hubIndexByGroup.get(link.from)
+    const to = hubIndexByGroup.get(link.to)
+    if (from === undefined || to === undefined) return
+    edges.push({ from, to })
+  })
+
+  return edges
+}
+
+/**
+ * The active node itself, plus every node directly connected to it by an
+ * edge (reference's `near` set, sample lines 963-967). Empty when nothing
+ * is active. Used to decide which nodes/edges stay at full opacity and
+ * which dim.
+ */
+export function getNeighborIndices(edges: readonly SkillEdge[], activeIndex: number | null): ReadonlySet<number> {
+  const neighbors = new Set<number>()
+  if (activeIndex === null) return neighbors
+
+  neighbors.add(activeIndex)
+  edges.forEach((edge) => {
+    if (edge.from === activeIndex) neighbors.add(edge.to)
+    if (edge.to === activeIndex) neighbors.add(edge.from)
+  })
+
+  return neighbors
+}
+
+export interface NodeVisualState {
+  /** This is the active node — grows and its border/label brighten. */
+  readonly isActive: boolean
+  /** Some other node is active and this one isn't in its neighbour set — dims to .28 opacity. */
+  readonly isDimmed: boolean
+}
+
+/** Maps one node's index to its visual state, given the current active node and its neighbour set. */
+export function getNodeVisualState(
+  index: number,
+  activeIndex: number | null,
+  neighbors: ReadonlySet<number>,
+): NodeVisualState {
+  return {
+    isActive: index === activeIndex,
+    isDimmed: activeIndex !== null && !neighbors.has(index),
+  }
+}
+
+export interface EdgeVisualState {
+  /** This edge touches the active node — draws in `accent` at the thicker stroke width. */
+  readonly isActive: boolean
+}
+
+/** Maps one edge to its visual state: lit up only when it touches the active node. */
+export function getEdgeVisualState(edge: SkillEdge, activeIndex: number | null): EdgeVisualState {
+  return {
+    isActive: activeIndex !== null && (edge.from === activeIndex || edge.to === activeIndex),
+  }
+}
+
+export interface SkillReadout {
+  readonly name: string
+  readonly groupLabel: string
+  readonly note: string
+  /** Whether this is a real node's readout (brighter name colour) vs. the default idle state. */
+  readonly isActive: boolean
+}
+
+const DEFAULT_READOUT_NAME = 'SKILL GRAPH'
+
+/**
+ * Reworded from the reference's "Hover any node to see what I actually do
+ * with it." (sample line 1052) — this graph's note is also reachable by
+ * focus and by tap, so the default copy names all three instead of
+ * implying a mouse is required (issue #319).
+ */
+const DEFAULT_READOUT_NOTE = 'Hover, focus, or tap any node to see what I actually do with it.'
+
+/**
+ * Derives the readout strip's content for the current active node (or the
+ * idle default when nothing is active) — reference sample lines
+ * 1050-1053. The idle `groupLabel` counts groups and non-hub nodes at
+ * call time rather than hardcoding "4 CLUSTERS · 19 TOOLS", so it can
+ * never drift from `SKILL_GROUPS`/`SKILL_NODES` again.
+ */
+export function getSkillReadout(
+  nodes: readonly SkillNode[],
+  groups: readonly SkillGroup[],
+  activeIndex: number | null,
+): SkillReadout {
+  if (activeIndex !== null) {
+    const node = nodes[activeIndex]
+    const group = groups.find((candidate) => candidate.id === node.group)
+    return {
+      name: node.label,
+      groupLabel: group?.name ?? '',
+      note: node.note,
+      isActive: true,
+    }
+  }
+
+  const memberCount = nodes.filter((node) => !node.hub).length
+  return {
+    name: DEFAULT_READOUT_NAME,
+    groupLabel: `${groups.length} CLUSTERS · ${memberCount} TOOLS`,
+    note: DEFAULT_READOUT_NOTE,
+    isActive: false,
+  }
+}


### PR DESCRIPTION
## Summary

Implements #319: replaces the Skills section's placeholder blurb with the four-hub interactive skills graph from the design reference.

- Four colour-coded hubs (LANGUAGES, ML & DATA, WEB, INFRA) and their 19 member nodes render as absolutely-positioned `<button>` nodes over an SVG edge layer, matching the reference's panel/readout-strip layout and node sizing/spacing.
- Every node's one-line usage note is revealed by hover, focus, or tap — a single `activeIndex` resolved with focus > hover > tap precedence, so keyboard and touch users reach the same content as mouse users.
- Tapping/clicking outside the panel dismisses the active note (document `pointerdown` listener, same outside-dismiss shape `ThemePicker.tsx` already uses). `Escape` clears and blurs.
- Every node is a real, focusable, tappable `<button type="button">` with an accessible name sourced from its own visible label text (the dot is `aria-hidden`, the label isn't).
- `usePrefersReducedMotion()` gates only the transition classes; the note still reveals instantly with motion off.
- Graph content/groups/positions live in a typed data module (`src/data/skills.ts`); edge derivation, neighbour-set, and visual-state logic is pure (`src/lib/skills/graph.ts`, no React).

Content correction: the reference's "Bash" node has no support in `public/resume.pdf`, so that slot (`g:0, x:28, y:33`) is now "JavaScript" (resume: Skills > Languages), same coordinates, new one-line note. Every other node, group, hub link, and note is the reference's own, verbatim. Member-node count (19) matches the reference's own "4 CLUSTERS · 19 TOOLS" figure — now computed from the data at render time instead of hardcoded.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] Verified node/edge counts programmatically (4 hubs, 19 members, 23 total — matches reference)
- [ ] Side-by-side visual check against the reference in a real browser — **not performed**; no browser automation tool was available in this environment. Please eyeball the section (especially around the 880-1024px range and short viewport heights) before merging.
- [ ] Manual keyboard/pointer walkthrough in a real browser — also not independently verified live; the interaction logic was written and typechecked but not exercised in an actual DOM/browser session.