### PR TITLE
Mobile pass: hamburger nav, header layout, project cards, skills graph, timeline

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" rx="4" fill="#FF8547"/>
+  <rect width="32" height="32" rx="4" fill="#5468FF"/>
   <text x="16" y="22" font-family="'Press Start 2P',monospace" font-size="14" fill="#050609" text-anchor="middle">FM</text>
 </svg>

--- a/src/components/layout/Clock.tsx
+++ b/src/components/layout/Clock.tsx
@@ -2,9 +2,12 @@ import { useEffect, useState } from 'react'
 import { usePrefersReducedMotion } from '@/lib/usePrefersReducedMotion'
 import { cn } from '@/lib/cn'
 
-function formatClock(date: Date): string {
+function formatClock(date: Date): { hm: string; s: string } {
   const pad = (value: number) => String(value).padStart(2, '0')
-  return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  return {
+    hm: `${pad(date.getHours())}:${pad(date.getMinutes())}`,
+    s: pad(date.getSeconds()),
+  }
 }
 
 /**
@@ -17,6 +20,15 @@ function formatClock(date: Date): string {
  * stops blinking and sits solid. A visitor who has asked for less motion
  * gets a clock that reads as "the time", not a widget that updates in
  * front of them every second.
+ *
+ * Mobile-only truncation (owner review on #314's PR): below the 880px
+ * `panel:` breakpoint the header shows hours and minutes only (`13:55`,
+ * not `13:55:11`) -- the seconds field is measured out of a phone-width
+ * header once the theme picker and hamburger are also in the row.
+ * `formatClock` splits the value into an `hm` and `s` part so the `:ss`
+ * suffix can be a separate span hidden below `panel:` in CSS rather than
+ * reformatting the string in JS per breakpoint; the `sr-only` live value
+ * always announces full hh:mm:ss precision regardless of viewport.
  */
 export function Clock() {
   const reducedMotion = usePrefersReducedMotion()
@@ -29,12 +41,17 @@ export function Clock() {
     return () => clearInterval(id)
   }, [reducedMotion])
 
-  const label = formatClock(now)
+  const { hm, s } = formatClock(now)
 
   return (
     <span className="flex items-center gap-[7px] text-[10.5px] tracking-[0.1em] text-dim-2">
-      <span aria-hidden="true">{label}</span>
-      <span className="sr-only">Current time {label}</span>
+      <span aria-hidden="true">
+        {hm}
+        <span className="hidden panel:inline">:{s}</span>
+      </span>
+      <span className="sr-only">
+        Current time {hm}:{s}
+      </span>
       <span
         aria-hidden="true"
         className={cn(

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { navItems } from '@/data/nav'
 import { cn } from '@/lib/cn'
 import { Clock } from './Clock'
+import { MobileNav } from './MobileNav'
 import { ScrollProgressBar } from './ScrollProgressBar'
 import { ThemePicker } from './ThemePicker'
 
@@ -9,6 +10,11 @@ import { ThemePicker } from './ThemePicker'
  * the theme picker (`ThemePicker`), and a live clock, with the scroll
  * progress bar as its last child (matching the design reference, which
  * nests the bar inside the header).
+ *
+ * Below the 880px `panel:` breakpoint (#314) the inline `<nav>` is hidden
+ * (`hidden panel:flex`) and `MobileNav` takes its place, so the header
+ * never has to cram all four links plus the theme picker into a phone-width
+ * bar -- see `MobileNav.tsx` for the full-screen menu it opens.
  *
  * Fixed-header / scroll-snap interaction: `scroll-snap-align: start`
  * (`.section-shell`, src/styles/layout.css) aligns each section to the
@@ -38,7 +44,7 @@ export function Header() {
 
         <nav
           aria-label="Section"
-          className="ml-auto flex gap-[clamp(10px,1.8vw,24px)] text-[10.5px] tracking-[0.16em] text-dim"
+          className="ml-auto hidden gap-[clamp(10px,1.8vw,24px)] text-[10.5px] tracking-[0.16em] text-dim panel:flex"
         >
           {navItems.map((item) => (
             <a
@@ -50,6 +56,8 @@ export function Header() {
             </a>
           ))}
         </nav>
+
+        <MobileNav />
 
         <ThemePicker />
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -16,6 +16,19 @@ import { ThemePicker } from './ThemePicker'
  * never has to cram all four links plus the theme picker into a phone-width
  * bar -- see `MobileNav.tsx` for the full-screen menu it opens.
  *
+ * Mobile-only trailing-group layout (owner review on #314's PR): below
+ * 880px the hamburger trigger must be the right-most element, with the
+ * theme picker collapsed to a single swatch and the clock dropping its
+ * seconds -- all three purely mobile concerns, so all three live as
+ * `panel:`-gated classes inside `MobileNav`/`ThemePicker`/`Clock`
+ * themselves rather than here. This component still owns the ordering:
+ * `MobileNav`'s wrapper is `order-last` (inert at desktop, where it's
+ * `panel:hidden` and out of flow entirely) and `ThemePicker` carries the
+ * `ml-auto` below 880px (the inline `<nav>` supplies it above 880px, so
+ * `ThemePicker` cancels its own with `panel:ml-0` there) so the trailing
+ * group -- theme picker, clock, hamburger, in that DOM/visual order --
+ * is pushed flush right as one unit.
+ *
  * Fixed-header / scroll-snap interaction: `scroll-snap-align: start`
  * (`.section-shell`, src/styles/layout.css) aligns each section to the
  * top of the scrollport, and native `#id` anchor jumps land at the exact

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -24,11 +24,11 @@ import { ThemePicker } from './ThemePicker'
  * `panel:`-gated classes inside `MobileNav`/`ThemePicker`/`Clock`
  * themselves rather than here. This component still owns the ordering:
  * `MobileNav`'s wrapper is `order-last` (inert at desktop, where it's
- * `panel:hidden` and out of flow entirely) and `ThemePicker` carries the
- * `ml-auto` below 880px (the inline `<nav>` supplies it above 880px, so
- * `ThemePicker` cancels its own with `panel:ml-0` there) so the trailing
- * group -- theme picker, clock, hamburger, in that DOM/visual order --
- * is pushed flush right as one unit.
+ * `panel:hidden` and out of flow entirely) and `ThemePicker`'s own flex-item
+ * root carries the `ml-auto` below 880px (the inline `<nav>` supplies it
+ * above 880px, so `ThemePicker` cancels its own with `panel:ml-0` there) so
+ * the trailing group -- theme picker, clock, hamburger, in that DOM/visual
+ * order -- is pushed flush right as one unit.
  *
  * Fixed-header / scroll-snap interaction: `scroll-snap-align: start`
  * (`.section-shell`, src/styles/layout.css) aligns each section to the

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,3 +1,4 @@
+import { useLayoutEffect, useRef } from 'react'
 import { navItems } from '@/data/nav'
 import { cn } from '@/lib/cn'
 import { Clock } from './Clock'
@@ -39,16 +40,39 @@ import { ThemePicker } from './ThemePicker'
  * `scroll-snap-type`) -- it relies purely on every section's own top
  * `padding-block` clamp (`.section-shell`) already exceeding the header's
  * rendered height, so the header only ever overlaps padding, never real
- * content. This component previously measured its own rendered height
- * and published it as a `--header-h` custom property so `layout.css`
- * could offset `scroll-padding-top` by it; that offset was removed
- * (mochi/style-match audit -- see `layout.css`) because stacking it on
- * top of the section's own padding double-offset every section below the
- * header, so the height-measuring effect that fed it is removed here too.
+ * content. This held at 880px+ (`clamp(4rem,9vh,5.5rem)` there comfortably
+ * clears the header) but not below it, where `.section-shell`'s base
+ * padding floors at 2.4rem/38.4px against a mobile header nearer 55-60px
+ * tall -- the hero eyebrow and every other section's heading row rendered
+ * partly behind the header (#314 owner review). `--header-h` is
+ * republished here (measured via `ResizeObserver`, not guessed, since the
+ * header's rendered height changes with the fluid type scale) so
+ * `layout.css`'s base `.section-shell` rule can clear it with
+ * `max(var(--space-lg), var(--header-h))`; the 880px+ override still uses
+ * its own clamp unconditionally, so desktop is unaffected.
  */
 export function Header() {
+  const headerRef = useRef<HTMLElement>(null)
+
+  useLayoutEffect(() => {
+    const el = headerRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+
+    const publish = () => {
+      document.documentElement.style.setProperty('--header-h', `${el.getBoundingClientRect().height}px`)
+    }
+
+    publish()
+    const observer = new ResizeObserver(publish)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   return (
-    <header className="fixed inset-x-0 top-0 z-[60] border-b border-line bg-bg-glass backdrop-blur-[9px]">
+    <header
+      ref={headerRef}
+      className="fixed inset-x-0 top-0 z-[60] border-b border-line bg-bg-glass backdrop-blur-[9px]"
+    >
       <div className="flex items-center gap-[clamp(10px,1.6vw,20px)] px-[clamp(20px,4vw,56px)] py-[12px]">
         <a href="#top" className="flex items-center gap-[9px] font-display text-[11px] text-fg">
           <span aria-hidden="true" className="inline-block h-[11px] w-[11px] rounded-full bg-fg" />

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { navItems } from '@/data/nav'
 import { cn } from '@/lib/cn'
 
@@ -49,6 +50,22 @@ import { cn } from '@/lib/cn'
  *    trap -- Tab still leaves the panel, it just has nothing invisible
  *    left to land on) is applied to everything else in the document while
  *    open and lifted on close.
+ *
+ * The open panel itself is rendered through a `createPortal` into
+ * `document.body` rather than in place. `Header.tsx`'s `<header>` sets
+ * `backdrop-blur-[9px]` (a `filter`), which per the CSS containing-block
+ * rules makes `header` itself the containing block for any
+ * `position:fixed` descendant -- so a plain in-place `fixed inset-0` here
+ * sizes/positions against the header's own (content-sized) box instead of
+ * the viewport. The header's auto height is set only by its normal-flow
+ * top bar, so the panel's background box ended up pinned to that thin
+ * strip while its flex content overflowed downward past it, unbacked,
+ * directly on top of the real page -- the "transparent panel, floating
+ * nav text over the hero" defect this shipped with. Portalling to
+ * `document.body` (which has no containing-block-establishing ancestor)
+ * restores `fixed inset-0` to a solid, opaque, full-viewport surface, with
+ * the four nav links sitting on top of it and nothing else visible
+ * through it.
  */
 export function MobileNav() {
   const [open, setOpen] = useState(false)
@@ -107,7 +124,7 @@ export function MobileNav() {
   const close = () => setOpen(false)
 
   return (
-    <div ref={wrapperRef} className="ml-auto panel:hidden">
+    <div ref={wrapperRef} className="order-last panel:hidden">
       <button
         ref={triggerRef}
         type="button"
@@ -142,43 +159,43 @@ export function MobileNav() {
         </span>
       </button>
 
-      {open ? (
-        <div
-          id={panelId}
-          className="fixed inset-0 z-[70] flex flex-col bg-bg"
-        >
-          <div className="flex items-center justify-end px-[clamp(20px,4vw,56px)] py-[12px]">
-            <button
-              type="button"
-              aria-label="Close menu"
-              onClick={close}
-              className="flex h-[30px] w-[30px] items-center justify-center border border-line-2 text-fg"
-            >
-              <span aria-hidden="true" className="relative block h-[14px] w-[14px]">
-                <span className="absolute inset-x-0 top-1/2 h-[1.5px] -translate-y-1/2 rotate-45 bg-fg" />
-                <span className="absolute inset-x-0 top-1/2 h-[1.5px] -translate-y-1/2 -rotate-45 bg-fg" />
-              </span>
-            </button>
-          </div>
+      {open
+        ? createPortal(
+            <div id={panelId} className="fixed inset-0 z-[70] flex flex-col bg-bg">
+              <div className="flex items-center justify-end px-[clamp(20px,4vw,56px)] py-[12px]">
+                <button
+                  type="button"
+                  aria-label="Close menu"
+                  onClick={close}
+                  className="flex h-[30px] w-[30px] items-center justify-center border border-line-2 text-fg"
+                >
+                  <span aria-hidden="true" className="relative block h-[14px] w-[14px]">
+                    <span className="absolute inset-x-0 top-1/2 h-[1.5px] -translate-y-1/2 rotate-45 bg-fg" />
+                    <span className="absolute inset-x-0 top-1/2 h-[1.5px] -translate-y-1/2 -rotate-45 bg-fg" />
+                  </span>
+                </button>
+              </div>
 
-          <nav
-            aria-label="Section"
-            className="flex flex-1 flex-col items-center justify-center gap-[var(--space-md)]"
-          >
-            {navItems.map((item, index) => (
-              <a
-                key={item.id}
-                ref={index === 0 ? firstLinkRef : undefined}
-                href={`#${item.id}`}
-                onClick={close}
-                className="font-display text-fluid-lg tracking-[0.14em] text-dim transition-colors duration-150 hover:text-accent-2"
+              <nav
+                aria-label="Section"
+                className="flex flex-1 flex-col items-center justify-center gap-[var(--space-md)]"
               >
-                {item.label}
-              </a>
-            ))}
-          </nav>
-        </div>
-      ) : null}
+                {navItems.map((item, index) => (
+                  <a
+                    key={item.id}
+                    ref={index === 0 ? firstLinkRef : undefined}
+                    href={`#${item.id}`}
+                    onClick={close}
+                    className="font-display text-fluid-lg tracking-[0.14em] text-dim transition-colors duration-150 hover:text-accent-2"
+                  >
+                    {item.label}
+                  </a>
+                ))}
+              </nav>
+            </div>,
+            document.body,
+          )
+        : null}
     </div>
   )
 }

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { navItems } from '@/data/nav'
+import { cn } from '@/lib/cn'
+
+/**
+ * Mobile hamburger nav (#314).
+ *
+ * The design reference (`ideas/Portfolio.html`) has no mobile nav at all --
+ * below the 880px `panel:` breakpoint it would just cram all four links,
+ * the theme picker, and the clock into the header, which stops being
+ * usable well before 375px. This is new work, not a port: the header's
+ * inline `<nav>` (see `Header.tsx`) is hidden below the breakpoint and this
+ * component's trigger button takes its place, opening a full-screen list
+ * of the same `navItems` the desktop nav renders.
+ *
+ * Interaction contract, modelled on `ThemePicker`'s trigger/dismiss pattern
+ * but deliberately NOT reusing its focus-out/outside-click dismissal or a
+ * focus trap: a full-screen panel has no "outside" to click, and the issue
+ * asks explicitly for a menu that "closes without trapping focus" -- Tab
+ * is free to leave the panel rather than cycling back through it. Opening
+ * moves focus to the first destination link (so keyboard users don't have
+ * to Tab past the close button to start navigating); Escape closes and
+ * returns focus to the trigger; picking a destination lets the anchor's
+ * default `#id` jump happen and closes the panel in the same click, so
+ * scrolling there and dismissing the menu is one gesture.
+ *
+ * Document scroll is suspended while the panel is open (`documentElement`
+ * is the real scroll container per `src/styles/layout.css`'s scroll-snap
+ * note) so the full-screen list doesn't fight page scroll underneath it.
+ */
+export function MobileNav() {
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const firstLinkRef = useRef<HTMLAnchorElement>(null)
+  const panelId = useId()
+
+  useEffect(() => {
+    if (!open) return
+
+    firstLinkRef.current?.focus()
+
+    const root = document.documentElement
+    const previousOverflow = root.style.overflow
+    root.style.overflow = 'hidden'
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+      setOpen(false)
+      triggerRef.current?.focus()
+    }
+    document.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      root.style.overflow = previousOverflow
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  const close = () => setOpen(false)
+
+  return (
+    <div className="ml-auto panel:hidden">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-expanded={open}
+        aria-controls={panelId}
+        aria-label={open ? 'Close menu' : 'Open menu'}
+        onClick={() => setOpen((value) => !value)}
+        className={cn(
+          'relative flex h-[30px] w-[30px] shrink-0 items-center justify-center',
+          'border border-line-2 bg-transparent transition-colors duration-150 hover:border-accent',
+        )}
+      >
+        <span aria-hidden="true" className="relative block h-[10px] w-[14px]">
+          <span
+            className={cn(
+              'absolute inset-x-0 top-0 h-[1.5px] bg-fg transition-transform duration-150',
+              open && 'translate-y-[4.25px] rotate-45',
+            )}
+          />
+          <span
+            className={cn(
+              'absolute inset-x-0 top-1/2 h-[1.5px] -translate-y-1/2 bg-fg transition-opacity duration-150',
+              open && 'opacity-0',
+            )}
+          />
+          <span
+            className={cn(
+              'absolute inset-x-0 bottom-0 h-[1.5px] bg-fg transition-transform duration-150',
+              open && '-translate-y-[4.25px] -rotate-45',
+            )}
+          />
+        </span>
+      </button>
+
+      {open ? (
+        <div
+          id={panelId}
+          className="fixed inset-0 z-[70] flex flex-col bg-bg"
+        >
+          <div className="flex items-center justify-end px-[clamp(20px,4vw,56px)] py-[12px]">
+            <button
+              type="button"
+              aria-label="Close menu"
+              onClick={close}
+              className="flex h-[30px] w-[30px] items-center justify-center border border-line-2 text-fg"
+            >
+              <span aria-hidden="true" className="relative block h-[14px] w-[14px]">
+                <span className="absolute inset-x-0 top-1/2 h-[1.5px] -translate-y-1/2 rotate-45 bg-fg" />
+                <span className="absolute inset-x-0 top-1/2 h-[1.5px] -translate-y-1/2 -rotate-45 bg-fg" />
+              </span>
+            </button>
+          </div>
+
+          <nav
+            aria-label="Section"
+            className="flex flex-1 flex-col items-center justify-center gap-[var(--space-md)]"
+          >
+            {navItems.map((item, index) => (
+              <a
+                key={item.id}
+                ref={index === 0 ? firstLinkRef : undefined}
+                href={`#${item.id}`}
+                onClick={close}
+                className="font-display text-fluid-lg tracking-[0.14em] text-dim transition-colors duration-150 hover:text-accent-2"
+              >
+                {item.label}
+              </a>
+            ))}
+          </nav>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -27,9 +27,32 @@ import { cn } from '@/lib/cn'
  * Document scroll is suspended while the panel is open (`documentElement`
  * is the real scroll container per `src/styles/layout.css`'s scroll-snap
  * note) so the full-screen list doesn't fight page scroll underneath it.
+ *
+ * Two things outside the panel itself have to be kept in sync while it's
+ * open, both driven from this one effect:
+ *
+ * 1. Crossing the 880px `panel:` breakpoint (matching `useFitToViewport`'s
+ *    `matchMedia` pattern) purely by CSS -- `panel:hidden` on this
+ *    component's own root -- would hide the fixed full-screen panel (it's
+ *    a descendant, so `display:none` cascades to it) while leaving `open`
+ *    (and therefore the scroll lock) true, since resizing never touches
+ *    React state on its own. A `matchMedia` listener closes the menu the
+ *    moment the viewport crosses into desktop width so the lock always
+ *    gets released.
+ * 2. Not trapping focus (see above) still leaves every *other* focusable
+ *    thing on the page -- the trigger button itself, the site mark link,
+ *    the theme picker, the clock, the skip link, all of `<main>` -- in
+ *    the normal tab sequence, sitting directly behind this panel's opaque
+ *    `bg-bg`. Without something marking them non-interactive, Tab/Shift+Tab
+ *    from the panel's own controls would silently move focus onto
+ *    controls the user cannot see under the overlay. `inert` (not a focus
+ *    trap -- Tab still leaves the panel, it just has nothing invisible
+ *    left to land on) is applied to everything else in the document while
+ *    open and lifted on close.
  */
 export function MobileNav() {
   const [open, setOpen] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const firstLinkRef = useRef<HTMLAnchorElement>(null)
   const panelId = useId()
@@ -50,16 +73,41 @@ export function MobileNav() {
     }
     document.addEventListener('keydown', onKeyDown)
 
+    const panelQuery = window.matchMedia('(min-width: 880px)')
+    const onPanelChange = (event: MediaQueryListEvent) => {
+      if (event.matches) setOpen(false)
+    }
+    panelQuery.addEventListener('change', onPanelChange)
+
+    const inertTargets: HTMLElement[] = []
+    const wrapper = wrapperRef.current
+    if (wrapper?.parentElement) {
+      for (const sibling of Array.from(wrapper.parentElement.children)) {
+        if (sibling !== wrapper && sibling instanceof HTMLElement) inertTargets.push(sibling)
+      }
+    }
+    const scrollBar = document.querySelector<HTMLElement>('header > [role="progressbar"]')
+    if (scrollBar) inertTargets.push(scrollBar)
+    const skipLink = document.querySelector<HTMLElement>('a[href="#main-content"]')
+    if (skipLink) inertTargets.push(skipLink)
+    const main = document.getElementById('main-content')
+    if (main) inertTargets.push(main)
+    if (triggerRef.current) inertTargets.push(triggerRef.current)
+
+    for (const el of inertTargets) el.inert = true
+
     return () => {
       root.style.overflow = previousOverflow
       document.removeEventListener('keydown', onKeyDown)
+      panelQuery.removeEventListener('change', onPanelChange)
+      for (const el of inertTargets) el.inert = false
     }
   }, [open])
 
   const close = () => setOpen(false)
 
   return (
-    <div className="ml-auto panel:hidden">
+    <div ref={wrapperRef} className="ml-auto panel:hidden">
       <button
         ref={triggerRef}
         type="button"

--- a/src/components/layout/ThemePicker.tsx
+++ b/src/components/layout/ThemePicker.tsx
@@ -105,8 +105,12 @@ export function ThemePicker() {
         aria-label={`Theme: ${activeTheme.name}`}
         onClick={() => setOpen((value) => !value)}
         className={cn(
-          'flex h-[30px] w-[30px] shrink-0 items-center justify-center gap-[8px] border-0 bg-transparent p-0',
-          'panel:h-auto panel:w-auto panel:justify-start panel:border panel:border-line-2 panel:px-[10px] panel:py-[7px]',
+          // `ml-auto` pushes the trailing group (swatch, clock, hamburger)
+          // flush to the header's right edge below 880px; the inline
+          // `<nav>` supplies its own `ml-auto` at panel width, so this one
+          // is cancelled there to avoid stacking two auto margins.
+          'ml-auto flex h-[30px] w-[30px] shrink-0 items-center justify-center gap-[8px] border-0 bg-transparent p-0',
+          'panel:ml-0 panel:h-auto panel:w-auto panel:justify-start panel:border panel:border-line-2 panel:px-[10px] panel:py-[7px]',
           'font-mono text-[10px] tracking-[0.16em] text-dim',
           'transition-[color,border-color] duration-150 hover:border-accent hover:text-fg',
         )}

--- a/src/components/layout/ThemePicker.tsx
+++ b/src/components/layout/ThemePicker.tsx
@@ -95,7 +95,12 @@ export function ThemePicker() {
   }
 
   return (
-    <div ref={containerRef} className="relative">
+    // `ml-auto` lives here, not on the button: this `div` is the actual flex
+    // item in the header row, so it's the element that needs the auto margin
+    // to consume the row's free space. Putting it on the button (an in-flow
+    // child of this shrink-wrapped div, not itself a flex item of the row)
+    // had no free space to push into, so it visually did nothing.
+    <div ref={containerRef} className="relative ml-auto panel:ml-0">
       <button
         ref={triggerRef}
         type="button"
@@ -105,17 +110,17 @@ export function ThemePicker() {
         aria-label={`Theme: ${activeTheme.name}`}
         onClick={() => setOpen((value) => !value)}
         className={cn(
-          // `ml-auto` pushes the trailing group (swatch, clock, hamburger)
-          // flush to the header's right edge below 880px; the inline
-          // `<nav>` supplies its own `ml-auto` at panel width, so this one
-          // is cancelled there to avoid stacking two auto margins.
-          'ml-auto flex h-[30px] w-[30px] shrink-0 items-center justify-center gap-[8px] border-0 bg-transparent p-0',
-          'panel:ml-0 panel:h-auto panel:w-auto panel:justify-start panel:border panel:border-line-2 panel:px-[10px] panel:py-[7px]',
+          'flex h-[30px] w-[30px] shrink-0 items-center justify-center gap-[8px] border-0 bg-transparent p-0',
+          'panel:h-auto panel:w-auto panel:justify-start panel:border panel:border-line-2 panel:px-[10px] panel:py-[7px]',
           'font-mono text-[10px] tracking-[0.16em] text-dim',
           'transition-[color,border-color] duration-150 hover:border-accent hover:text-fg',
         )}
       >
-        <span aria-hidden="true" className="h-[14px] w-[14px] panel:hidden" style={{ background: activeTheme.swatch[0] }} />
+        {/* Mobile trigger uses swatch[1] (the accent colour), not swatch[0]
+            (the background colour) -- swatch[0] on every theme is near-black,
+            near-identical to the header's own background, so a single dot in
+            that colour was rendering but effectively invisible. */}
+        <span aria-hidden="true" className="h-[14px] w-[14px] panel:hidden" style={{ background: activeTheme.swatch[1] }} />
         <span aria-hidden="true" className="hidden gap-[2px] panel:flex">
           {activeTheme.swatch.map((color, index) => (
             <span key={index} className="h-[9px] w-[9px]" style={{ background: color }} />

--- a/src/components/layout/ThemePicker.tsx
+++ b/src/components/layout/ThemePicker.tsx
@@ -29,6 +29,19 @@ import { DEFAULT_THEME_ID, THEMES } from '@/theme/themes'
  * state, seeded from whatever was already stored (or the default) so a
  * page that loaded with a previously-chosen theme shows the right theme
  * immediately rather than flashing back to ORIGINAL.
+ *
+ * Mobile-only collapse (owner review on #314's PR): below the 880px
+ * `panel:` breakpoint the trigger has no room for the full swatch row,
+ * the visible theme name, or its own bordered box (three colour squares
+ * plus "ORIGINAL" inside a wide border was measured overflowing/colliding
+ * with the hamburger at phone widths). Below `panel:` the trigger renders
+ * as one square swatch (the active theme's first colour) with no border
+ * and no visible text; `aria-label` (not the visible name text, which is
+ * `hidden` and therefore stripped from the accessible name below the
+ * breakpoint) carries the accessible name at every width, so the control
+ * stays keyboard-operable and namer-complete on its own regardless of
+ * which visual it's rendering. `panel:` classes restore the desktop
+ * swatch row, name, and bordered box exactly as before.
  */
 export function ThemePicker() {
   const [themeId, setThemeId] = useState(() => getStoredThemeId() ?? DEFAULT_THEME_ID)
@@ -89,20 +102,24 @@ export function ThemePicker() {
         aria-haspopup="menu"
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
+        aria-label={`Theme: ${activeTheme.name}`}
         onClick={() => setOpen((value) => !value)}
         className={cn(
-          'flex items-center gap-[8px] border border-line-2 bg-transparent px-[10px] py-[7px]',
+          'flex h-[30px] w-[30px] shrink-0 items-center justify-center gap-[8px] border-0 bg-transparent p-0',
+          'panel:h-auto panel:w-auto panel:justify-start panel:border panel:border-line-2 panel:px-[10px] panel:py-[7px]',
           'font-mono text-[10px] tracking-[0.16em] text-dim',
           'transition-[color,border-color] duration-150 hover:border-accent hover:text-fg',
         )}
       >
-        <span aria-hidden="true" className="flex gap-[2px]">
+        <span aria-hidden="true" className="h-[14px] w-[14px] panel:hidden" style={{ background: activeTheme.swatch[0] }} />
+        <span aria-hidden="true" className="hidden gap-[2px] panel:flex">
           {activeTheme.swatch.map((color, index) => (
             <span key={index} className="h-[9px] w-[9px]" style={{ background: color }} />
           ))}
         </span>
-        <span className="sr-only">Theme: </span>
-        {activeTheme.name}
+        <span aria-hidden="true" className="hidden panel:inline">
+          {activeTheme.name}
+        </span>
       </button>
 
       {open ? (

--- a/src/components/sections/EducationExperience.tsx
+++ b/src/components/sections/EducationExperience.tsx
@@ -129,12 +129,31 @@ function TimelineColumnCells({
     <>
       <div
         className={cn(
-          'flex flex-wrap items-center gap-[13px] px-[18px] py-[clamp(11px,1.8vh,16px)]',
+          /*
+           * Below 880px this row is forced `flex-nowrap` with the heading
+           * truncating (`min-w-0` + `truncate` below) instead of wrapping
+           * (mochi/issue-348): at 375px the education heading ("Wichita
+           * State University") plus its "EDUCATION" tag don't fit on one
+           * line under the original unconditional `flex-wrap`, so the tag
+           * got pushed onto its own row -- taller block, tag placement
+           * that didn't match the (shorter) experience heading, which
+           * happened to still fit inline. Forcing nowrap + truncation
+           * keeps the tag inline on the same row for every header
+           * regardless of heading length, so header shape and tag
+           * placement stay identical across both categories. `panel:`
+           * (880px, the one breakpoint) restores the original unconditional
+           * `flex-wrap` + fixed `px-[18px]` for desktop, which is
+           * untouched by this change -- headings there already fit inline
+           * with room to spare, so this is a no-op above 880px.
+           */
+          'flex flex-nowrap items-center gap-[var(--space-fit-3xs)] px-[clamp(14px,1.8vw,22px)] py-[clamp(11px,1.8vh,16px)] panel:flex-wrap panel:gap-[13px] panel:px-[18px]',
           isExperience ? 'bg-accent text-bg' : 'bg-fg text-bg',
         )}
       >
-        <span aria-hidden="true" className="h-3 w-3 rounded-full bg-bg" />
-        <span className="font-display text-[clamp(12px,1.5vw,15px)]">{column.heading}</span>
+        <span aria-hidden="true" className="h-[9px] w-[9px] shrink-0 rounded-full bg-bg panel:h-3 panel:w-3" />
+        <span className="min-w-0 flex-1 truncate whitespace-nowrap font-display text-[clamp(12px,1.5vw,15px)] panel:flex-initial panel:overflow-visible panel:whitespace-normal">
+          {column.heading}
+        </span>
         {/*
          * Opacity dropped entirely and weight raised to `font-medium`
          * (mochi/style-match task 1, second pass): the owner reported the
@@ -155,7 +174,9 @@ function TimelineColumnCells({
          * Mono weights (`src/styles/fonts.css`), so this stays a real
          * weight, not a browser-synthesized fake bold.
          */}
-        <span className="ml-auto text-fit-meta font-medium uppercase tracking-[0.2em]">{column.kind}</span>
+        <span className="ml-auto shrink-0 text-fit-meta font-medium uppercase tracking-[0.1em] panel:tracking-[0.2em]">
+          {column.kind}
+        </span>
       </div>
 
       {column.entries.map((entry) => (
@@ -192,7 +213,22 @@ function TimelineEntryCell({
        * (`text-accent-2`/`text-fg`) are already brighter than this and
        * inherit the new weight from this row.
        */}
-      <div className="flex flex-wrap items-center gap-[12px] text-fit-meta font-medium uppercase tracking-[0.18em] text-fg-2">
+      {/*
+       * Below 880px this row is forced into a column (status pill, then
+       * date, always in that order) instead of the original unconditional
+       * `flex-wrap` row (mochi/issue-348): at 375px the longer date
+       * ranges ("JAN 2026 - MAY 2027 (EXPECTED)") don't fit next to their
+       * status pill and wrap onto their own line, while shorter ranges
+       * ("JAN 2022 - DEC 2025") stay inline -- so titles below started at
+       * different offsets card to card depending on which entry's date
+       * happened to wrap. Forcing a column on mobile makes every entry
+       * use the same two-row shape (pill row, then date row) regardless
+       * of date length, so titles land at the same offset everywhere.
+       * `panel:` (880px, the one breakpoint) restores the original
+       * unconditional row + wrap + centered items for desktop, which is
+       * untouched by this change.
+       */}
+      <div className="flex flex-col items-start gap-[var(--space-fit-3xs-tight)] text-fit-meta font-medium uppercase tracking-[0.18em] text-fg-2 panel:flex-row panel:flex-wrap panel:items-center panel:gap-[12px]">
         {/*
          * This `pulse` animation is intentionally mirrored by the Thesis
          * project card's "RUNNING" tag label (`ProjectTag.tsx`,
@@ -224,7 +260,7 @@ function TimelineEntryCell({
             {entry.statusLabel}
           </span>
         </span>
-        <span className="ml-auto">{entry.dateRange}</span>
+        <span className="panel:ml-auto">{entry.dateRange}</span>
       </div>
 
       <div className="font-display text-fit-title leading-[1.45] text-fg">{entry.title}</div>

--- a/src/components/sections/EducationExperience.tsx
+++ b/src/components/sections/EducationExperience.tsx
@@ -130,28 +130,29 @@ function TimelineColumnCells({
       <div
         className={cn(
           /*
-           * Below 880px this row is forced `flex-nowrap` with the heading
-           * truncating (`min-w-0` + `truncate` below) instead of wrapping
-           * (mochi/issue-348): at 375px the education heading ("Wichita
-           * State University") plus its "EDUCATION" tag don't fit on one
-           * line under the original unconditional `flex-wrap`, so the tag
-           * got pushed onto its own row -- taller block, tag placement
-           * that didn't match the (shorter) experience heading, which
-           * happened to still fit inline. Forcing nowrap + truncation
-           * keeps the tag inline on the same row for every header
-           * regardless of heading length, so header shape and tag
-           * placement stay identical across both categories. `panel:`
-           * (880px, the one breakpoint) restores the original unconditional
-           * `flex-wrap` + fixed `px-[18px]` for desktop, which is
-           * untouched by this change -- headings there already fit inline
-           * with room to spare, so this is a no-op above 880px.
+           * Below 880px this row keeps the tag inline via `flex-nowrap`,
+           * but the heading itself is no longer truncated (rejected,
+           * #314 owner review -- a longer institution name was getting
+           * clipped to "Wichita State Uni…", which the owner called
+           * unacceptable: any real heading text must always be fully
+           * readable). `min-w-0` still lets the heading shrink to make
+           * room for the tag, and it now wraps onto a second line instead
+           * of being cut off -- `items-start` (was `items-center`) keeps
+           * the tag pinned to the first line's cap height instead of
+           * re-centering against a heading that may now be two lines
+           * tall, so tag placement still reads the same way across both
+           * the education and experience headers regardless of which
+           * one's heading wraps. `panel:` (880px, the one breakpoint)
+           * restores the original unconditional `flex-wrap` + centered
+           * items + fixed `px-[18px]` for desktop, untouched by this
+           * change.
            */
-          'flex flex-nowrap items-center gap-[var(--space-fit-3xs)] px-[clamp(14px,1.8vw,22px)] py-[clamp(11px,1.8vh,16px)] panel:flex-wrap panel:gap-[13px] panel:px-[18px]',
+          'flex flex-nowrap items-start gap-[var(--space-fit-3xs)] px-[clamp(14px,1.8vw,22px)] py-[clamp(11px,1.8vh,16px)] panel:flex-wrap panel:items-center panel:gap-[13px] panel:px-[18px]',
           isExperience ? 'bg-accent text-bg' : 'bg-fg text-bg',
         )}
       >
         <span aria-hidden="true" className="h-[9px] w-[9px] shrink-0 rounded-full bg-bg panel:h-3 panel:w-3" />
-        <span className="min-w-0 flex-1 truncate whitespace-nowrap font-display text-[clamp(12px,1.5vw,15px)] panel:flex-initial panel:overflow-visible panel:whitespace-normal">
+        <span className="min-w-0 flex-1 font-display text-[clamp(12px,1.5vw,15px)] panel:flex-initial">
           {column.heading}
         </span>
         {/*

--- a/src/components/sections/ProjectsFeatured.tsx
+++ b/src/components/sections/ProjectsFeatured.tsx
@@ -109,9 +109,19 @@ export function ProjectsFeatured() {
          * with real content and the shrink pass correctly measure and
          * correct any future overflow instead.
          */}
+        {/*
+         * `minmax(min(340px,100%),1fr)`, not a bare `minmax(340px,1fr)`:
+         * the bare form's 340px floor can exceed the section's available
+         * inline size below 880px (owner review, #314) -- wrapping it in
+         * `min(...,100%)` caps the floor at the grid's own width whenever
+         * that's narrower than 340px, so the column can never demand more
+         * room than actually exists. `min(340px,100%) === 340px` whenever
+         * the container is wide enough, so this is a no-op above that
+         * width -- desktop is unaffected.
+         */}
         <div
           ref={fitRef}
-          className="grid grid-cols-[repeat(auto-fit,minmax(340px,1fr))] border border-line-2 bg-panel"
+          className="grid grid-cols-[repeat(auto-fit,minmax(min(340px,100%),1fr))] border border-line-2 bg-panel"
         >
           <div className="flex min-w-0 flex-col gap-[var(--space-fit-xs)] p-[clamp(16px,2.4vh,30px)_clamp(18px,2.2vw,30px)]">
             {/*

--- a/src/components/sections/ProjectsFeatured.tsx
+++ b/src/components/sections/ProjectsFeatured.tsx
@@ -76,7 +76,7 @@ export function ProjectsFeatured() {
        * its normal top-of-section position, same mechanism as
        * `ProjectsOther.tsx`.
        */}
-      <div className="flex flex-1 flex-col justify-center panel:mt-[var(--space-fit-margin)]">
+      <div className="mt-[var(--space-fit-margin)] flex flex-1 flex-col justify-center">
         {/*
          * `grid-cols-[repeat(auto-fit,...)]` is the sample's own
          * unconditional grid (line 339); `minmax(340px,1fr)` alone
@@ -130,8 +130,21 @@ export function ProjectsFeatured() {
              * it flush with the title's cap height instead of the
              * (undefined once multi-line) baseline. Same pattern reused
              * verbatim in `ProjectsOther.tsx` for both its cards.
+             *
+             * Below 880px this stacks into a column instead (#314 owner
+             * review): "Leviathan" renders through `text-fit-xl`, a
+             * height-based clamp up to 34px in the blocky display font --
+             * at narrow mobile widths its glyphs visually overhang their
+             * own measured box (verified via pixel-sampling a real render:
+             * ink extends well past the text node's own
+             * `getBoundingClientRect` width), landing on the badge's left
+             * edge even though the two boxes don't geometrically overlap.
+             * Giving the badge its own row below the title removes the
+             * collision outright regardless of that overhang. `panel:
+             * flex-row` restores the side-by-side row at 880px+, where the
+             * smaller `panel:` title size doesn't exhibit it.
              */}
-            <div className="flex items-start justify-between gap-[12px]">
+            <div className="flex flex-col items-start gap-[var(--space-2xs)] panel:flex-row panel:items-start panel:justify-between panel:gap-[12px]">
               <span className="min-w-0 flex-1 font-display text-fit-xl leading-tight tracking-[-0.03em] text-fg">
                 Leviathan
               </span>

--- a/src/components/sections/ProjectsOther.tsx
+++ b/src/components/sections/ProjectsOther.tsx
@@ -61,8 +61,12 @@ export function ProjectsOther() {
        * `.section-shell`'s own `justify-content:center` (on the
        * heading+wrapper block as a whole) has nothing left to redistribute
        * -- the wrapper already occupies 100% of the remaining height.
+       *
+       * `mt-` was `panel:`-only, leaving zero gap below 880px between the
+       * "THE OTHER STUFF I WORKED ON" caption and the first card (#314
+       * owner review) -- unconditional now, same margin at every width.
        */}
-      <div className="flex flex-1 flex-col justify-center panel:mt-[var(--space-fit-margin)]">
+      <div className="mt-[var(--space-fit-margin)] flex flex-1 flex-col justify-center">
         {/*
          * `auto-fit`/`minmax(320px,1fr)` (sample line 424) is also the
          * mechanism that lets this grid reflow as more projects are added

--- a/src/components/sections/ProjectsOther.tsx
+++ b/src/components/sections/ProjectsOther.tsx
@@ -112,9 +112,10 @@ export function ProjectsOther() {
          * other regardless (both cards' tops sit on the same grid-row
          * edge either way).
          */}
+        {/* minmax(min(320px,100%),1fr): same overflow guard as ProjectsFeatured's grid -- caps the column floor at the container's own width below 880px, a no-op above it. */}
         <div
           ref={fitRef}
-          className="grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-[clamp(14px,1.6vw,20px)]"
+          className="grid grid-cols-[repeat(auto-fit,minmax(min(320px,100%),1fr))] gap-[clamp(14px,1.6vw,20px)]"
         >
           {OTHER_PROJECTS.map((project) => (
             <OtherProjectCard key={project.id} project={project} />

--- a/src/components/sections/ProjectsOther.tsx
+++ b/src/components/sections/ProjectsOther.tsx
@@ -113,9 +113,19 @@ export function ProjectsOther() {
          * edge either way).
          */}
         {/* minmax(min(320px,100%),1fr): same overflow guard as ProjectsFeatured's grid -- caps the column floor at the container's own width below 880px, a no-op above it. */}
+        {/*
+         * `auto-rows-fr` (below 880px, `auto-fit` only fits one column, so
+         * MLA and Thesis land in two separate grid ROWS, not two columns in
+         * one row -- `align-items: stretch` only equalises siblings sharing
+         * a row, so it did nothing there and Thesis rendered at its own,
+         * shorter, content height). Flexed auto rows with an indefinite
+         * grid-container height resolve every row to the tallest row's own
+         * content size, so both cards end up equal without touching the
+         * 880px+ single-row case (a no-op there, same as today).
+         */}
         <div
           ref={fitRef}
-          className="grid grid-cols-[repeat(auto-fit,minmax(min(320px,100%),1fr))] gap-[clamp(14px,1.6vw,20px)]"
+          className="grid grid-cols-[repeat(auto-fit,minmax(min(320px,100%),1fr))] auto-rows-fr gap-[clamp(14px,1.6vw,20px)]"
         >
           {OTHER_PROJECTS.map((project) => (
             <OtherProjectCard key={project.id} project={project} />

--- a/src/components/sections/leviathan/InferencePipeline.tsx
+++ b/src/components/sections/leviathan/InferencePipeline.tsx
@@ -119,7 +119,8 @@ export function InferencePipeline() {
       className="flex flex-col gap-[clamp(10px,2vh,22px)]"
     >
       <PipelineRow label="position">
-        <span aria-hidden="true" className="flex flex-wrap text-[clamp(9px,1.4vh,13px)]">
+        {/* min-w-0: each char is its own flex item so this already wraps freely, but the container still needs permission to shrink below its content's width. */}
+        <span aria-hidden="true" className="flex min-w-0 flex-wrap text-[clamp(9px,1.4vh,13px)]">
           {fenChars.map((cell, index) => (
             <span
               key={index}
@@ -133,7 +134,7 @@ export function InferencePipeline() {
       </PipelineRow>
 
       <PipelineRow label="tokens">
-        <div aria-hidden="true" className="flex flex-wrap gap-[5px]">
+        <div aria-hidden="true" className="flex min-w-0 flex-wrap gap-[5px]">
           {tokenCells.map((cell, index) => (
             <span
               key={index}

--- a/src/components/sections/otherProjects/CopyInstallCommand.tsx
+++ b/src/components/sections/otherProjects/CopyInstallCommand.tsx
@@ -62,15 +62,7 @@ export function CopyInstallCommand({ command, className }: CopyInstallCommandPro
       <span aria-hidden="true" className="shrink-0 text-accent-2">
         $
       </span>
-      {/*
-       * `min-w-0` is required alongside `flex-1` here: a flex item's
-       * default min-width is its content's min-content size, and
-       * `whitespace-nowrap` makes that the full, unbroken command string --
-       * so without `min-w-0` this span (and the row around it) refused to
-       * shrink below the command's full width, pushing the "copy" button
-       * off the card and clipping the command text at the viewport edge
-       * instead of ever engaging `overflow-x-auto` (#314 owner review).
-       */}
+      {/* min-w-0: a flex item's default min-width is its (nowrap) content size, which blocked overflow-x-auto from ever kicking in. */}
       <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap">{command}</span>
       <button
         type="button"

--- a/src/components/sections/otherProjects/CopyInstallCommand.tsx
+++ b/src/components/sections/otherProjects/CopyInstallCommand.tsx
@@ -59,16 +59,25 @@ export function CopyInstallCommand({ command, className }: CopyInstallCommandPro
         className,
       )}
     >
-      <span aria-hidden="true" className="text-accent-2">
+      <span aria-hidden="true" className="shrink-0 text-accent-2">
         $
       </span>
-      <span className="flex-1 overflow-x-auto whitespace-nowrap">{command}</span>
+      {/*
+       * `min-w-0` is required alongside `flex-1` here: a flex item's
+       * default min-width is its content's min-content size, and
+       * `whitespace-nowrap` makes that the full, unbroken command string --
+       * so without `min-w-0` this span (and the row around it) refused to
+       * shrink below the command's full width, pushing the "copy" button
+       * off the card and clipping the command text at the viewport edge
+       * instead of ever engaging `overflow-x-auto` (#314 owner review).
+       */}
+      <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap">{command}</span>
       <button
         type="button"
         onClick={handleCopy}
         disabled={!clipboardAvailable}
         aria-label={clipboardAvailable ? undefined : 'Copy unavailable -- select the command text above instead'}
-        className="whitespace-nowrap border border-line-2 px-[var(--space-2xs)] py-[2px] text-2xs text-dim tracking-[0.1em] hover:border-accent hover:text-accent-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-line-2 disabled:hover:text-dim"
+        className="shrink-0 whitespace-nowrap border border-line-2 px-[var(--space-2xs)] py-[2px] text-2xs text-dim tracking-[0.1em] hover:border-accent hover:text-accent-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-line-2 disabled:hover:text-dim"
       >
         {copied ? 'copied' : 'copy'}
       </button>

--- a/src/components/sections/otherProjects/CopyInstallCommand.tsx
+++ b/src/components/sections/otherProjects/CopyInstallCommand.tsx
@@ -55,21 +55,23 @@ export function CopyInstallCommand({ command, className }: CopyInstallCommandPro
   return (
     <div
       className={cn(
-        'flex items-center gap-[9px] bg-panel-2 px-[14px] py-[12px] font-mono text-2xs text-fg-2',
+        'flex flex-col gap-[9px] bg-panel-2 px-[14px] py-[12px] font-mono text-2xs text-fg-2 panel:flex-row panel:items-center',
         className,
       )}
     >
-      <span aria-hidden="true" className="shrink-0 text-accent-2">
-        $
-      </span>
-      {/* min-w-0: a flex item's default min-width is its (nowrap) content size, which blocked overflow-x-auto from ever kicking in. */}
-      <span className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap">{command}</span>
+      {/* Command wraps (word-break: break-word) instead of scrolling below 880px -- horizontal scroll inside a strip this narrow isn't discoverable on a phone. */}
+      <div className="flex items-start gap-[9px] panel:min-w-0 panel:flex-1 panel:items-center">
+        <span aria-hidden="true" className="shrink-0 text-accent-2">
+          $
+        </span>
+        <span className="min-w-0 flex-1 break-words">{command}</span>
+      </div>
       <button
         type="button"
         onClick={handleCopy}
         disabled={!clipboardAvailable}
         aria-label={clipboardAvailable ? undefined : 'Copy unavailable -- select the command text above instead'}
-        className="shrink-0 whitespace-nowrap border border-line-2 px-[var(--space-2xs)] py-[2px] text-2xs text-dim tracking-[0.1em] hover:border-accent hover:text-accent-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-line-2 disabled:hover:text-dim"
+        className="shrink-0 self-end whitespace-nowrap border border-line-2 px-[var(--space-2xs)] py-[2px] text-2xs text-dim tracking-[0.1em] hover:border-accent hover:text-accent-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:border-line-2 disabled:hover:text-dim panel:self-auto"
       >
         {copied ? 'copied' : 'copy'}
       </button>

--- a/src/components/sections/otherProjects/OtherProjectCard.tsx
+++ b/src/components/sections/otherProjects/OtherProjectCard.tsx
@@ -39,7 +39,30 @@ export function OtherProjectCard({ project }: { project: OtherProject }) {
   return (
     <article className="flex flex-col gap-[var(--space-fit-xs)] border border-line bg-panel p-[clamp(16px,2.4vh,28px)_clamp(18px,2.2vw,28px)] transition-[border-color,transform] duration-200 hover:border-accent motion-safe:hover:-translate-y-[3px]">
       <div className="flex items-start justify-between gap-[12px]">
-        <h3 className="min-w-0 flex-1 font-display text-fluid-lg text-fg">{project.title}</h3>
+        {/*
+         * Title sizing is width-driven (`text-fluid-lg`, `--text-lg`
+         * ~19.2-24px) ONLY from 880px up, restored via the `panel:`
+         * override (issue #346 fix). Below 880px the base classes switch to
+         * `text-fit-title` (`--text-fit-title`, a height-based clamp
+         * ~11.5-16px, the same token `EducationExperience.tsx` already uses
+         * for its own card/entry titles) with a tighter `leading-[1.45]`.
+         *
+         * At 375px, the unconditional width-based size (~20px, near its own
+         * floor already) was still wide enough that MLA's four-word title
+         * ("Multi-Head Latent Attention") wrapped one word per line in the
+         * blocky `font-display` ("Press Start 2P") -- ballooning that card
+         * to roughly triple the height of the one-line "Thesis" card below
+         * it and breaking the shared title/description/metric/footer
+         * rhythm the two cards are meant to share (issue #346). The
+         * height-based scale shrinks with viewport HEIGHT, not width, so it
+         * isn't pinned near its own max at narrow widths the way the
+         * width-based scale is -- it renders small enough for the long
+         * title to wrap to two lines instead of four, without touching the
+         * `panel:`-gated desktop size at all.
+         */}
+        <h3 className="min-w-0 flex-1 font-display text-fit-title leading-[1.45] text-fg panel:text-fluid-lg panel:leading-[1.6]">
+          {project.title}
+        </h3>
         <ProjectTag label={project.badge.label} year={project.badge.year} blink={project.badge.blink} />
       </div>
 

--- a/src/components/sections/skills/SkillsGraph.tsx
+++ b/src/components/sections/skills/SkillsGraph.tsx
@@ -113,7 +113,7 @@ export function SkillsGraph() {
     >
       <div
         ref={panelRef}
-        className="relative min-h-0 border border-line-2 bg-panel px-[clamp(30px,5vw,60px)] py-[clamp(22px,3.4vh,42px)]"
+        className="relative aspect-square min-h-0 border border-line-2 bg-panel px-[clamp(30px,5vw,60px)] py-[clamp(22px,3.4vh,42px)] panel:aspect-auto"
       >
         <div className="relative h-full w-full">
           <svg
@@ -149,6 +149,7 @@ export function SkillsGraph() {
               <button
                 key={node.id}
                 type="button"
+                aria-label={node.label}
                 style={{ left: `${node.x}%`, top: `${node.y}%` }}
                 className={cn(
                   'absolute h-0 w-0 border-0 bg-transparent p-0 text-left',
@@ -173,10 +174,19 @@ export function SkillsGraph() {
                       'transition-[transform,border-color] duration-200 [transition-timing-function:cubic-bezier(.2,1.2,.4,1)]',
                   )}
                 />
+                {/* Node labels are `aria-hidden` and hidden outright below the
+                    `panel:` breakpoint (see file header) -- the button carries
+                    its own `aria-label`, so hiding this span costs nothing for
+                    assistive tech. Below 880px the panel is too narrow for 19
+                    `whitespace-nowrap` labels to coexist without overlapping
+                    each other and the hub captions (issue #347); the tap/
+                    focus/hover readout strip beneath the graph is the mobile
+                    substitute for reading a node's name. */}
                 <span
+                  aria-hidden="true"
                   className={cn(
-                    'absolute left-0 -translate-x-1/2 whitespace-nowrap tracking-[0.1em]',
-                    node.hub ? 'top-[16px] text-[10px]' : 'top-[12px] text-[10.5px]',
+                    'hidden tracking-[0.1em] panel:absolute panel:left-0 panel:block panel:-translate-x-1/2 panel:whitespace-nowrap',
+                    node.hub ? 'panel:top-[16px] panel:text-[10px]' : 'panel:top-[12px] panel:text-[10.5px]',
                     isActive ? 'text-fg' : 'text-dim',
                     !reducedMotion && 'transition-colors duration-200',
                   )}

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -173,9 +173,21 @@
  * hard to scroll within an overflowing section. Not addressed here.
  */
 
+/*
+ * `--header-h` is published imperatively by `Header.tsx` (measured, not
+ * guessed, since the header's rendered height changes with the fluid type
+ * scale and with viewport width). The base (below-880px) top padding uses
+ * `max(var(--space-lg), var(--header-h))` so the fixed header never covers
+ * a section's real content at mobile widths, where `--space-lg` alone
+ * (2.4-3.6rem) can floor below the header's rendered height (~55-60px) --
+ * the hero eyebrow and other sections' heading rows rendered partly behind
+ * the header until this was added (#314 owner review). The 880px+ override
+ * below keeps its own unconditional clamp (already proven to clear the
+ * header there, see `App.tsx`), so this only changes mobile.
+ */
 .section-shell {
   width: 100%;
-  padding-block: var(--space-lg) var(--space-md);
+  padding-block: max(var(--space-lg), var(--header-h, 4rem)) var(--space-md);
   padding-inline: var(--space-md);
   display: flex;
   flex-direction: column;
@@ -183,12 +195,6 @@
 }
 
 /*
- * `--header-h` is published imperatively by `Header.tsx` (measured, not
- * guessed, since the header's rendered height changes with the fluid type
- * scale and with viewport width). It is no longer consumed here (see
- * below); `Header.tsx` still publishes it in case a future consumer needs
- * a measured header height.
- *
  * `scroll-padding-top` was removed from `:root` (mochi/style-match audit):
  * a prior revision added it reasoning it was needed so `scroll-snap-align:
  * start` and anchor jumps wouldn't land a section under the fixed header.

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -184,10 +184,17 @@
  * the header until this was added (#314 owner review). The 880px+ override
  * below keeps its own unconditional clamp (already proven to clear the
  * header there, see `App.tsx`), so this only changes mobile.
+ *
+ * `+ var(--space-md)` on the `--header-h` branch adds real breathing room
+ * below the bar itself (clearing the header alone left content flush
+ * against it, #314 owner follow-up) -- `--space-md` (1.6-2.4rem) matches
+ * the hero's own internal block rhythm (its `mt-[...]` gaps run
+ * 20-34px), so the gap under the header reads as deliberate, not
+ * token-sized.
  */
 .section-shell {
   width: 100%;
-  padding-block: max(var(--space-lg), var(--header-h, 4rem)) var(--space-md);
+  padding-block: max(var(--space-lg), var(--header-h, 4rem) + var(--space-md)) var(--space-md);
   padding-inline: var(--space-md);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Mobile fixes for phone widths, all in one PR.

Closes #314
Closes #346
Closes #347
Closes #348

## Nav + header
- Full-screen hamburger menu below 880px; inline links return above it.
- Panel portals to `document.body` — the header's `backdrop-blur` was acting as a containing block for `position: fixed`, collapsing the panel to a thin strip and letting the page show through.
- Menu closes on crossing above 880px (releases the scroll lock); background marked `inert` while open.
- Hamburger sits right-most on mobile; theme control collapses to a single swatch (no label); clock shows HH:MM on mobile, HH:MM:SS on desktop.

## Project cards
- Card title uses the height-based scale below 880px so long titles stop wrapping one word per line and ballooning the card.

## Skills graph
- Graph panel gets a mobile height (it had none below 880px, so it collapsed and stacked all 19 labels on one baseline, spilling past its border).
- Node labels hidden on mobile with `aria-label` moved onto the buttons; the readout strip is the mobile way to read a node.

## Timeline
- Group headers hold one row with the tag inline for every category.
- Entry status pill and date range stack in a fixed order on mobile so titles start at the same offset.

Every change is gated on the 880px breakpoint; desktop rendering is unchanged.

Checks: `typecheck`, `lint`, `build` pass on the merged branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive mobile navigation menu with keyboard-friendly focus handling, Escape dismissal, and scroll locking.
  * Added responsive theme picker and skill graph behavior for smaller screens.
* **Bug Fixes**
  * Prevented fixed-header overlap and improved content wrapping across timelines, project cards, commands, and pipeline content.
  * Improved clock readability by simplifying the mobile display while preserving full screen-reader announcements.
* **Style**
  * Refined responsive layouts, spacing, alignment, typography, and project grid sizing across viewport widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->