### PR TITLE
Fix inconsistent project card sizing on mobile

### DIFF
--- a/src/components/sections/otherProjects/OtherProjectCard.tsx
+++ b/src/components/sections/otherProjects/OtherProjectCard.tsx
@@ -39,7 +39,30 @@ export function OtherProjectCard({ project }: { project: OtherProject }) {
   return (
     <article className="flex flex-col gap-[var(--space-fit-xs)] border border-line bg-panel p-[clamp(16px,2.4vh,28px)_clamp(18px,2.2vw,28px)] transition-[border-color,transform] duration-200 hover:border-accent motion-safe:hover:-translate-y-[3px]">
       <div className="flex items-start justify-between gap-[12px]">
-        <h3 className="min-w-0 flex-1 font-display text-fluid-lg text-fg">{project.title}</h3>
+        {/*
+         * Title sizing is width-driven (`text-fluid-lg`, `--text-lg`
+         * ~19.2-24px) ONLY from 880px up, restored via the `panel:`
+         * override (issue #346 fix). Below 880px the base classes switch to
+         * `text-fit-title` (`--text-fit-title`, a height-based clamp
+         * ~11.5-16px, the same token `EducationExperience.tsx` already uses
+         * for its own card/entry titles) with a tighter `leading-[1.45]`.
+         *
+         * At 375px, the unconditional width-based size (~20px, near its own
+         * floor already) was still wide enough that MLA's four-word title
+         * ("Multi-Head Latent Attention") wrapped one word per line in the
+         * blocky `font-display` ("Press Start 2P") -- ballooning that card
+         * to roughly triple the height of the one-line "Thesis" card below
+         * it and breaking the shared title/description/metric/footer
+         * rhythm the two cards are meant to share (issue #346). The
+         * height-based scale shrinks with viewport HEIGHT, not width, so it
+         * isn't pinned near its own max at narrow widths the way the
+         * width-based scale is -- it renders small enough for the long
+         * title to wrap to two lines instead of four, without touching the
+         * `panel:`-gated desktop size at all.
+         */}
+        <h3 className="min-w-0 flex-1 font-display text-fit-title leading-[1.45] text-fg panel:text-fluid-lg panel:leading-[1.6]">
+          {project.title}
+        </h3>
         <ProjectTag label={project.badge.label} year={project.badge.year} blink={project.badge.blink} />
       </div>
 


### PR DESCRIPTION
Closes #346

## Summary
- At mobile widths (below the 880px breakpoint), other-project card titles used a width-based fluid scale that stayed near ~20px regardless of viewport width. In the display font, MLA's four-word title ("Multi-Head Latent Attention") wrapped one word per line, tripling that card's height and breaking the shared title/description/metric-row/footer rhythm against the shorter Thesis card next to it.
- Switched the card title's base (mobile) font size to the existing height-based `text-fit-title` scale (same token already used for card/entry titles in the Timeline section), restoring the original width-based size and line-height only at the 880px `panel:` breakpoint via `panel:text-fluid-lg panel:leading-[1.6]`.
- Desktop (>= 880px) rendering is unchanged; only the sub-880px title size/line-height changed.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual visual check at 375px width (not run in this environment — no browser available)