### PR TITLE
Fix skills readout strip overlapping on mobile

### DIFF
--- a/src/components/sections/skills/SkillsGraph.tsx
+++ b/src/components/sections/skills/SkillsGraph.tsx
@@ -113,7 +113,7 @@ export function SkillsGraph() {
     >
       <div
         ref={panelRef}
-        className="relative min-h-0 border border-line-2 bg-panel px-[clamp(30px,5vw,60px)] py-[clamp(22px,3.4vh,42px)]"
+        className="relative aspect-square min-h-0 border border-line-2 bg-panel px-[clamp(30px,5vw,60px)] py-[clamp(22px,3.4vh,42px)] panel:aspect-auto"
       >
         <div className="relative h-full w-full">
           <svg
@@ -149,6 +149,7 @@ export function SkillsGraph() {
               <button
                 key={node.id}
                 type="button"
+                aria-label={node.label}
                 style={{ left: `${node.x}%`, top: `${node.y}%` }}
                 className={cn(
                   'absolute h-0 w-0 border-0 bg-transparent p-0 text-left',
@@ -173,10 +174,19 @@ export function SkillsGraph() {
                       'transition-[transform,border-color] duration-200 [transition-timing-function:cubic-bezier(.2,1.2,.4,1)]',
                   )}
                 />
+                {/* Node labels are `aria-hidden` and hidden outright below the
+                    `panel:` breakpoint (see file header) -- the button carries
+                    its own `aria-label`, so hiding this span costs nothing for
+                    assistive tech. Below 880px the panel is too narrow for 19
+                    `whitespace-nowrap` labels to coexist without overlapping
+                    each other and the hub captions (issue #347); the tap/
+                    focus/hover readout strip beneath the graph is the mobile
+                    substitute for reading a node's name. */}
                 <span
+                  aria-hidden="true"
                   className={cn(
-                    'absolute left-0 -translate-x-1/2 whitespace-nowrap tracking-[0.1em]',
-                    node.hub ? 'top-[16px] text-[10px]' : 'top-[12px] text-[10.5px]',
+                    'hidden tracking-[0.1em] panel:absolute panel:left-0 panel:block panel:-translate-x-1/2 panel:whitespace-nowrap',
+                    node.hub ? 'panel:top-[16px] panel:text-[10px]' : 'panel:top-[12px] panel:text-[10.5px]',
                     isActive ? 'text-fg' : 'text-dim',
                     !reducedMotion && 'transition-colors duration-200',
                   )}


### PR DESCRIPTION
Closes #347

At mobile widths (below the 880px panel breakpoint) the skills graph panel had no real height to lay its 19 node labels out in: it relied on a `minmax(0,1fr)` grid row that only gets a real size once `useFitToViewport` measures a fixed section height, and that mechanism is a no-op below 880px. The panel collapsed to almost nothing, so every node label (plus the 4 hub captions) rendered on top of each other and spilled past the panel's own border into the graph card underneath.

Fix:
- The panel gets an `aspect-square` fallback below 880px so it has real height to distribute nodes across (`panel:aspect-auto` restores the existing desktop sizing, unchanged).
- Per-node text labels are hidden below 880px rather than trying to fit 19 nowrap labels into ~320px of width; the node dots plus the existing tap/focus/hover readout strip beneath the graph remain as the way to read a node's name on mobile.
- Each node button now carries its own `aria-label` so hiding the visual label below 880px costs nothing for assistive tech.

Desktop (≥880px) rendering is unchanged — verified by reading through the `panel:` overrides, which restore every class removed by the mobile-only base styles.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual check at 375px in a browser (not run in this session — reviewer should confirm against the linked screenshots)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added accessible labels to skill buttons.
* **Responsive Design**
  * Updated the skills graph to use a square layout by default and adapt automatically on larger screens.
  * Improved label visibility across screen sizes while preserving the mobile readout experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->