### PR TITLE
Add a Vitest test harness and cover the pure lib logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "tsx": "^4.22.0",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.59.2",
-        "vite": "^8.0.12"
+        "vite": "^8.0.12",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@ai-hero/sandcastle": {
@@ -2228,6 +2229,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -2628,6 +2647,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2666,6 +2798,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/balanced-match": {
@@ -2758,6 +2900,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -2875,6 +3027,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.28.0",
@@ -3113,6 +3272,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3121,6 +3290,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-check": {
@@ -3930,6 +4109,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3999,6 +4192,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4187,6 +4387,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -4203,6 +4410,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
@@ -4235,6 +4456,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -4250,6 +4488,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toml": {
@@ -4501,6 +4749,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4515,6 +4853,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
     "typecheck": "tsc -b",
     "sandcastle": "npx tsx .sandcastle/main.ts",
     "generate:game4-moves": "tsx scripts/extract-game4-moves.ts"
@@ -37,6 +38,7 @@
     "tsx": "^4.22.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.2",
-    "vite": "^8.0.12"
+    "vite": "^8.0.12",
+    "vitest": "^4.1.10"
   }
 }

--- a/src/lib/go/board.test.ts
+++ b/src/lib/go/board.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import { applyMove, computeBoardStates, createEmptyBoard, type Move } from './board'
+
+describe('createEmptyBoard', () => {
+  it('produces a 19x19 board of nulls', () => {
+    const board = createEmptyBoard()
+    expect(board.length).toBe(19)
+    expect(board.every((row) => row.length === 19 && row.every((stone) => stone === null))).toBe(true)
+  })
+})
+
+describe('applyMove', () => {
+  it('places a stone at the given position with no captures', () => {
+    const board = createEmptyBoard()
+    const result = applyMove(board, { color: 'B', position: { row: 3, col: 3 } })
+    expect(result.board[3][3]).toBe('B')
+    expect(result.captured).toEqual([])
+  })
+
+  it('does not mutate the board passed in', () => {
+    const board = createEmptyBoard()
+    applyMove(board, { color: 'B', position: { row: 3, col: 3 } })
+    expect(board[3][3]).toBe(null)
+  })
+
+  it('throws on an out-of-bounds move', () => {
+    const board = createEmptyBoard()
+    expect(() => applyMove(board, { color: 'B', position: { row: -1, col: 0 } })).toThrow()
+    expect(() => applyMove(board, { color: 'B', position: { row: 0, col: 19 } })).toThrow()
+  })
+
+  it('throws when the target position is already occupied', () => {
+    const board = createEmptyBoard()
+    const afterFirst = applyMove(board, { color: 'B', position: { row: 5, col: 5 } }).board
+    expect(() => applyMove(afterFirst, { color: 'W', position: { row: 5, col: 5 } })).toThrow()
+  })
+
+  it('captures a single stone surrounded in a corner', () => {
+    const moves: Move[] = [
+      { color: 'W', position: { row: 0, col: 0 } },
+      { color: 'B', position: { row: 0, col: 1 } },
+      { color: 'B', position: { row: 1, col: 0 } },
+    ]
+    const states = computeBoardStates(moves)
+    const last = states[states.length - 1]
+    expect(last.captured).toEqual([{ row: 0, col: 0 }])
+    expect(last.board[0][0]).toBe(null)
+    expect(last.board[0][1]).toBe('B')
+    expect(last.board[1][0]).toBe('B')
+  })
+
+  it('captures a multi-stone group when its last liberty is filled', () => {
+    // Two connected white stones fully surrounded by black.
+    const moves: Move[] = [
+      { color: 'W', position: { row: 5, col: 5 } },
+      { color: 'W', position: { row: 5, col: 6 } },
+      { color: 'B', position: { row: 4, col: 5 } },
+      { color: 'B', position: { row: 4, col: 6 } },
+      { color: 'B', position: { row: 6, col: 5 } },
+      { color: 'B', position: { row: 6, col: 6 } },
+      { color: 'B', position: { row: 5, col: 4 } },
+      { color: 'B', position: { row: 5, col: 7 } },
+    ]
+    const states = computeBoardStates(moves)
+    const last = states[states.length - 1]
+    expect(last.captured).toEqual(
+      expect.arrayContaining([
+        { row: 5, col: 5 },
+        { row: 5, col: 6 },
+      ]),
+    )
+    expect(last.captured.length).toBe(2)
+    expect(last.board[5][5]).toBe(null)
+    expect(last.board[5][6]).toBe(null)
+  })
+
+  it('removes a self-capturing (suicide) stone with no liberties', () => {
+    const moves: Move[] = [
+      { color: 'B', position: { row: 0, col: 1 } },
+      { color: 'B', position: { row: 1, col: 0 } },
+      { color: 'W', position: { row: 0, col: 0 } },
+    ]
+    const states = computeBoardStates(moves)
+    const last = states[states.length - 1]
+    expect(last.captured).toEqual([{ row: 0, col: 0 }])
+    expect(last.board[0][0]).toBe(null)
+    expect(last.board[0][1]).toBe('B')
+    expect(last.board[1][0]).toBe('B')
+  })
+
+  it('is not a self-capture when the move simultaneously captures an opponent group that frees a liberty', () => {
+    // White plays at P=(5,5), whose only apparent liberty is a lone black
+    // stone at E=(5,6) that itself has zero liberties once P is filled.
+    // Captures must resolve before the mover's own liberties are checked,
+    // so this is a legal capturing move, not suicide.
+    const moves: Move[] = [
+      { color: 'B', position: { row: 4, col: 5 } }, // N
+      { color: 'B', position: { row: 6, col: 5 } }, // S
+      { color: 'B', position: { row: 5, col: 4 } }, // W
+      { color: 'W', position: { row: 4, col: 6 } },
+      { color: 'W', position: { row: 6, col: 6 } },
+      { color: 'W', position: { row: 5, col: 7 } },
+      { color: 'B', position: { row: 5, col: 6 } }, // E, lone stone pinned by the three whites above
+      { color: 'W', position: { row: 5, col: 5 } }, // P
+    ]
+    const states = computeBoardStates(moves)
+    const last = states[states.length - 1]
+    expect(last.captured).toEqual([{ row: 5, col: 6 }])
+    expect(last.board[5][5]).toBe('W')
+    expect(last.board[5][6]).toBe(null)
+  })
+})
+
+describe('computeBoardStates', () => {
+  it('produces one entry per move, numbered from 1', () => {
+    const moves: Move[] = [
+      { color: 'B', position: { row: 0, col: 0 } },
+      { color: 'W', position: { row: 1, col: 1 } },
+      { color: 'B', position: { row: 2, col: 2 } },
+    ]
+    const states = computeBoardStates(moves)
+    expect(states.map((state) => state.moveNumber)).toEqual([1, 2, 3])
+    expect(states.map((state) => state.move)).toEqual(moves)
+  })
+
+  it('carries stones forward across moves without duplicating captures', () => {
+    const moves: Move[] = [
+      { color: 'B', position: { row: 0, col: 0 } },
+      { color: 'W', position: { row: 5, col: 5 } },
+    ]
+    const states = computeBoardStates(moves)
+    expect(states[0].board[0][0]).toBe('B')
+    expect(states[1].board[0][0]).toBe('B')
+    expect(states[1].board[5][5]).toBe('W')
+  })
+})

--- a/src/lib/leviathan/pipeline.test.ts
+++ b/src/lib/leviathan/pipeline.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ATTENTION_ROW_COUNT,
+  PIPELINE_LOOP_LENGTH,
+  buildAttentionCellModels,
+  buildFenCharModels,
+  buildTokenModels,
+  candidateSetIndexForCycle,
+  computePipelineFrame,
+  cycleForTick,
+  frameForTick,
+  settledPipelineFrame,
+  stageAtFrame,
+} from './pipeline'
+
+describe('frameForTick', () => {
+  it('wraps ticks into [0, loopLength)', () => {
+    expect(frameForTick(0)).toBe(0)
+    expect(frameForTick(PIPELINE_LOOP_LENGTH)).toBe(0)
+    expect(frameForTick(PIPELINE_LOOP_LENGTH + 5)).toBe(5)
+  })
+
+  it('wraps negative ticks into a positive frame', () => {
+    expect(frameForTick(-1)).toBe(PIPELINE_LOOP_LENGTH - 1)
+  })
+
+  it('respects a custom loop length', () => {
+    expect(frameForTick(10, 4)).toBe(2)
+  })
+})
+
+describe('cycleForTick', () => {
+  it('increments once per full loop', () => {
+    expect(cycleForTick(0)).toBe(0)
+    expect(cycleForTick(PIPELINE_LOOP_LENGTH - 1)).toBe(0)
+    expect(cycleForTick(PIPELINE_LOOP_LENGTH)).toBe(1)
+    expect(cycleForTick(PIPELINE_LOOP_LENGTH * 2 + 3)).toBe(2)
+  })
+})
+
+describe('stageAtFrame', () => {
+  it('reports the active stage at each stage boundary', () => {
+    expect(stageAtFrame(0)).toBe('position')
+    expect(stageAtFrame(17)).toBe('position')
+    expect(stageAtFrame(18)).toBe('tokens')
+    expect(stageAtFrame(27)).toBe('tokens')
+    expect(stageAtFrame(28)).toBe('attention')
+    expect(stageAtFrame(53)).toBe('attention')
+    expect(stageAtFrame(54)).toBe('policy')
+    expect(stageAtFrame(63)).toBe('policy')
+    expect(stageAtFrame(64)).toBe('move')
+    expect(stageAtFrame(PIPELINE_LOOP_LENGTH - 1)).toBe('move')
+  })
+})
+
+describe('computePipelineFrame', () => {
+  it('reveals nothing at frame 0', () => {
+    const model = computePipelineFrame(0, 40, 6)
+    expect(model.frame).toBe(0)
+    expect(model.cycle).toBe(0)
+    expect(model.stage).toBe('position')
+    expect(model.positionRevealCount).toBe(0)
+    expect(model.tokensRevealedCount).toBe(0)
+    expect(model.attentionRowsRevealed).toBe(0)
+    expect(model.policyRevealed).toBe(false)
+    expect(model.moveRevealed).toBe(false)
+  })
+
+  it('reveals tokens one at a time once the tokens stage starts', () => {
+    const model = computePipelineFrame(20, 40, 6)
+    expect(model.stage).toBe('tokens')
+    expect(model.tokensRevealedCount).toBe(3) // 20 - 18 + 1
+  })
+
+  it('caps tokensRevealedCount at tokenCount', () => {
+    const model = computePipelineFrame(30, 40, 2)
+    expect(model.tokensRevealedCount).toBe(2)
+  })
+
+  it('reveals the fully-scanned position string by the end of the position stage', () => {
+    const model = computePipelineFrame(18, 40, 6)
+    expect(model.positionRevealCount).toBe(40)
+  })
+
+  it('sets policyRevealed and moveRevealed at their stage boundaries', () => {
+    expect(computePipelineFrame(53, 10, 4).policyRevealed).toBe(false)
+    expect(computePipelineFrame(54, 10, 4).policyRevealed).toBe(true)
+    expect(computePipelineFrame(63, 10, 4).moveRevealed).toBe(false)
+    expect(computePipelineFrame(64, 10, 4).moveRevealed).toBe(true)
+  })
+
+  it('tracks the cycle count across loop boundaries', () => {
+    const model = computePipelineFrame(PIPELINE_LOOP_LENGTH + 10, 40, 6)
+    expect(model.cycle).toBe(1)
+    expect(model.frame).toBe(10)
+  })
+})
+
+describe('settledPipelineFrame', () => {
+  it('fully reveals every stage using the last frame of the loop', () => {
+    const model = settledPipelineFrame(40, 6)
+    expect(model.frame).toBe(PIPELINE_LOOP_LENGTH - 1)
+    expect(model.stage).toBe('move')
+    expect(model.positionRevealCount).toBe(40)
+    expect(model.tokensRevealedCount).toBe(6)
+    expect(model.attentionRowsRevealed).toBe(ATTENTION_ROW_COUNT)
+    expect(model.policyRevealed).toBe(true)
+    expect(model.moveRevealed).toBe(true)
+  })
+})
+
+describe('candidateSetIndexForCycle', () => {
+  it('rotates deterministically through the available sets', () => {
+    expect(candidateSetIndexForCycle(0, 3)).toBe(0)
+    expect(candidateSetIndexForCycle(1, 3)).toBe(1)
+    expect(candidateSetIndexForCycle(3, 3)).toBe(0)
+    expect(candidateSetIndexForCycle(4, 3)).toBe(1)
+  })
+
+  it('wraps negative cycles into range', () => {
+    expect(candidateSetIndexForCycle(-1, 3)).toBe(2)
+  })
+
+  it('returns 0 when there are no candidate sets', () => {
+    expect(candidateSetIndexForCycle(5, 0)).toBe(0)
+  })
+})
+
+describe('buildFenCharModels', () => {
+  it('marks characters before the reveal count as revealed, with a cursor at the last one', () => {
+    const models = buildFenCharModels('abc', 2)
+    expect(models).toEqual([
+      { ch: 'a', revealed: true, isCursor: false },
+      { ch: 'b', revealed: true, isCursor: true },
+      { ch: 'c', revealed: false, isCursor: false },
+    ])
+  })
+
+  it('has no cursor when nothing has been revealed', () => {
+    const models = buildFenCharModels('abc', 0)
+    expect(models.every((m) => !m.isCursor && !m.revealed)).toBe(true)
+  })
+})
+
+describe('buildTokenModels', () => {
+  it('reveals only the leading tokens up to revealedCount', () => {
+    const models = buildTokenModels(['a', 'b', 'c'], 1)
+    expect(models).toEqual([
+      { id: 'a', revealed: true },
+      { id: 'b', revealed: false },
+      { id: 'c', revealed: false },
+    ])
+  })
+})
+
+describe('buildAttentionCellModels', () => {
+  it('masks cells above the causal diagonal and rows not yet revealed', () => {
+    const cells = buildAttentionCellModels(2, 3)
+    const masked = new Map(cells.map((cell) => [`${cell.row},${cell.col}`, cell.masked]))
+    // row 0: only col 0 is unmasked (col <= row)
+    expect(masked.get('0,0')).toBe(false)
+    expect(masked.get('0,1')).toBe(true)
+    expect(masked.get('0,2')).toBe(true)
+    // row 1: col 0 and 1 unmasked (col <= row), both within revealed rows
+    expect(masked.get('1,0')).toBe(false)
+    expect(masked.get('1,1')).toBe(false)
+    expect(masked.get('1,2')).toBe(true)
+    // row 2 is not yet revealed (attentionRowsRevealed = 2), so fully masked
+    expect(masked.get('2,0')).toBe(true)
+    expect(masked.get('2,1')).toBe(true)
+    expect(masked.get('2,2')).toBe(true)
+  })
+
+  it('gives masked cells the flat masked intensity', () => {
+    const cells = buildAttentionCellModels(0, 3)
+    expect(cells.every((cell) => cell.masked && cell.intensity === 0.05)).toBe(true)
+  })
+
+  it('computes a graduated intensity for unmasked cells', () => {
+    const cells = buildAttentionCellModels(3, 3)
+    const cell00 = cells.find((c) => c.row === 0 && c.col === 0)
+    const cell10 = cells.find((c) => c.row === 1 && c.col === 0)
+    expect(cell00?.intensity).toBeCloseTo(0.631, 3)
+    expect(cell10?.intensity).toBeCloseTo(0.3308, 3)
+  })
+})

--- a/src/lib/otherProjects/agentCluster.test.ts
+++ b/src/lib/otherProjects/agentCluster.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { AGENT_CYCLE_LENGTH, computeAgentClusterFrame, settledAgentClusterFrame } from './agentCluster'
+
+describe('computeAgentClusterFrame', () => {
+  it('returns one dot per agent, with sequential ids', () => {
+    const dots = computeAgentClusterFrame(0, 5)
+    expect(dots.map((dot) => dot.id)).toEqual([0, 1, 2, 3, 4])
+  })
+
+  it('returns an empty list for zero agents', () => {
+    expect(computeAgentClusterFrame(0, 0)).toEqual([])
+  })
+
+  it('starts a flaggable agent (index 0) idle, then active, then flagged over its cycle', () => {
+    // index 0 has phase offset 0 and is flaggable (0 % 7 === 0).
+    expect(computeAgentClusterFrame(0, 1)[0].state).toBe('idle')
+    expect(computeAgentClusterFrame(14, 1)[0].state).toBe('idle')
+    expect(computeAgentClusterFrame(15, 1)[0].state).toBe('active')
+    expect(computeAgentClusterFrame(20, 1)[0].state).toBe('active')
+    expect(computeAgentClusterFrame(21, 1)[0].state).toBe('flagged')
+    expect(computeAgentClusterFrame(23, 1)[0].state).toBe('flagged')
+  })
+
+  it('wraps a flaggable agent back to idle after one full cycle', () => {
+    expect(computeAgentClusterFrame(AGENT_CYCLE_LENGTH, 1)[0].state).toBe('idle')
+  })
+
+  it('never flags a non-flaggable agent, capping it at active', () => {
+    // index 1 is not flaggable (1 % 7 !== 0); its phase is offset by 5.
+    const dots = computeAgentClusterFrame(0, 2)
+    // phase for index 1 at tick 0 is (0 + 5) % 24 = 5 -> idle
+    expect(dots[1].state).toBe('idle')
+
+    // Push tick so index 1's phase lands in the flagged range (>= 21);
+    // it must still read 'active', never 'flagged'.
+    const flaggedRangeDots = computeAgentClusterFrame(16, 2) // phase = (16+5)%24 = 21
+    expect(flaggedRangeDots[1].state).toBe('active')
+  })
+
+  it('offsets each agent from its neighbours so the cluster is not in lockstep', () => {
+    const dots = computeAgentClusterFrame(15, 3)
+    // index 0: phase 15 -> active. index 1: phase (15+5)%24=20 -> active.
+    // index 2: phase (15+10)%24=1 -> idle.
+    expect(dots.map((d) => d.state)).toEqual(['active', 'active', 'idle'])
+  })
+})
+
+describe('settledAgentClusterFrame', () => {
+  it('matches the frame at the last tick of one cycle', () => {
+    expect(settledAgentClusterFrame(10)).toEqual(computeAgentClusterFrame(AGENT_CYCLE_LENGTH - 1, 10))
+  })
+
+  it('shows a mix of states rather than a single frozen state', () => {
+    const dots = settledAgentClusterFrame(10)
+    const states = new Set(dots.map((dot) => dot.state))
+    expect(states.size).toBeGreaterThan(1)
+  })
+})

--- a/src/lib/skills/graph.test.ts
+++ b/src/lib/skills/graph.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import type { HubLink, SkillGroup, SkillNode } from '@/data/skills'
+import { deriveSkillEdges, getEdgeVisualState, getNeighborIndices, getNodeVisualState, getSkillReadout } from './graph'
+
+function node(partial: Partial<SkillNode> & Pick<SkillNode, 'id' | 'group' | 'hub'>): SkillNode {
+  return { label: partial.id, x: 0, y: 0, note: `${partial.id} note`, ...partial }
+}
+
+// Two groups, each with a hub and two members, plus a hub-to-hub link.
+const NODES: readonly SkillNode[] = [
+  node({ id: 'hub0', group: 0, hub: true, label: 'Hub 0' }), // index 0
+  node({ id: 'member0a', group: 0, hub: false }), // index 1
+  node({ id: 'member0b', group: 0, hub: false }), // index 2
+  node({ id: 'hub1', group: 1, hub: true, label: 'Hub 1' }), // index 3
+  node({ id: 'member1a', group: 1, hub: false }), // index 4
+]
+
+const HUB_LINKS: readonly HubLink[] = [{ from: 0, to: 1 }]
+
+const GROUPS: readonly SkillGroup[] = [
+  { id: 0, name: 'GROUP ZERO' },
+  { id: 1, name: 'GROUP ONE' },
+]
+
+describe('deriveSkillEdges', () => {
+  it('adds a hub-to-member edge for every non-hub node, plus the hub-link edges', () => {
+    const edges = deriveSkillEdges(NODES, HUB_LINKS)
+    expect(edges).toEqual(
+      expect.arrayContaining([
+        { from: 0, to: 1 },
+        { from: 0, to: 2 },
+        { from: 3, to: 4 },
+        { from: 0, to: 3 },
+      ]),
+    )
+    expect(edges.length).toBe(4)
+  })
+
+  it('skips a member whose group has no hub in the node list', () => {
+    const orphan = node({ id: 'orphan', group: 99, hub: false })
+    const edges = deriveSkillEdges([...NODES, orphan], HUB_LINKS)
+    expect(edges.some((edge) => edge.to === NODES.length)).toBe(false)
+  })
+
+  it('skips a hub link whose group id has no matching hub', () => {
+    const edges = deriveSkillEdges(NODES, [{ from: 0, to: 99 }])
+    expect(edges.some((edge) => edge.from === 0 && edge.to === 99)).toBe(false)
+  })
+
+  it('returns no edges for an empty node list', () => {
+    expect(deriveSkillEdges([], [])).toEqual([])
+  })
+})
+
+describe('getNeighborIndices', () => {
+  const edges = deriveSkillEdges(NODES, HUB_LINKS)
+
+  it('returns an empty set when nothing is active', () => {
+    expect(getNeighborIndices(edges, null)).toEqual(new Set())
+  })
+
+  it('includes the active node plus every node directly connected to it', () => {
+    // Hub 0 connects to member0a, member0b, and hub1 (via the hub link).
+    expect(getNeighborIndices(edges, 0)).toEqual(new Set([0, 1, 2, 3]))
+  })
+
+  it('includes only the active node and its own hub for a member node', () => {
+    expect(getNeighborIndices(edges, 1)).toEqual(new Set([1, 0]))
+  })
+})
+
+describe('getNodeVisualState', () => {
+  const edges = deriveSkillEdges(NODES, HUB_LINKS)
+  const neighbors = getNeighborIndices(edges, 0)
+
+  it('marks the active node as active and not dimmed', () => {
+    expect(getNodeVisualState(0, 0, neighbors)).toEqual({ isActive: true, isDimmed: false })
+  })
+
+  it('does not dim a neighbour of the active node', () => {
+    expect(getNodeVisualState(1, 0, neighbors)).toEqual({ isActive: false, isDimmed: false })
+  })
+
+  it('dims a node that is neither active nor a neighbour', () => {
+    expect(getNodeVisualState(4, 0, neighbors)).toEqual({ isActive: false, isDimmed: true })
+  })
+
+  it('dims nothing when there is no active node', () => {
+    expect(getNodeVisualState(4, null, new Set())).toEqual({ isActive: false, isDimmed: false })
+  })
+})
+
+describe('getEdgeVisualState', () => {
+  const edges = deriveSkillEdges(NODES, HUB_LINKS)
+
+  it('lights up an edge touching the active node', () => {
+    expect(getEdgeVisualState(edges[0], 0)).toEqual({ isActive: true })
+  })
+
+  it('leaves an edge untouched by the active node inactive', () => {
+    const unrelatedEdge = { from: 3, to: 4 }
+    expect(getEdgeVisualState(unrelatedEdge, 0) as { isActive: boolean }).toEqual({ isActive: false })
+  })
+
+  it('is inactive for every edge when nothing is active', () => {
+    expect(getEdgeVisualState(edges[0], null)).toEqual({ isActive: false })
+  })
+})
+
+describe('getSkillReadout', () => {
+  it('reports the active node label, its group name, and its note', () => {
+    const readout = getSkillReadout(NODES, GROUPS, 1)
+    expect(readout).toEqual({
+      name: NODES[1].label,
+      groupLabel: 'GROUP ZERO',
+      note: NODES[1].note,
+      isActive: true,
+    })
+  })
+
+  it('falls back to an empty group label if the node references an unknown group', () => {
+    const strayNode = node({ id: 'stray', group: 42, hub: false })
+    const readout = getSkillReadout([strayNode], GROUPS, 0)
+    expect(readout.groupLabel).toBe('')
+  })
+
+  it('reports the default idle readout, counting groups and non-hub nodes, when nothing is active', () => {
+    const readout = getSkillReadout(NODES, GROUPS, null)
+    expect(readout.isActive).toBe(false)
+    expect(readout.name).toBe('SKILL GRAPH')
+    // 2 groups, 3 non-hub member nodes (member0a, member0b, member1a).
+    expect(readout.groupLabel).toBe('2 CLUSTERS · 3 TOOLS')
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url'
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
@@ -9,5 +9,9 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
+  },
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## Summary
- Adds Vitest, wired into the existing Vite config (`vitest/config` merge, `test: { environment: 'node', include: ['src/**/*.test.ts'] }`), and a `test` npm script (`vitest run`).
- Covers the four pure, side-effect-free modules under `src/lib/` through their existing exported interfaces — no production code restructured:
  - Go board model: move application, single- and multi-stone captures, self-capture (suicide) removal, and the capture-before-suicide ordering the module's own docstring calls out, plus invalid-move errors (occupied / out of bounds).
  - Inference-pipeline frame derivation: frame/cycle wrapping, stage boundaries, per-stage reveal counts, the settled (reduced-motion) frame, candidate-set rotation, and the per-character/per-token/per-cell model builders.
  - Agent-cluster state machine: idle → active → flagged transitions over successive ticks, the flaggable stride, the per-agent phase offset, and the settled frame.
  - Skills-graph edge derivation: hub→member and hub→hub edges, neighbour-set derivation, node/edge visual state, and the readout (active node vs. default idle counts).

Closes #353

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` — 4 files, 57 tests, all passing