### PR TITLE
Give the 880px breakpoint a single owner in JavaScript

### DIFF
--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { navItems } from '@/data/nav'
 import { cn } from '@/lib/cn'
+import { PANEL_QUERY, subscribeToMediaQuery } from '@/lib/useMediaQuery'
 
 /**
  * Mobile hamburger nav (#314).
@@ -32,14 +33,15 @@ import { cn } from '@/lib/cn'
  * Two things outside the panel itself have to be kept in sync while it's
  * open, both driven from this one effect:
  *
- * 1. Crossing the 880px `panel:` breakpoint (matching `useFitToViewport`'s
- *    `matchMedia` pattern) purely by CSS -- `panel:hidden` on this
- *    component's own root -- would hide the fixed full-screen panel (it's
- *    a descendant, so `display:none` cascades to it) while leaving `open`
- *    (and therefore the scroll lock) true, since resizing never touches
- *    React state on its own. A `matchMedia` listener closes the menu the
- *    moment the viewport crosses into desktop width so the lock always
- *    gets released.
+ * 1. Crossing the 880px `panel:` breakpoint purely by CSS -- `panel:hidden`
+ *    on this component's own root -- would hide the fixed full-screen panel
+ *    (it's a descendant, so `display:none` cascades to it) while leaving
+ *    `open` (and therefore the scroll lock) true, since resizing never
+ *    touches React state on its own. Subscribing to the shared panel query
+ *    (`subscribeToMediaQuery(PANEL_QUERY, ...)` from `useMediaQuery`, #354 --
+ *    the same module `useFitToViewport` and `usePrefersReducedMotion`
+ *    consume) closes the menu the moment the viewport crosses into desktop
+ *    width so the lock always gets released.
  * 2. Not trapping focus (see above) still leaves every *other* focusable
  *    thing on the page -- the trigger button itself, the site mark link,
  *    the theme picker, the clock, the skip link, all of `<main>` -- in
@@ -90,11 +92,9 @@ export function MobileNav() {
     }
     document.addEventListener('keydown', onKeyDown)
 
-    const panelQuery = window.matchMedia('(min-width: 880px)')
-    const onPanelChange = (event: MediaQueryListEvent) => {
-      if (event.matches) setOpen(false)
-    }
-    panelQuery.addEventListener('change', onPanelChange)
+    const unsubscribeFromPanelQuery = subscribeToMediaQuery(PANEL_QUERY, (matches) => {
+      if (matches) setOpen(false)
+    })
 
     const inertTargets: HTMLElement[] = []
     const wrapper = wrapperRef.current
@@ -116,7 +116,7 @@ export function MobileNav() {
     return () => {
       root.style.overflow = previousOverflow
       document.removeEventListener('keydown', onKeyDown)
-      panelQuery.removeEventListener('change', onPanelChange)
+      unsubscribeFromPanelQuery()
       for (const el of inertTargets) el.inert = false
     }
   }, [open])

--- a/src/lib/useFitToViewport.ts
+++ b/src/lib/useFitToViewport.ts
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react'
-
-const PANEL_QUERY = '(min-width: 880px)'
+import { PANEL_QUERY, queryMatches, subscribeToMediaQuery } from '@/lib/useMediaQuery'
 
 /**
  * Reproduces the design reference's `[data-fit]` shrink-to-fit mechanism.
@@ -29,12 +28,10 @@ export function useFitToViewport<T extends HTMLElement>(): React.RefObject<T | n
       return
     }
 
-    const mql = window.matchMedia(PANEL_QUERY)
-
     const fit = () => {
       const section = el.closest('section')
       el.style.setProperty('zoom', '1')
-      if (!section || !mql.matches) return
+      if (!section || !queryMatches(PANEL_QUERY)) return
 
       for (let pass = 0; pass < 3; pass++) {
         const over = section.getBoundingClientRect().height - window.innerHeight
@@ -56,7 +53,7 @@ export function useFitToViewport<T extends HTMLElement>(): React.RefObject<T | n
     fit()
     const initialTimer = setTimeout(fit, 300)
     window.addEventListener('resize', fitSoon, { passive: true })
-    mql.addEventListener('change', fitSoon)
+    const unsubscribe = subscribeToMediaQuery(PANEL_QUERY, fitSoon)
 
     let cancelled = false
     if (document.fonts && document.fonts.ready) {
@@ -70,7 +67,7 @@ export function useFitToViewport<T extends HTMLElement>(): React.RefObject<T | n
       clearTimeout(fitTimer)
       clearTimeout(initialTimer)
       window.removeEventListener('resize', fitSoon)
-      mql.removeEventListener('change', fitSoon)
+      unsubscribe()
     }
   }, [])
 

--- a/src/lib/useMediaQuery.test.ts
+++ b/src/lib/useMediaQuery.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PANEL_QUERY, queryMatches, subscribeToMediaQuery } from './useMediaQuery'
+
+/**
+ * Minimal fake `MediaQueryList`: enough of the `matchMedia` surface
+ * (`matches`, `addEventListener('change', ...)`, `removeEventListener`) for
+ * `useMediaQuery`'s consumers, plus a `trigger` helper so tests can flip
+ * `matches` and fire the same `change` listeners the browser would.
+ */
+class FakeMediaQueryList {
+  matches: boolean
+  private listeners = new Set<() => void>()
+
+  constructor(matches: boolean) {
+    this.matches = matches
+  }
+
+  addEventListener(type: 'change', listener: () => void) {
+    if (type === 'change') this.listeners.add(listener)
+  }
+
+  removeEventListener(type: 'change', listener: () => void) {
+    if (type === 'change') this.listeners.delete(listener)
+  }
+
+  trigger(matches: boolean) {
+    this.matches = matches
+    for (const listener of this.listeners) listener()
+  }
+
+  get listenerCount() {
+    return this.listeners.size
+  }
+}
+
+describe('PANEL_QUERY', () => {
+  it('is the one 880px breakpoint, expressed as a min-width query', () => {
+    expect(PANEL_QUERY).toBe('(min-width: 880px)')
+  })
+})
+
+describe('queryMatches', () => {
+  const originalWindow = globalThis.window
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      // @ts-expect-error -- restoring the no-window (Node test) baseline
+      delete globalThis.window
+    } else {
+      globalThis.window = originalWindow
+    }
+  })
+
+  it('returns false when window is undefined', () => {
+    // @ts-expect-error -- simulating an environment without `window`
+    delete globalThis.window
+    expect(queryMatches(PANEL_QUERY)).toBe(false)
+  })
+
+  it('returns false when matchMedia is not a function', () => {
+    // @ts-expect-error -- simulating jsdom's lack of matchMedia
+    globalThis.window = {}
+    expect(queryMatches(PANEL_QUERY)).toBe(false)
+  })
+
+  it('reflects the current match state from matchMedia', () => {
+    const mql = new FakeMediaQueryList(true)
+    // @ts-expect-error -- stubbing just enough of window for this read
+    globalThis.window = { matchMedia: () => mql }
+    expect(queryMatches(PANEL_QUERY)).toBe(true)
+
+    mql.trigger(false)
+    expect(queryMatches(PANEL_QUERY)).toBe(false)
+  })
+})
+
+describe('subscribeToMediaQuery', () => {
+  const originalWindow = globalThis.window
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      // @ts-expect-error -- restoring the no-window (Node test) baseline
+      delete globalThis.window
+    } else {
+      globalThis.window = originalWindow
+    }
+  })
+
+  it('returns a no-op cleanup when matchMedia is unavailable', () => {
+    // @ts-expect-error -- simulating an environment without matchMedia
+    delete globalThis.window
+    const onChange = vi.fn()
+    const unsubscribe = subscribeToMediaQuery(PANEL_QUERY, onChange)
+    expect(() => unsubscribe()).not.toThrow()
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('calls onChange with the new match state on every change', () => {
+    const mql = new FakeMediaQueryList(false)
+    // @ts-expect-error -- stubbing just enough of window for this subscription
+    globalThis.window = { matchMedia: () => mql }
+
+    const onChange = vi.fn()
+    subscribeToMediaQuery(PANEL_QUERY, onChange)
+
+    mql.trigger(true)
+    expect(onChange).toHaveBeenLastCalledWith(true)
+
+    mql.trigger(false)
+    expect(onChange).toHaveBeenLastCalledWith(false)
+  })
+
+  it('stops calling onChange after the returned cleanup runs', () => {
+    const mql = new FakeMediaQueryList(false)
+    // @ts-expect-error -- stubbing just enough of window for this subscription
+    globalThis.window = { matchMedia: () => mql }
+
+    const onChange = vi.fn()
+    const unsubscribe = subscribeToMediaQuery(PANEL_QUERY, onChange)
+    unsubscribe()
+
+    mql.trigger(true)
+    expect(onChange).not.toHaveBeenCalled()
+    expect(mql.listenerCount).toBe(0)
+  })
+})

--- a/src/lib/useMediaQuery.ts
+++ b/src/lib/useMediaQuery.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Single owner of media-query subscription on the JavaScript side, and of
+ * the one hard breakpoint (`PANEL_QUERY`, 880px) that the rest of the app
+ * cares about (#354).
+ *
+ * Before this module existed, three different places independently stated
+ * "880px" (or reimplemented the same subscribe/read/cleanup dance around a
+ * different query): `useFitToViewport`'s own `PANEL_QUERY` constant,
+ * `MobileNav`'s inline `matchMedia('(min-width: 880px)')` literal, and
+ * `usePrefersReducedMotion`'s hand-rolled `matchMedia` + `addEventListener`
+ * + `removeEventListener` cycle around `(prefers-reduced-motion: reduce)`.
+ * Everything below funnels through the same two primitives instead:
+ * `queryMatches` for a synchronous read and `subscribeToMediaQuery` for the
+ * live-update lifecycle. `usePanelBreakpoint` (backed by the generic
+ * `useMediaQuery`) is the one place "is the viewport at/above 880px"
+ * gets asked as a React hook.
+ *
+ * The CSS token (`--breakpoint-panel` in `src/index.css`, consumed as the
+ * `panel:` variant and by `@media (min-width: 880px)` in
+ * `src/styles/layout.css`) remains the authority for CSS. This module only
+ * owns the JavaScript side, which cannot read a CSS custom property to
+ * build a `matchMedia` query -- the string below has to be kept in sync
+ * with `--breakpoint-panel` by hand, but now there is exactly one place to
+ * do that instead of three.
+ */
+export const PANEL_QUERY = '(min-width: 880px)'
+
+function getMql(query: string): MediaQueryList | undefined {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return undefined
+  }
+  return window.matchMedia(query)
+}
+
+/** Synchronous read of whether `query` currently matches. */
+export function queryMatches(query: string): boolean {
+  return getMql(query)?.matches ?? false
+}
+
+/**
+ * Subscribes to changes in whether `query` matches, calling `onChange` with
+ * the new match state on every change. Returns the cleanup function; a
+ * no-op subscription (and no-op cleanup) is returned in environments
+ * without `matchMedia` (e.g. some test setups) rather than throwing.
+ */
+export function subscribeToMediaQuery(query: string, onChange: (matches: boolean) => void): () => void {
+  const mql = getMql(query)
+  if (!mql) return () => {}
+
+  const listener = () => onChange(mql.matches)
+  mql.addEventListener('change', listener)
+  return () => mql.removeEventListener('change', listener)
+}
+
+/** Tracks whether `query` currently matches, live. */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => queryMatches(query))
+
+  useEffect(() => subscribeToMediaQuery(query, setMatches), [query])
+
+  return matches
+}
+
+/** Tracks whether the viewport is at/above the 880px `panel:` breakpoint, live. */
+export function usePanelBreakpoint(): boolean {
+  return useMediaQuery(PANEL_QUERY)
+}

--- a/src/lib/usePrefersReducedMotion.ts
+++ b/src/lib/usePrefersReducedMotion.ts
@@ -1,13 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useMediaQuery } from '@/lib/useMediaQuery'
 
 const QUERY = '(prefers-reduced-motion: reduce)'
-
-function getInitialValue(): boolean {
-  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-    return false
-  }
-  return window.matchMedia(QUERY).matches
-}
 
 /**
  * Tracks the visitor's `prefers-reduced-motion` preference, live. If the OS
@@ -16,24 +9,13 @@ function getInitialValue(): boolean {
  * headline-stat counters) react immediately rather than only picking it up
  * on next load.
  *
- * Defaults to `false` (motion allowed) in environments without
- * `matchMedia` (e.g. some test setups) rather than throwing. jsdom does not
- * implement `window.matchMedia` at all (it is `undefined`, not a stub),
- * which is why both the initial read and the effect guard for it.
+ * Delegates the actual subscribe/read/cleanup dance to `useMediaQuery`
+ * (#354) -- this hook is just that generic hook pinned to the
+ * reduced-motion query. Defaults to `false` (motion allowed) in
+ * environments without `matchMedia` (e.g. some test setups) rather than
+ * throwing; see `useMediaQuery`'s own handling of that case. jsdom does not
+ * implement `window.matchMedia` at all (it is `undefined`, not a stub).
  */
 export function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(getInitialValue)
-
-  useEffect(() => {
-    if (typeof window.matchMedia !== 'function') return
-
-    const mql = window.matchMedia(QUERY)
-    const onChange = () => setReduced(mql.matches)
-
-    onChange()
-    mql.addEventListener('change', onChange)
-    return () => mql.removeEventListener('change', onChange)
-  }, [])
-
-  return reduced
+  return useMediaQuery(QUERY)
 }


### PR DESCRIPTION
## Summary
Closes #354.

880px is the only breakpoint, but three JavaScript places each stated it independently: `useFitToViewport` kept its own `PANEL_QUERY` constant, `MobileNav` retyped the literal `matchMedia('(min-width: 880px)')`, and `usePrefersReducedMotion` reimplemented the same subscribe/read/cleanup dance around a different query.

- New module `src/lib/useMediaQuery.ts` owns media-query subscription: `PANEL_QUERY` (the one 880px value), `queryMatches` (sync read), `subscribeToMediaQuery` (the one subscribe/cleanup implementation), the generic `useMediaQuery` hook, and `usePanelBreakpoint` for callers that just want a boolean.
- `useFitToViewport` now calls `queryMatches(PANEL_QUERY)` inside its fit pass and `subscribeToMediaQuery(PANEL_QUERY, fitSoon)` for the change lifecycle, instead of holding its own `MediaQueryList`.
- `MobileNav` subscribes via `subscribeToMediaQuery(PANEL_QUERY, ...)` instead of building its own `matchMedia('(min-width: 880px)')`.
- `usePrefersReducedMotion` is now a one-line wrapper around `useMediaQuery('(prefers-reduced-motion: reduce)')` — same query as before (not the panel query; the issue's ask was to share the *pattern*, not to conflate the two concerns), subscribe/cleanup logic deleted from that file entirely.
- CSS (`--breakpoint-panel` in `src/index.css`, `@media (min-width: 880px)` in `src/styles/layout.css`) is untouched — still the CSS-side authority.

The only remaining `(min-width: 880px)` string literal in `src/**/*.{ts,tsx}` lives in `useMediaQuery.ts` itself (plus an assertion of that same value in its test).

## Verified
- `npm run typecheck` — passes (`tsc -b`, no errors)
- `npm run lint` — passes (0 problems; this surfaced a real `react-hooks/set-state-in-effect` violation in an early draft of `useMediaQuery`, fixed by dropping the redundant synchronous `setMatches` call in the effect body)
- `npm run build` — passes, `dist/` produced
- `npx vitest run` — 5 files / 64 tests passed, including the new `src/lib/useMediaQuery.test.ts` (constant value, `queryMatches` in no-window/no-matchMedia/normal cases, `subscribeToMediaQuery`'s change notifications and cleanup, via a small fake `MediaQueryList`)

## Not verified
- No browser check at 375px/1440px — this environment has no display. The vitest project runs its `lib` tests under the `node` environment (no jsdom/DOM here at all), so there's no automated exercise of the actual React hooks (`useFitToViewport`, `MobileNav`, `usePrefersReducedMotion`) either; the new tests cover the shared module's non-React logic only, and the three consumers were checked by reading the diffs plus `tsc`/`build` succeeding, not by rendering them. Someone with a browser should confirm: mobile menu closes when crossing above 880px, viewport-fit only runs above it, reduced-motion still tracks live OS changes, and desktop rendering (1440px) is unchanged from before this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized media-query handling for responsive layouts and accessibility preferences.
  * Added graceful fallback behavior for environments without media-query support.

* **Bug Fixes**
  * Mobile navigation now closes automatically when switching to desktop-width layouts.
  * Improved responsive viewport fitting and reduced-motion detection consistency.

* **Tests**
  * Added comprehensive coverage for media-query matching, subscriptions, updates, cleanup, and unsupported browser environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->