### PR TITLE
Share the animation tick helpers

### DIFF
--- a/src/components/hero/GoBoardReplay.tsx
+++ b/src/components/hero/GoBoardReplay.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { GAME4_BLACK_LABEL, GAME4_CAPTION, GAME4_WHITE_LABEL } from '@/data/hero'
+import { startAnimationFrameLoop } from '@/lib/animationFrameLoop'
 import { cn } from '@/lib/cn'
 import { BOARD_SIZE } from '@/lib/go/board'
 import {
@@ -91,13 +92,10 @@ function BoardGrid({ frame }: { frame: BoardFrame }) {
 export function GoBoardReplay() {
   const reducedMotion = usePrefersReducedMotion()
   const [elapsed, setElapsed] = useState(0)
-  const startRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (reducedMotion) return undefined
 
-    startRef.current = null
-    let frameId: number
     // Signature of "what would render" (move number, phase, whether a
     // capture is mid-fade) for the most recent tick that actually
     // triggered a re-render. Ticks that would produce an identical
@@ -112,9 +110,7 @@ export function GoBoardReplay() {
     // by JS every tick, not CSS, so it must never skip.
     let lastSignature: string | null = null
 
-    const tick = (timestamp: number) => {
-      if (startRef.current === null) startRef.current = timestamp
-      const nextElapsed = timestamp - startRef.current
+    return startAnimationFrameLoop((nextElapsed) => {
       const timing = frameAtElapsed(nextElapsed)
       const signature = `${timing.moveNumber}|${timing.phase}|${hasActiveCaptureFade(timing.loopElapsed)}`
 
@@ -122,12 +118,7 @@ export function GoBoardReplay() {
         lastSignature = signature
         setElapsed(nextElapsed)
       }
-
-      frameId = requestAnimationFrame(tick)
-    }
-    frameId = requestAnimationFrame(tick)
-
-    return () => cancelAnimationFrame(frameId)
+    })
   }, [reducedMotion])
 
   let frame: BoardFrame

--- a/src/components/hero/HeroTagline.tsx
+++ b/src/components/hero/HeroTagline.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
+import { startAnimationFrameLoop } from '@/lib/animationFrameLoop'
 import { cn } from '@/lib/cn'
 import { isTypingDone, typedText } from '@/lib/hero/typewriter'
 import { usePrefersReducedMotion } from '@/lib/usePrefersReducedMotion'
@@ -22,26 +23,15 @@ interface HeroTaglineProps {
 export function HeroTagline({ text, className }: HeroTaglineProps) {
   const reducedMotion = usePrefersReducedMotion()
   const [elapsed, setElapsed] = useState(0)
-  const startRef = useRef<number | null>(null)
 
   useEffect(() => {
     if (reducedMotion) return undefined
     if (isTypingDone(text, 0)) return undefined
 
-    startRef.current = null
-    let frameId: number
-
-    const tick = (timestamp: number) => {
-      if (startRef.current === null) startRef.current = timestamp
-      const next = timestamp - startRef.current
+    return startAnimationFrameLoop((next) => {
       setElapsed(next)
-      if (!isTypingDone(text, next)) {
-        frameId = requestAnimationFrame(tick)
-      }
-    }
-    frameId = requestAnimationFrame(tick)
-
-    return () => cancelAnimationFrame(frameId)
+      return !isTypingDone(text, next)
+    })
     // Runs once per mount / per reduced-motion change; `text` is static content.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reducedMotion])

--- a/src/components/layout/Clock.tsx
+++ b/src/components/layout/Clock.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
-import { usePrefersReducedMotion } from '@/lib/usePrefersReducedMotion'
 import { cn } from '@/lib/cn'
+import { startIntervalTick } from '@/lib/intervalTick'
+import { usePrefersReducedMotion } from '@/lib/usePrefersReducedMotion'
 
 function formatClock(date: Date): { hm: string; s: string } {
   const pad = (value: number) => String(value).padStart(2, '0')
@@ -35,10 +36,9 @@ export function Clock() {
   const [now, setNow] = useState(() => new Date())
 
   useEffect(() => {
-    if (reducedMotion) return
+    if (reducedMotion) return undefined
 
-    const id = setInterval(() => setNow(new Date()), 1000)
-    return () => clearInterval(id)
+    return startIntervalTick(() => setNow(new Date()), 1000)
   }, [reducedMotion])
 
   const { hm, s } = formatClock(now)

--- a/src/components/sections/leviathan/InferencePipeline.tsx
+++ b/src/components/sections/leviathan/InferencePipeline.tsx
@@ -7,6 +7,7 @@ import {
   PIPELINE_TOKEN_IDS,
 } from '@/data/leviathan'
 import { cn } from '@/lib/cn'
+import { startIntervalTick } from '@/lib/intervalTick'
 import {
   ATTENTION_ROW_COUNT,
   buildAttentionCellModels,
@@ -95,9 +96,8 @@ export function InferencePipeline() {
   const [tick, setTick] = useState(0)
 
   useEffect(() => {
-    if (reducedMotion) return
-    const id = setInterval(() => setTick((t) => t + 1), FRAME_INTERVAL_MS)
-    return () => clearInterval(id)
+    if (reducedMotion) return undefined
+    return startIntervalTick(() => setTick((t) => t + 1), FRAME_INTERVAL_MS)
   }, [reducedMotion])
 
   const frameModel = reducedMotion

--- a/src/components/sections/leviathan/StatCounter.tsx
+++ b/src/components/sections/leviathan/StatCounter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type { LeviathanStat } from '@/data/leviathan'
+import { startAnimationFrameLoop } from '@/lib/animationFrameLoop'
 import { countUpValue } from '@/lib/leviathan/countUp'
 import { usePrefersReducedMotion } from '@/lib/usePrefersReducedMotion'
 
@@ -43,18 +44,13 @@ export function StatCounter({ stat }: StatCounterProps) {
     const node = ref.current
     if (!node) return
 
-    let frameId = 0
+    let cancelLoop: (() => void) | undefined
 
     const startCountUp = () => {
-      const start = performance.now()
-      const tick = (now: number) => {
-        const elapsed = now - start
+      cancelLoop = startAnimationFrameLoop((elapsed) => {
         setAnimated(countUpValue(stat.target, elapsed, COUNT_DURATION_MS))
-        if (elapsed < COUNT_DURATION_MS) {
-          frameId = requestAnimationFrame(tick)
-        }
-      }
-      frameId = requestAnimationFrame(tick)
+        return elapsed < COUNT_DURATION_MS
+      })
     }
 
     const observer = new IntersectionObserver(
@@ -72,7 +68,7 @@ export function StatCounter({ stat }: StatCounterProps) {
 
     return () => {
       observer.disconnect()
-      if (frameId) cancelAnimationFrame(frameId)
+      cancelLoop?.()
     }
   }, [showFinal, stat])
 

--- a/src/components/sections/otherProjects/AgentCluster.tsx
+++ b/src/components/sections/otherProjects/AgentCluster.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { AGENT_DOT_COUNT } from '@/data/otherProjects'
 import { cn } from '@/lib/cn'
+import { startIntervalTick } from '@/lib/intervalTick'
 import {
   type AgentState,
   computeAgentClusterFrame,
@@ -42,9 +43,8 @@ export function AgentCluster({ className }: { className?: string } = {}) {
   const [tick, setTick] = useState(0)
 
   useEffect(() => {
-    if (reducedMotion) return
-    const id = setInterval(() => setTick((t) => t + 1), FRAME_INTERVAL_MS)
-    return () => clearInterval(id)
+    if (reducedMotion) return undefined
+    return startIntervalTick(() => setTick((t) => t + 1), FRAME_INTERVAL_MS)
   }, [reducedMotion])
 
   const dots = reducedMotion

--- a/src/lib/animationFrameLoop.test.ts
+++ b/src/lib/animationFrameLoop.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { vi } from 'vitest'
+import { startAnimationFrameLoop } from './animationFrameLoop'
+
+/**
+ * Minimal requestAnimationFrame/cancelAnimationFrame fake. The test
+ * environment is Node (no DOM, no real rAF clock), so frames are stepped
+ * explicitly via `runFrame(timestamp)` instead of relying on real time.
+ */
+function installFakeRaf() {
+  let nextId = 1
+  const callbacks = new Map<number, FrameRequestCallback>()
+
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    const id = nextId++
+    callbacks.set(id, cb)
+    return id
+  })
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    callbacks.delete(id)
+  })
+
+  return {
+    /** Invokes every callback currently pending, as one animation frame. */
+    runFrame(timestamp: number) {
+      const pending = [...callbacks.values()]
+      callbacks.clear()
+      for (const cb of pending) cb(timestamp)
+    },
+    pendingCount() {
+      return callbacks.size
+    },
+  }
+}
+
+describe('startAnimationFrameLoop', () => {
+  let raf: ReturnType<typeof installFakeRaf>
+
+  beforeEach(() => {
+    raf = installFakeRaf()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('measures elapsed time from the first frame, not from call time', () => {
+    const elapsedValues: number[] = []
+    startAnimationFrameLoop((elapsed) => {
+      elapsedValues.push(elapsed)
+    })
+
+    raf.runFrame(1000)
+    raf.runFrame(1016)
+    raf.runFrame(1032)
+
+    expect(elapsedValues).toEqual([0, 16, 32])
+  })
+
+  it('reschedules another frame after each tick by default', () => {
+    startAnimationFrameLoop(() => undefined)
+
+    expect(raf.pendingCount()).toBe(1)
+    raf.runFrame(0)
+    expect(raf.pendingCount()).toBe(1)
+    raf.runFrame(16)
+    expect(raf.pendingCount()).toBe(1)
+  })
+
+  it('stops rescheduling once onTick returns false', () => {
+    let ticks = 0
+    startAnimationFrameLoop((elapsed) => {
+      ticks++
+      return elapsed < 20
+    })
+
+    raf.runFrame(0) // elapsed 0 -> continue
+    expect(raf.pendingCount()).toBe(1)
+    raf.runFrame(30) // elapsed 30 -> stop
+    expect(raf.pendingCount()).toBe(0)
+    expect(ticks).toBe(2)
+  })
+
+  it('cancels the pending frame when the returned cancel function is called', () => {
+    const cancel = startAnimationFrameLoop(() => undefined)
+
+    expect(raf.pendingCount()).toBe(1)
+    cancel()
+    expect(raf.pendingCount()).toBe(0)
+  })
+
+  it('does not invoke onTick again after cancellation even if a stray frame fires', () => {
+    const onTick = vi.fn()
+    const cancel = startAnimationFrameLoop(onTick)
+    cancel()
+
+    // Simulate a frame that was already in flight before cancellation took
+    // effect: our fake clears callbacks on cancel, so nothing should fire.
+    raf.runFrame(0)
+
+    expect(onTick).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/animationFrameLoop.ts
+++ b/src/lib/animationFrameLoop.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared `requestAnimationFrame` loop shape (issue #358).
+ *
+ * Three components (the hero Go board replay, the hero tagline typer, and
+ * the leviathan stat counter) each hand-rolled the same effect: capture a
+ * start timestamp on the first frame, compute elapsed time since then on
+ * every subsequent frame, do some work with that elapsed value, and keep
+ * rescheduling until told to stop or unmounted. This is that loop, factored
+ * out once so the scheduling/timestamp/cleanup plumbing only has to be
+ * gotten right in one place.
+ *
+ * `onTick` receives the elapsed time (ms) since the loop started and does
+ * whatever per-frame work the caller needs (typically a `setState` call).
+ * Returning `false` stops the loop after that tick (the callback will not
+ * be invoked again); any other return value (including `undefined`, the
+ * common case for a callback with no explicit return) keeps it going.
+ *
+ * This is a plain function, not a hook: callers decide when to start the
+ * loop (some start it unconditionally from a mount effect, others start it
+ * on demand from inside an `IntersectionObserver` callback) and are
+ * responsible for their own reduced-motion gating before calling it. It
+ * returns a cancel function, meant to be used directly as a React effect's
+ * cleanup return value.
+ */
+export function startAnimationFrameLoop(onTick: (elapsedMs: number) => boolean | void): () => void {
+  let frameId: number
+  let start: number | null = null
+
+  const tick = (timestamp: number) => {
+    if (start === null) start = timestamp
+    const elapsed = timestamp - start
+    const shouldContinue = onTick(elapsed) !== false
+    if (shouldContinue) {
+      frameId = requestAnimationFrame(tick)
+    }
+  }
+
+  frameId = requestAnimationFrame(tick)
+
+  return () => cancelAnimationFrame(frameId)
+}

--- a/src/lib/intervalTick.test.ts
+++ b/src/lib/intervalTick.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { startIntervalTick } from './intervalTick'
+
+describe('startIntervalTick', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('calls the callback every delayMs', () => {
+    const callback = vi.fn()
+    startIntervalTick(callback, 100)
+
+    vi.advanceTimersByTime(350)
+
+    expect(callback).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not call the callback before the first delay elapses', () => {
+    const callback = vi.fn()
+    startIntervalTick(callback, 100)
+
+    vi.advanceTimersByTime(99)
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('stops calling the callback once the returned cancel function runs', () => {
+    const callback = vi.fn()
+    const cancel = startIntervalTick(callback, 100)
+
+    vi.advanceTimersByTime(100)
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    cancel()
+    vi.advanceTimersByTime(500)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/intervalTick.ts
+++ b/src/lib/intervalTick.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared `setInterval` tick shape (issue #358).
+ *
+ * Three components (the header clock, the leviathan inference pipeline,
+ * and the "other projects" agent cluster) each hand-rolled the same
+ * effect: start a `setInterval` on mount, tick a callback every `delayMs`,
+ * and `clearInterval` on unmount. This is that effect, factored out once.
+ *
+ * A plain function rather than a hook, matching `startAnimationFrameLoop`:
+ * callers invoke it from inside their own effect, after their own
+ * reduced-motion gate, and return the cancel function as that effect's
+ * cleanup.
+ */
+export function startIntervalTick(callback: () => void, delayMs: number): () => void {
+  const id = setInterval(callback, delayMs)
+  return () => clearInterval(id)
+}


### PR DESCRIPTION
## Summary

Closes #358.

Verified the issue's claim against the code: it holds. Three components hand-rolled the same `requestAnimationFrame` elapsed-time loop (capture start timestamp, compute elapsed, do work, reschedule, cancel on unmount):

- Hero Go board replay
- Hero tagline typer
- Leviathan stat counter (count-up on scroll into view)

...and three more hand-rolled the same `setInterval` tick effect (start on mount, tick every N ms, clear on unmount):

- Header clock (1000ms)
- Inference pipeline (110ms)
- Agent cluster (260ms)

`ScrollProgressBar` also uses `requestAnimationFrame`, but for a different shape entirely — it coalesces scroll/resize events into at most one pending frame rather than running a self-rescheduling loop — so it was deliberately left untouched; forcing it through the new helper would change its behavior.

## What changed

- `src/lib/animationFrameLoop.ts` — `startAnimationFrameLoop(onTick)`: runs the rAF loop, measures elapsed time from the first frame, and keeps rescheduling until `onTick` returns `false` or the returned cancel function is called.
- `src/lib/intervalTick.ts` — `startIntervalTick(callback, delayMs)`: wraps `setInterval`/`clearInterval` and returns a cancel function.
- Both are plain functions, not hooks — each consumer still does its own reduced-motion gate (`if (reducedMotion) return undefined`) before calling the helper and returns the helper's cancel function directly as its effect cleanup. This matches how the components already used the pattern (e.g. the stat counter starts its loop on demand from an `IntersectionObserver` callback, not from the mount effect itself), so no consumer needed a hook wrapping `useEffect`.
- All six consumers now route through one of the two helpers; the per-consumer business logic (frame-signature dedupe in the Go board replay, typing-done check in the tagline, count-up duration in the stat counter) stays in the component, since that part isn't shared.

## Timing

No interval period, duration, or easing changed: 1000ms / 110ms / 260ms intervals are untouched, and the rAF loop still measures elapsed time the same way (from the first invoked frame). One micro-timing note: the stat counter previously took its "start" timestamp from `performance.now()` at the moment the `IntersectionObserver` callback fired, then measured elapsed against the first rAF timestamp; the shared helper instead starts the clock at the first rAF timestamp itself. The difference is sub-frame (a few ms at most) and not observable.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npx vitest run` — 65 tests passed (6 files), including new `animationFrameLoop.test.ts` and `intervalTick.test.ts` covering: elapsed measured from first frame, default rescheduling, stopping when the tick callback returns `false`, cancellation, and (for the interval helper) fake-timer-driven call counts and cancellation.
- [ ] Browser verification at 375px/1440px — **not done**. This change is behavioral, not visual, and I have no browser in this environment. Animation smoothness/feel is exactly what green tests don't cover — someone should eyeball the hero replay, hero tagline, scroll progress bar (unchanged), clock, inference pipeline, and agent cluster at both widths before merging.

## Left undone

- Manual browser verification (see above).