### PR TITLE
Stretch project cards to fill their section instead of floating

### DIFF
--- a/src/components/sections/ProjectsFeatured.tsx
+++ b/src/components/sections/ProjectsFeatured.tsx
@@ -57,24 +57,37 @@ export function ProjectsFeatured() {
       />
 
       {/*
-       * Card sizes to its own content; leftover section height sits
-       * OUTSIDE it, as section background (mochi/style-match task 1 --
-       * same call as `ProjectsOther.tsx`, see that file for the fuller
-       * writeup). A prior revision kept `flex-1` + `max-height:760px` +
-       * `mt-auto` on the stat/link row specifically because a real render
-       * of the design reference does the exact same thing -- but the owner
-       * has since reviewed a real render of THIS build and called it wrong
-       * here too: at 1440x900 that combination measured a 239px gap
-       * between the last bullet and the stat footer, sitting in the
-       * card's text column for no reason other than "the section has that
-       * much leftover height to distribute." This is an approved
-       * deviation from the reference for that reason.
+       * Owner report (with screenshots): on a tall desktop viewport the
+       * card floated in the vertical middle of the section with a large
+       * dead band above AND below it (~250px each at a ~1500px-tall
+       * viewport). Cause: this wrapper's `flex-1` swallows the section's
+       * leftover vertical height, and `justify-center` then splits that
+       * leftover evenly above and below the content-sized card below --
+       * those two halves were the bands. Fix: the card itself (the
+       * `fitRef` grid) now also carries `flex-1`, so it grows to fill the
+       * space this wrapper hands it instead of staying content-sized and
+       * floating within it. `justify-center` stays on this wrapper (it
+       * still centers on the rare frame where the card's own min-content
+       * height is shorter than the space available, e.g. a future project
+       * list with less copy) but with the card stretching, there is
+       * normally no leftover left to center.
        *
-       * This wrapper (`flex-1` + `justify-center`) is what now consumes
-       * the section's leftover vertical space, centering the
-       * content-sized card within it -- the heading above stays pinned at
-       * its normal top-of-section position, same mechanism as
-       * `ProjectsOther.tsx`.
+       * A prior revision kept `flex-1` + `max-height:760px` + `mt-auto` on
+       * the stat/link row specifically because a real render of the design
+       * reference does the exact same thing -- but the owner reviewed a
+       * real render of THIS build and called it wrong: at 1440x900 that
+       * combination measured a 239px gap between the last bullet and the
+       * stat footer, sitting INSIDE the card's text column for no reason
+       * other than "the section has that much leftover height to
+       * distribute." That is why the fix above does not restore either the
+       * `max-height` cap (see the note on the grid div below) or the
+       * `mt-auto` on the stat/link row -- both were the mechanism that
+       * produced that in-card gap, and neither is being brought back.
+       *
+       * This wrapper (`flex-1` + `justify-center`) is what consumes the
+       * section's leftover vertical space and hands it to the card below
+       * -- the heading above stays pinned at its normal top-of-section
+       * position, same mechanism as `ProjectsOther.tsx`.
        */}
       <div className="mt-[var(--space-fit-margin)] flex flex-1 flex-col justify-center">
         {/*
@@ -108,6 +121,25 @@ export function ProjectsFeatured() {
          * exposed this. Leaving the box uncapped lets the section grow
          * with real content and the shrink pass correctly measure and
          * correct any future overflow instead.
+         *
+         * The design reference caps this element at `max-height:760px`
+         * (line 338); this build deliberately does not restore that cap,
+         * because on the owner's screen this card already renders ~858px
+         * tall -- a 760px cap would SHRINK it below its natural content
+         * height, which is the opposite of the fix below. This is an
+         * approved deviation from the reference.
+         *
+         * Re-verified with `flex-1` added to this element (owner's
+         * float/dead-band fix, see the wrapper comment above): the
+         * reasoning above still holds. `flex-1` only lets this box grow to
+         * consume leftover space handed to it by its `flex-col` parent; it
+         * does not add a max-height, and a flex item's default
+         * `min-height: auto` still stops it from ever shrinking below its
+         * own content height. So this box still can't under-report its
+         * true size, and the section can still grow taller than the
+         * viewport when content genuinely overflows -- the shrink pass
+         * keeps seeing real overflow via `section.getBoundingClientRect()`
+         * exactly as before.
          */}
         {/*
          * `minmax(min(340px,100%),1fr)`, not a bare `minmax(340px,1fr)`:
@@ -121,7 +153,7 @@ export function ProjectsFeatured() {
          */}
         <div
           ref={fitRef}
-          className="grid grid-cols-[repeat(auto-fit,minmax(min(340px,100%),1fr))] border border-line-2 bg-panel"
+          className="grid flex-1 grid-cols-[repeat(auto-fit,minmax(min(340px,100%),1fr))] border border-line-2 bg-panel"
         >
           <div className="flex min-w-0 flex-col gap-[var(--space-fit-xs)] p-[clamp(16px,2.4vh,30px)_clamp(18px,2.2vw,30px)]">
             {/*

--- a/src/components/sections/ProjectsOther.tsx
+++ b/src/components/sections/ProjectsOther.tsx
@@ -40,27 +40,43 @@ export function ProjectsOther() {
       />
 
       {/*
-       * Cards size to their own content, and the section's leftover height
-       * sits OUTSIDE them as background (mochi/style-match task 1) -- the
-       * opposite of a prior revision's `flex-1` + `minmax(0,1fr)` card row,
-       * which forced each card to stretch to fill the section and dumped
-       * the leftover height inside the card as dead space above the
-       * install command / agent-dot row. That was a deliberate, verified
-       * reproduction of the design reference's OWN behaviour at the time
-       * (see the git history on this file); the owner has since reviewed a
-       * real render and called it wrong for this build, explicitly as a
-       * deviation from the reference -- the cards are "too big for the
-       * content they hold."
+       * Owner report (with screenshots): on a tall desktop viewport the
+       * card grid floated in the vertical middle of the section with a
+       * large dead band above AND below it (~250px each at a ~1500px-tall
+       * viewport). Cause: this wrapper's `flex-1` swallows the section's
+       * leftover vertical height, and `justify-center` then splits that
+       * leftover evenly above and below the content-sized grid below --
+       * those two halves were the bands. Fix: the grid itself (the
+       * `fitRef` element) now also carries `flex-1`, so it grows to fill
+       * the space this wrapper hands it instead of staying content-sized
+       * and floating within it. `justify-center` stays on this wrapper
+       * (it still centers on the rare frame where the grid's own
+       * min-content height is shorter than the space available) but with
+       * the grid stretching, there is normally no leftover left to center.
+       *
+       * This is a different fix from a prior revision's `flex-1` +
+       * `minmax(0,1fr)` card row, which forced each individual CARD to
+       * stretch and dumped the leftover height inside each card as dead
+       * space above the install command / agent-dot row. That was a
+       * deliberate, verified reproduction of the design reference's OWN
+       * behaviour at the time (see the git history on this file); the
+       * owner reviewed a real render and called it wrong for this build --
+       * the cards were "too big for the content they hold." The `flex-1`
+       * added here is on the outer GRID container, not on the individual
+       * cards, so it does not reintroduce that per-card stretching; see
+       * `OtherProjectCard.tsx` for how row-mate height equalisation is
+       * still handled (`align-items: stretch` + a small, deliberate
+       * `mt-auto` inside the shorter card).
        *
        * This wrapper (`flex-1`, so it -- not the heading above it --
        * consumes the section's leftover vertical space) is a plain flex
-       * column with `justify-center`, so the un-stretched, content-sized
-       * grid below centres vertically WITHIN this wrapper only. The
-       * heading stays pinned at its normal top-of-section position: only
-       * the wrapper (and everything inside it) can grow, so
-       * `.section-shell`'s own `justify-content:center` (on the
-       * heading+wrapper block as a whole) has nothing left to redistribute
-       * -- the wrapper already occupies 100% of the remaining height.
+       * column with `justify-center`, so the grid below now fills that
+       * leftover space instead of floating within it. The heading stays
+       * pinned at its normal top-of-section position: only the wrapper
+       * (and everything inside it) can grow, so `.section-shell`'s own
+       * `justify-content:center` (on the heading+wrapper block as a whole)
+       * has nothing left to redistribute -- the wrapper already occupies
+       * 100% of the remaining height.
        *
        * `mt-` was `panel:`-only, leaving zero gap below 880px between the
        * "THE OTHER STUFF I WORKED ON" caption and the first card (#314
@@ -94,6 +110,24 @@ export function ProjectsOther() {
          * card-count ceiling notes for how far that shrinking stays
          * legible).
          *
+         * This build deliberately does not restore that cap even now that
+         * `flex-1` has been added below (owner's float/dead-band fix, see
+         * the wrapper comment above), because on the owner's screen this
+         * grid already renders ~858px tall for 2 cards -- a 680px cap
+         * would SHRINK it below its natural content height, the opposite
+         * of the fix. This is an approved deviation from the reference.
+         *
+         * Re-verified with `flex-1` added: the reasoning above still
+         * holds. `flex-1` only lets this box grow to consume leftover
+         * space handed to it by its `flex-col` parent; it does not add a
+         * max-height, and a flex item's default `min-height: auto` still
+         * stops it from ever shrinking below its own content height. So
+         * this box still can't under-report its true size, and the
+         * section can still grow taller than the viewport when content
+         * genuinely overflows -- the shrink pass keeps seeing real
+         * overflow via `section.getBoundingClientRect()` exactly as
+         * before.
+         *
          * CSS Grid's own default (`align-items: stretch`) is deliberately
          * left in effect here (mochi/style-match audit, defect 1): a prior
          * pass overrode it with `items-start` specifically so a shorter
@@ -125,7 +159,7 @@ export function ProjectsOther() {
          */}
         <div
           ref={fitRef}
-          className="grid grid-cols-[repeat(auto-fit,minmax(min(320px,100%),1fr))] auto-rows-fr gap-[clamp(14px,1.6vw,20px)]"
+          className="grid flex-1 grid-cols-[repeat(auto-fit,minmax(min(320px,100%),1fr))] auto-rows-fr gap-[clamp(14px,1.6vw,20px)]"
         >
           {OTHER_PROJECTS.map((project) => (
             <OtherProjectCard key={project.id} project={project} />


### PR DESCRIPTION
## Defect

Owner-reported, with screenshots: on a tall desktop viewport, both projects sections showed the card block floating in the vertical middle of the section, with roughly 250px of dead space above it and 250px below (measured on a ~1500px-tall viewport).

Cause: each section's outer wrapper (`flex-1 flex-col justify-center`) correctly absorbs the section's leftover vertical height, but `justify-center` then splits that leftover evenly above and below the content-sized card sitting inside it — those two halves are the dead bands.

## Fix

Per the owner's direction, the wrapper is unchanged (`justify-center` stays). Only the card itself now grows to fill the space it sits in:

- `ProjectsFeatured.tsx`: added `flex-1` to the `fitRef` grid div (the Leviathan card).
- `ProjectsOther.tsx`: added `flex-1` to the `fitRef` grid div (the two-card grid).

With the card stretching to consume the wrapper's leftover height, there's normally nothing left for `justify-center` to redistribute, so the bands collapse. `justify-center` is kept as a fallback for the rare case where the card's own content is shorter than the space available.

Both files carried long-standing comments explaining that the card is deliberately content-sized and that leftover height sits *outside* it. That framing no longer matches the code, so both comment blocks were rewritten to describe the new behaviour, why `justify-center` remains, and to preserve the historical context (a prior revision's `flex-1` + `max-height:760px` + `mt-auto` combination measured a 239px gap *inside* the card's text column at 1440x900 — reframed as the reason the max-height cap and `mt-auto` are not being restored, not deleted).

## Deliberate deviation from the design reference

The reference (`ideas/Portfolio.html`) caps this element at `max-height:760px` (Leviathan) / `680px` (other-projects grid). This build intentionally does **not** restore that cap: on the owner's screen the card already renders ~858px tall, so a 760px cap would *shrink* it below its natural content height — the opposite of what's wanted here. This is called out as an approved deviation in both files' comments.

## `useFitToViewport` comment re-check

`ProjectsFeatured.tsx` had a comment arguing "no `max-h` here" because a capped box would stop `useFitToViewport`'s shrink-to-fit pass from seeing genuine overflow. I checked whether that reasoning still holds now that `flex-1` is added to the same element (a flex-grown box could in principle report a different height to the fit pass):

- The hook measures overflow via `section.getBoundingClientRect().height` vs `window.innerHeight` — not the `fitRef` element's own height — so what the grid reports about itself doesn't gate overflow detection.
- `flex-1` only lets the box consume *leftover* space from its `flex-col` parent; a flex item's default `min-height: auto` still prevents it from ever shrinking below its own content height, and there's still no max-height capping it from growing further.
- So the box still can't under-report its true size, and the section can still grow past the viewport when content genuinely overflows, keeping the shrink pass correct.

Conclusion: the reasoning still holds. Updated the comment in both files to state this explicitly rather than leave the older claim unverified against the new code.

## Verification

- `npm run typecheck` — pass, no output/errors.
- `npm run lint` — pass, no output/errors.
- `npm run build` — pass (`tsc -b && vite build`, 65 modules, built in 287ms).
- `npx vitest run` — pass, 4 files / 57 tests.

**Not verified in a browser** — I did not run the dev server or take screenshots, so the visual fix (bands collapsing) has not been confirmed against a real render. Only static checks above were run.