### PR TITLE
Make viewport-fit invariants structural

### DIFF
--- a/src/components/layout/FitRegion.tsx
+++ b/src/components/layout/FitRegion.tsx
@@ -1,0 +1,51 @@
+import type { ComponentPropsWithoutRef } from 'react'
+import { useSectionFitClaim } from '@/components/layout/sectionFitContext'
+import type { FitStrategy } from '@/lib/fitStrategy'
+import { useFitToViewport } from '@/lib/useFitToViewport'
+
+interface FitRegionProps extends Omit<ComponentPropsWithoutRef<'div'>, 'ref'> {
+  /**
+   * Swaps the correction math `useFitToViewport` runs (`src/lib/
+   * fitStrategy.ts`). Defaults to the reference's own CSS-`zoom` mechanism;
+   * exists so a different fitting approach can be tried per-region without
+   * touching the section that renders it.
+   */
+  strategy?: FitStrategy
+}
+
+/**
+ * The one place the four sections that need to shrink to fit one viewport
+ * (`EducationExperience`, `ProjectsOther`, `ProjectsFeatured`,
+ * `SkillsGraph`) get that behaviour, instead of each repeating the same
+ * `ref`/`data-fit` wiring around `useFitToViewport` directly (#356).
+ *
+ * Two invariants that used to live only in a comment are now structural:
+ *
+ * - **Must be inside a `<Section>`.** `useSectionFitClaim()` throws
+ *   immediately if there is no enclosing `Section` -- there is nothing for
+ *   the hook to measure against otherwise, so this used to fail silently
+ *   (the hook's own `el.closest('section')` check would just find nothing
+ *   and no-op forever). Now it fails loudly, at the source.
+ * - **At most one per section.** `Section` hands out a single `FitClaim`
+ *   to its subtree; the first `FitRegion` to mount claims it, and any
+ *   further one in the same section is refused rather than silently
+ *   compounding its `zoom` with the first's (`src/lib/fitClaim.ts`,
+ *   `useFitToViewport.ts`). The refused region logs a `console.error` and
+ *   simply does not shrink, instead of the two fighting invisibly.
+ *
+ * `data-fit=""` is applied uniformly here, matching the design reference's
+ * own attribute on these elements -- previously two of the four call sites
+ * carried it and two didn't, an inconsistency with no behavioural effect
+ * (nothing in `src/styles/*.css` selects on `[data-fit]`) but worth fixing
+ * now that the markup lives in one place.
+ */
+export function FitRegion({ strategy, children, ...rest }: FitRegionProps) {
+  const claim = useSectionFitClaim()
+  const fitRef = useFitToViewport<HTMLDivElement>(claim, strategy)
+
+  return (
+    <div ref={fitRef} data-fit="" {...rest}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/layout/Section.tsx
+++ b/src/components/layout/Section.tsx
@@ -1,5 +1,7 @@
-import type { ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
+import { SectionFitContext } from '@/components/layout/sectionFitContext'
 import { cn } from '@/lib/cn'
+import { createFitClaim } from '@/lib/fitClaim'
 
 interface SectionProps {
   id: string
@@ -31,15 +33,22 @@ interface SectionProps {
  * (via `headingId`) means there is exactly one place the name is written,
  * instead of a separate `aria-label` string that has to be kept in sync
  * with a heading assistive tech users can already see and hear.
+ *
+ * Also provides the `FitClaim` (`src/lib/fitClaim.ts`) its subtree's
+ * `FitRegion`(s) (`FitRegion.tsx`) contend for -- one instance per
+ * `Section`, stable for its whole lifetime, so at most one `FitRegion`
+ * inside it can ever be active at a time (#356).
  */
 export function Section({ id, headingId, children, className }: SectionProps) {
+  const [fitClaim] = useState(createFitClaim)
+
   return (
     <section
       id={id}
       aria-labelledby={headingId}
       className={cn('section-shell', className)}
     >
-      {children}
+      <SectionFitContext.Provider value={fitClaim}>{children}</SectionFitContext.Provider>
     </section>
   )
 }

--- a/src/components/layout/sectionFitContext.ts
+++ b/src/components/layout/sectionFitContext.ts
@@ -1,0 +1,28 @@
+import { createContext, useContext } from 'react'
+import type { FitClaim } from '@/lib/fitClaim'
+
+/**
+ * The claim a `Section`'s own `FitRegion`(s) contend for (`src/lib/
+ * fitClaim.ts`). `Section` provides one instance per section; `FitRegion`
+ * reads it via `useSectionFitClaim`.
+ *
+ * Split out of `Section.tsx` itself so that file can stay component-only
+ * (react-refresh's fast-refresh lint rule requires files that export a
+ * component to export nothing else).
+ */
+export const SectionFitContext = createContext<FitClaim | null>(null)
+
+/**
+ * Throws when called outside a `<Section>` -- there is nothing sensible
+ * for a fit region to measure against without one (`useFitToViewport` fits
+ * an element to its *owning section's* rendered height), so `FitRegion`
+ * uses this to make "attach fit behaviour outside a section" a
+ * build-time-visible mistake instead of a silently-broken runtime no-op.
+ */
+export function useSectionFitClaim(): FitClaim {
+  const claim = useContext(SectionFitContext)
+  if (!claim) {
+    throw new Error('<FitRegion> must be rendered inside a <Section>; there is no section for it to fit to.')
+  }
+  return claim
+}

--- a/src/components/sections/EducationExperience.tsx
+++ b/src/components/sections/EducationExperience.tsx
@@ -1,9 +1,9 @@
+import { FitRegion } from '@/components/layout/FitRegion'
 import { Section } from '@/components/layout/Section'
 import { SectionHeading } from '@/components/layout/SectionHeading'
 import { EDUCATION_COLUMN, EXPERIENCE_COLUMN, type TimelineColumn, type TimelineEntry } from '@/data/timeline'
 import { getSectionMeta } from '@/data/sections'
 import { cn } from '@/lib/cn'
-import { useFitToViewport } from '@/lib/useFitToViewport'
 
 const meta = getSectionMeta('path')
 
@@ -27,8 +27,6 @@ const meta = getSectionMeta('path')
  * presentation: no dates, titles, or bullets are written here.
  */
 export function EducationExperience() {
-  const fitRef = useFitToViewport<HTMLDivElement>()
-
   return (
     <Section id={meta.id} headingId="path-heading">
       <SectionHeading number={meta.number} title={meta.title} headingId="path-heading" />
@@ -103,15 +101,13 @@ export function EducationExperience() {
        * cells, same mechanism as before, just without the two empty
        * spacer tracks.
        */}
-      <div
-        ref={fitRef}
+      <FitRegion
         data-pathgrid=""
-        data-fit=""
         className="mt-[var(--space-fit-margin-tight)] grid flex-1 grid-flow-col auto-cols-[minmax(0,1fr)] grid-rows-[auto_repeat(2,auto_auto_auto_minmax(0,1fr))] gap-px border border-line-2 bg-line max-h-[720px]"
       >
         <TimelineColumnCells column={EDUCATION_COLUMN} kind="education" />
         <TimelineColumnCells column={EXPERIENCE_COLUMN} kind="experience" />
-      </div>
+      </FitRegion>
     </Section>
   )
 }

--- a/src/components/sections/ProjectsFeatured.tsx
+++ b/src/components/sections/ProjectsFeatured.tsx
@@ -1,3 +1,4 @@
+import { FitRegion } from '@/components/layout/FitRegion'
 import { Section } from '@/components/layout/Section'
 import { SectionHeading } from '@/components/layout/SectionHeading'
 import { InferencePipeline } from '@/components/sections/leviathan/InferencePipeline'
@@ -14,7 +15,6 @@ import {
   LEVIATHAN_SUMMARY,
 } from '@/data/leviathan'
 import { getSectionMeta } from '@/data/sections'
-import { useFitToViewport } from '@/lib/useFitToViewport'
 
 const meta = getSectionMeta('projects')
 
@@ -45,8 +45,6 @@ const meta = getSectionMeta('projects')
  * themselves.
  */
 export function ProjectsFeatured() {
-  const fitRef = useFitToViewport<HTMLDivElement>()
-
   return (
     <Section id={meta.id} headingId="projects-heading">
       <SectionHeading
@@ -176,10 +174,7 @@ export function ProjectsFeatured() {
          * the container is wide enough, so this is a no-op above that
          * width -- desktop is unaffected.
          */}
-        <div
-          ref={fitRef}
-          className="grid grid-cols-[repeat(auto-fit,minmax(min(340px,100%),1fr))] border border-line-2 bg-panel panel:min-h-[68dvh]"
-        >
+        <FitRegion className="grid grid-cols-[repeat(auto-fit,minmax(min(340px,100%),1fr))] border border-line-2 bg-panel panel:min-h-[68dvh]">
           <ProjectCardShell>
             {/*
              * Title row is the shared `ProjectCardTitleRow`
@@ -257,7 +252,7 @@ export function ProjectsFeatured() {
           <div className="flex min-w-0 flex-col justify-center border-line bg-panel-2 p-[clamp(14px,2.2vh,26px)_clamp(16px,2vw,26px)] panel:border-l">
             <InferencePipeline />
           </div>
-        </div>
+        </FitRegion>
       </div>
     </Section>
   )

--- a/src/components/sections/ProjectsOther.tsx
+++ b/src/components/sections/ProjectsOther.tsx
@@ -1,9 +1,9 @@
+import { FitRegion } from '@/components/layout/FitRegion'
 import { Section } from '@/components/layout/Section'
 import { SectionHeading } from '@/components/layout/SectionHeading'
 import { OtherProjectCard } from '@/components/sections/otherProjects/OtherProjectCard'
 import { OTHER_PROJECTS } from '@/data/otherProjects'
 import { getSectionMeta } from '@/data/sections'
-import { useFitToViewport } from '@/lib/useFitToViewport'
 
 const meta = getSectionMeta('more')
 
@@ -28,8 +28,6 @@ const meta = getSectionMeta('more')
  * on their account.
  */
 export function ProjectsOther() {
-  const fitRef = useFitToViewport<HTMLDivElement>()
-
   return (
     <Section id={meta.id} headingId="more-heading">
       <SectionHeading
@@ -203,14 +201,11 @@ export function ProjectsOther() {
          * content size, so both cards end up equal without touching the
          * 880px+ single-row case (a no-op there, same as today).
          */}
-        <div
-          ref={fitRef}
-          className="grid grid-cols-[repeat(auto-fit,minmax(min(320px,100%),1fr))] auto-rows-fr gap-[clamp(14px,1.6vw,20px)] panel:min-h-[52dvh]"
-        >
+        <FitRegion className="grid grid-cols-[repeat(auto-fit,minmax(min(320px,100%),1fr))] auto-rows-fr gap-[clamp(14px,1.6vw,20px)] panel:min-h-[52dvh]">
           {OTHER_PROJECTS.map((project) => (
             <OtherProjectCard key={project.id} project={project} />
           ))}
-        </div>
+        </FitRegion>
       </div>
     </Section>
   )

--- a/src/components/sections/skills/SkillsGraph.tsx
+++ b/src/components/sections/skills/SkillsGraph.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { FitRegion } from '@/components/layout/FitRegion'
 import { HUB_LINKS, SKILL_GROUPS, SKILL_NODES } from '@/data/skills'
 import { cn } from '@/lib/cn'
 import {
@@ -8,7 +9,6 @@ import {
   getNodeVisualState,
   getSkillReadout,
 } from '@/lib/skills/graph'
-import { useFitToViewport } from '@/lib/useFitToViewport'
 import { usePrefersReducedMotion } from '@/lib/usePrefersReducedMotion'
 
 /** Computed once — `SKILL_NODES`/`HUB_LINKS` are static imports, not per-render state. */
@@ -67,7 +67,6 @@ const GROUP_DOT_CLASSES: Record<number, { readonly bg: string; readonly border: 
  * and the active node still visually stands out, just without animating.
  */
 export function SkillsGraph() {
-  const fitRef = useFitToViewport<HTMLDivElement>()
   const panelRef = useRef<HTMLDivElement>(null)
   const reducedMotion = usePrefersReducedMotion()
 
@@ -106,11 +105,7 @@ export function SkillsGraph() {
   }, [activeIndex])
 
   return (
-    <div
-      ref={fitRef}
-      data-fit=""
-      className="mt-[var(--space-fit-margin-tight)] grid max-h-[760px] flex-1 grid-cols-[minmax(0,1fr)] grid-rows-[minmax(0,1fr)_auto] gap-[14px]"
-    >
+    <FitRegion className="mt-[var(--space-fit-margin-tight)] grid max-h-[760px] flex-1 grid-cols-[minmax(0,1fr)] grid-rows-[minmax(0,1fr)_auto] gap-[14px]">
       <div
         ref={panelRef}
         className="relative aspect-square min-h-0 border border-line-2 bg-panel px-[clamp(30px,5vw,60px)] py-[clamp(22px,3.4vh,42px)] panel:aspect-auto"
@@ -220,6 +215,6 @@ export function SkillsGraph() {
         <span className="text-[9.5px] tracking-[0.18em] text-accent">{readout.groupLabel}</span>
         <span className="text-[13px] text-dim [text-wrap:pretty]">{readout.note}</span>
       </div>
-    </div>
+    </FitRegion>
   )
 }

--- a/src/lib/fitClaim.test.ts
+++ b/src/lib/fitClaim.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { createFitClaim } from './fitClaim'
+
+describe('createFitClaim', () => {
+  it('starts unheld', () => {
+    expect(createFitClaim().isHeld).toBe(false)
+  })
+
+  it('lets the first caller claim it', () => {
+    const claim = createFitClaim()
+    expect(claim.claim()).toBe(true)
+    expect(claim.isHeld).toBe(true)
+  })
+
+  it('refuses a second claim while the first is still held', () => {
+    const claim = createFitClaim()
+    claim.claim()
+    expect(claim.claim()).toBe(false)
+    expect(claim.isHeld).toBe(true)
+  })
+
+  it('lets a new claimant succeed after release', () => {
+    const claim = createFitClaim()
+    claim.claim()
+    claim.release()
+    expect(claim.isHeld).toBe(false)
+    expect(claim.claim()).toBe(true)
+  })
+
+  it('tolerates a release that was never preceded by a successful claim', () => {
+    const claim = createFitClaim()
+    expect(() => claim.release()).not.toThrow()
+    expect(claim.isHeld).toBe(false)
+  })
+
+  it('keeps claims from separate instances independent', () => {
+    const a = createFitClaim()
+    const b = createFitClaim()
+    expect(a.claim()).toBe(true)
+    expect(b.claim()).toBe(true)
+  })
+})

--- a/src/lib/fitClaim.ts
+++ b/src/lib/fitClaim.ts
@@ -1,0 +1,42 @@
+/**
+ * Guards against two `FitRegion`s (`src/components/layout/FitRegion.tsx`)
+ * being active inside the same section at once.
+ *
+ * `useFitToViewport` drives a section's shrink-to-fit correction by writing
+ * a CSS `zoom` onto its element -- `zoom` compounds with any other `zoom`
+ * already in effect on a descendant, so two fitted regions sharing one
+ * `<section>` would silently double-correct each other rather than
+ * independently reaching a sane size. A single `<section>` genuinely only
+ * ever needs one such region (the whole point is "shrink THIS section to
+ * fit one screen"), so this is a claim, not a counter: the first region to
+ * mount inside a given `Section` holds it, and any further one that tries
+ * to mount there is refused rather than silently compounding.
+ *
+ * Deliberately plain (no React import) so it is fully unit-testable without
+ * a DOM.
+ */
+export interface FitClaim {
+  /** Attempts to take the claim. Returns `true` if it succeeded (no other holder), `false` if it was already held. */
+  claim(): boolean
+  /** Releases the claim. Safe to call even if this caller never held it. */
+  release(): void
+  /** Whether the claim is currently held by anyone. */
+  readonly isHeld: boolean
+}
+
+export function createFitClaim(): FitClaim {
+  let held = false
+  return {
+    claim() {
+      if (held) return false
+      held = true
+      return true
+    },
+    release() {
+      held = false
+    },
+    get isHeld() {
+      return held
+    },
+  }
+}

--- a/src/lib/fitStrategy.test.ts
+++ b/src/lib/fitStrategy.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { isResidualOverflow, zoomFitStrategy } from './fitStrategy'
+
+describe('zoomFitStrategy.nextCorrection', () => {
+  it('proposes no correction once the section already fits (overflow <= 1px)', () => {
+    expect(zoomFitStrategy.nextCorrection({ overflowPx: 1, elementHeightPx: 500, currentScale: 1 })).toBeNull()
+    expect(zoomFitStrategy.nextCorrection({ overflowPx: 0, elementHeightPx: 500, currentScale: 1 })).toBeNull()
+    expect(zoomFitStrategy.nextCorrection({ overflowPx: -20, elementHeightPx: 500, currentScale: 1 })).toBeNull()
+  })
+
+  it('proposes no correction when the element reports no height to measure against', () => {
+    expect(zoomFitStrategy.nextCorrection({ overflowPx: 50, elementHeightPx: 0, currentScale: 1 })).toBeNull()
+    expect(zoomFitStrategy.nextCorrection({ overflowPx: 50, elementHeightPx: -10, currentScale: 1 })).toBeNull()
+  })
+
+  it('shrinks proportionally to how much of the element the overflow represents', () => {
+    // 100px of a 1000px-tall element overflowing -> keep 90% of the current scale.
+    const correction = zoomFitStrategy.nextCorrection({ overflowPx: 100, elementHeightPx: 1000, currentScale: 1 })
+    expect(correction).not.toBeNull()
+    expect(correction?.scale).toBeCloseTo(0.9)
+    expect(correction?.cssValue).toBe(String(correction?.scale))
+  })
+
+  it('compounds against a scale already applied from a previous pass', () => {
+    const correction = zoomFitStrategy.nextCorrection({ overflowPx: 50, elementHeightPx: 500, currentScale: 0.7 })
+    expect(correction?.scale).toBeCloseTo(0.7 * 0.9)
+  })
+
+  it('never proposes a scale below its own floor, however large the overflow', () => {
+    const correction = zoomFitStrategy.nextCorrection({ overflowPx: 900, elementHeightPx: 1000, currentScale: 1 })
+    expect(correction?.scale).toBe(zoomFitStrategy.floor)
+  })
+
+  it('never proposes a scale below its floor even compounding from an already-shrunk scale', () => {
+    const correction = zoomFitStrategy.nextCorrection({ overflowPx: 900, elementHeightPx: 1000, currentScale: 0.65 })
+    expect(correction?.scale).toBe(zoomFitStrategy.floor)
+  })
+})
+
+describe('isResidualOverflow', () => {
+  it('is false when the section fits (overflow at/under the 1px tolerance)', () => {
+    expect(isResidualOverflow(1, zoomFitStrategy.floor, zoomFitStrategy)).toBe(false)
+    expect(isResidualOverflow(0, zoomFitStrategy.floor, zoomFitStrategy)).toBe(false)
+  })
+
+  it('is false when real overflow remains but the floor has not been reached yet', () => {
+    expect(isResidualOverflow(50, 0.9, zoomFitStrategy)).toBe(false)
+  })
+
+  it('is true once the floor is reached and the section still overflows', () => {
+    expect(isResidualOverflow(50, zoomFitStrategy.floor, zoomFitStrategy)).toBe(true)
+  })
+
+  it('is true for a scale below the floor too (defensive: should never happen, but must not hide the case)', () => {
+    expect(isResidualOverflow(50, zoomFitStrategy.floor - 0.1, zoomFitStrategy)).toBe(true)
+  })
+})

--- a/src/lib/fitStrategy.ts
+++ b/src/lib/fitStrategy.ts
@@ -1,0 +1,67 @@
+/**
+ * The correction math `useFitToViewport` runs each pass, factored out as a
+ * swappable, DOM-free `FitStrategy` so the shrink-to-fit *mechanism* (CSS
+ * `zoom`, a 0.6 floor, up to 3 passes) is one interchangeable implementation
+ * of the hook's contract ("given how far the section overflows, propose a
+ * smaller scale") rather than baked into the hook itself.
+ */
+
+/** One pass's measurements, gathered from the live DOM by the caller. */
+export interface FitPassInput {
+  /** How many px the owning section's rendered height exceeds `window.innerHeight` by. Non-positive means it already fits. */
+  overflowPx: number
+  /** The fitted element's own rendered height for this pass. */
+  elementHeightPx: number
+  /** The scale already applied from the previous pass (1 = unscaled). */
+  currentScale: number
+}
+
+/** A proposed correction: the new scale, and the CSS declaration that applies it. */
+export interface FitCorrection {
+  scale: number
+  cssValue: string
+}
+
+export interface FitStrategy {
+  /** CSS property this strategy drives (e.g. `'zoom'`). */
+  readonly cssProperty: string
+  /** Value that neutralises the property, applied before each measurement pass and on cleanup. */
+  readonly resetValue: string
+  /** The smallest scale this strategy will ever propose. */
+  readonly floor: number
+  /** Maximum correction passes attempted before giving up. */
+  readonly maxPasses: number
+  /** Proposes the next correction, or `null` if no further correction should be attempted (already fits, or nothing more to try). */
+  nextCorrection(input: FitPassInput): FitCorrection | null
+}
+
+const FLOOR = 0.6
+
+/**
+ * Direct port of the design reference's own runtime behaviour (see
+ * `useFitToViewport.ts`'s header comment for the full history): shrink via
+ * CSS `zoom`, floor at 0.6x, stop once the section is within 1px of fitting
+ * or the element reports no height to measure against.
+ */
+export const zoomFitStrategy: FitStrategy = {
+  cssProperty: 'zoom',
+  resetValue: '1',
+  floor: FLOOR,
+  maxPasses: 3,
+  nextCorrection({ overflowPx, elementHeightPx, currentScale }) {
+    if (overflowPx <= 1) return null
+    if (elementHeightPx <= 0) return null
+    const scale = Math.max(FLOOR, currentScale * Math.max(FLOOR, (elementHeightPx - overflowPx) / elementHeightPx))
+    return { scale, cssValue: String(scale) }
+  },
+}
+
+/**
+ * Whether a finished fit pass should be surfaced to a developer as a "gave
+ * up, content still overflows" case rather than silently leaving the
+ * section too tall for the viewport. True once the strategy's floor has
+ * been reached and real overflow still remains.
+ */
+export function isResidualOverflow(finalOverflowPx: number, finalScale: number, strategy: FitStrategy): boolean {
+  return finalOverflowPx > 1 && finalScale <= strategy.floor
+}

--- a/src/lib/useFitToViewport.ts
+++ b/src/lib/useFitToViewport.ts
@@ -1,4 +1,6 @@
 import { useEffect, useRef } from 'react'
+import type { FitClaim } from '@/lib/fitClaim'
+import { isResidualOverflow, zoomFitStrategy, type FitStrategy } from '@/lib/fitStrategy'
 import { PANEL_QUERY, queryMatches, subscribeToMediaQuery } from '@/lib/useMediaQuery'
 
 /**
@@ -9,17 +11,29 @@ import { PANEL_QUERY, queryMatches, subscribeToMediaQuery } from '@/lib/useMedia
  * section growing past one viewport tall, but the reference does not rely
  * on that alone -- every `data-fit` element also gets a runtime pass that
  * measures its owning `<section>` against `window.innerHeight` and, if it
- * still overflows, scales the element down via CSS `zoom` (floor 0.6x,
- * up to 3 correction passes) until it fits or the floor is hit. That is
- * the actual mechanism that guarantees the "one section, one screen"
- * promise at viewport heights too short for the clamp bounds alone to
- * cover -- this hook is a direct port of it, not a reinterpretation.
+ * still overflows, scales the element down (via `strategy`, `zoomFitStrategy`
+ * by default -- CSS `zoom`, floor 0.6x, up to 3 correction passes) until it
+ * fits or the strategy gives up. That is the actual mechanism that
+ * guarantees the "one section, one screen" promise at viewport heights too
+ * short for the clamp bounds alone to cover.
  *
  * Only runs at/above the 880px panel breakpoint (`PANEL_QUERY`), where
  * `.section-shell` fixes sections to `100dvh` in the first place. Below
  * it sections are ordinary flow content -- nothing is ever shrunk there.
+ *
+ * This is the low-level primitive `FitRegion` (`src/components/layout/
+ * FitRegion.tsx`) is built on -- it is not meant to be reached for
+ * directly. It requires a `FitClaim` (from `src/lib/fitClaim.ts`) as proof
+ * that a section has already agreed to host exactly one fit region: the
+ * only sanctioned way to obtain one is `Section`'s own context, so a
+ * caller reaching for this hook still has to go through `FitRegion` (or
+ * explicitly work around that contract) rather than being able to attach
+ * fit behaviour to an arbitrary element with no owning section.
  */
-export function useFitToViewport<T extends HTMLElement>(): React.RefObject<T | null> {
+export function useFitToViewport<T extends HTMLElement>(
+  claim: FitClaim,
+  strategy: FitStrategy = zoomFitStrategy,
+): React.RefObject<T | null> {
   const ref = useRef<T | null>(null)
 
   useEffect(() => {
@@ -28,19 +42,36 @@ export function useFitToViewport<T extends HTMLElement>(): React.RefObject<T | n
       return
     }
 
+    if (!claim.claim()) {
+      // Deliberately surfaced: two fit regions in one section would otherwise silently compound their zoom.
+      console.error(
+        '[useFitToViewport] Another fit region is already active in this section; nesting two is not supported. This region will not shrink to fit.',
+      )
+      return
+    }
+
     const fit = () => {
       const section = el.closest('section')
-      el.style.setProperty('zoom', '1')
+      el.style.setProperty(strategy.cssProperty, strategy.resetValue)
       if (!section || !queryMatches(PANEL_QUERY)) return
 
-      for (let pass = 0; pass < 3; pass++) {
-        const over = section.getBoundingClientRect().height - window.innerHeight
-        if (over <= 1) break
-        const cur = Number.parseFloat(el.style.getPropertyValue('zoom')) || 1
-        const h = el.getBoundingClientRect().height
-        if (h <= 0) break
-        const next = Math.max(0.6, cur * Math.max(0.6, (h - over) / h))
-        el.style.setProperty('zoom', String(next))
+      let scale = 1
+      let overflowPx = 0
+      for (let pass = 0; pass < strategy.maxPasses; pass++) {
+        overflowPx = section.getBoundingClientRect().height - window.innerHeight
+        const elementHeightPx = el.getBoundingClientRect().height
+        const correction = strategy.nextCorrection({ overflowPx, elementHeightPx, currentScale: scale })
+        if (!correction) break
+        scale = correction.scale
+        el.style.setProperty(strategy.cssProperty, correction.cssValue)
+      }
+
+      if (isResidualOverflow(overflowPx, scale, strategy)) {
+        // Deliberately surfaced: previously this case was silent (the section is left overflowing the viewport with no signal anywhere).
+        console.warn(
+          `[useFitToViewport] Gave up shrinking a section to fit the viewport: still ${Math.round(overflowPx)}px too tall at the ${strategy.floor}x floor.`,
+          section,
+        )
       }
     }
 
@@ -68,8 +99,9 @@ export function useFitToViewport<T extends HTMLElement>(): React.RefObject<T | n
       clearTimeout(initialTimer)
       window.removeEventListener('resize', fitSoon)
       unsubscribe()
+      claim.release()
     }
-  }, [])
+  }, [claim, strategy])
 
   return ref
 }


### PR DESCRIPTION
## Summary

- Introduces `FitRegion` (`src/components/layout/FitRegion.tsx`), the single module that now owns the previously-repeated `ref`/`data-fit` wrapper markup for the four sections that shrink to fit one viewport.
- `Section` (`src/components/layout/Section.tsx`) hands each of its subtrees a `FitClaim` (`src/lib/fitClaim.ts`) via context (`src/components/layout/sectionFitContext.ts`). `FitRegion` reads that claim through `useSectionFitClaim()`, which throws if there is no enclosing `Section` — attaching fit behaviour outside a section is no longer a silent no-op.
- A second `FitRegion` mounting inside the same section is refused rather than silently compounding its CSS `zoom` with the first's: the refused region logs a `console.error` and simply doesn't shrink.
- The shrink-to-fit correction math is pulled out of the hook into a swappable `FitStrategy` (`src/lib/fitStrategy.ts`), defaulting to the existing CSS-`zoom`/0.6-floor/3-pass mechanism, so a different fitting approach can be substituted on a `FitRegion` without touching the sections that use it.
- The previously-silent "gave up at the floor, still overflowing" case is now surfaced via `console.warn`, decided by a pure, tested `isResidualOverflow` check.
- All four call sites (`EducationExperience`, `ProjectsOther`, `ProjectsFeatured`, `SkillsGraph`) migrated to `FitRegion`; rendering is unchanged (only the wiring around each `ref`/`data-fit` div moved).

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (added `src/lib/fitClaim.test.ts` and `src/lib/fitStrategy.test.ts` covering the pure claim/strategy logic — viewport fit itself can't be exercised in jsdom, so it isn't faked)
- [ ] Manual browser check at 375px and 1440px (not done by me — see PR description note)

Refs #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added viewport-fitting support for section content, with configurable fitting strategies.
  * Added automatic zoom-based fitting for project, education, and skills layouts.
  * Prevented multiple regions within the same section from fitting simultaneously.

* **Bug Fixes**
  * Improved handling of persistent overflow and unavailable size measurements.
  * Added safeguards when fitting reaches its minimum scale.

* **Tests**
  * Added coverage for fitting behavior, overflow detection, ownership, release, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->