### PR TITLE
Own overlay behaviour in one module instead of per-overlay

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { Header } from '@/components/layout/Header'
 import { SkipLink } from '@/components/layout/SkipLink'
 import { Contact } from '@/components/sections/Contact'
@@ -57,13 +58,30 @@ import { cn } from '@/lib/cn'
  * (#317-#321). The mobile hamburger menu (#314) is a separate ticket --
  * the nav links and header rendered here are the desktop shape only. The
  * theme picker (#313) is wired up inside `<Header>` itself.
+ *
+ * Overlay background (#355): `MobileNav`'s full-screen panel needs to mark
+ * everything else on the page `inert` while it's open. That "everything
+ * else" is exactly this component's three top-level children --
+ * `<SkipLink>`, `<Header>` (which itself contains the nav links, theme
+ * picker, clock, and progress bar -- inerting the header cascades to all of
+ * them, including `MobileNav`'s own trigger), and `<main>`. This module is
+ * the one place that composes those three, so it is the one place that
+ * *declares* the background list -- three refs, handed down as a prop --
+ * rather than `MobileNav` rediscovering them by selector or id. See
+ * `src/lib/overlay.ts` for why that distinction matters.
  */
 function App() {
+  const skipLinkRef = useRef<HTMLAnchorElement>(null)
+  const headerRef = useRef<HTMLElement>(null)
+  const mainRef = useRef<HTMLElement>(null)
+  const overlayBackground = [skipLinkRef, headerRef, mainRef]
+
   return (
     <>
-      <SkipLink />
-      <Header />
+      <SkipLink ref={skipLinkRef} />
+      <Header ref={headerRef} overlayBackground={overlayBackground} />
       <main
+        ref={mainRef}
         id="main-content"
         tabIndex={-1}
         className={cn('snap-shell', 'flex min-h-screen flex-col', 'bg-bg text-fg')}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useRef } from 'react'
+import type { Ref, RefObject } from 'react'
 import { navItems } from '@/data/nav'
 import { cn } from '@/lib/cn'
 import { Clock } from './Clock'
@@ -50,8 +51,24 @@ import { ThemePicker } from './ThemePicker'
  * `layout.css`'s base `.section-shell` rule can clear it with
  * `max(var(--space-lg), var(--header-h))`; the 880px+ override still uses
  * its own clamp unconditionally, so desktop is unaffected.
+ *
+ * `overlayBackground` (#355): forwarded straight through to `MobileNav`,
+ * unopened -- `App.tsx` is the one place that declares what counts as
+ * "background" for the mobile nav's overlay (see its docstring), and this
+ * component is just the layer that composition happens to pass through.
+ * `ref` here is a second, independent thing: it's *this* header element's
+ * own node being merged into `App.tsx`'s background list (the header, and
+ * everything inside it -- nav links, theme picker, clock, progress bar,
+ * `MobileNav`'s own trigger -- all become `inert` together when the panel
+ * marks it as background), not something `Header` itself reads.
  */
-export function Header() {
+export function Header({
+  ref,
+  overlayBackground,
+}: {
+  ref?: Ref<HTMLElement>
+  overlayBackground: RefObject<HTMLElement | null>[]
+}) {
   const headerRef = useRef<HTMLElement>(null)
 
   useLayoutEffect(() => {
@@ -70,7 +87,11 @@ export function Header() {
 
   return (
     <header
-      ref={headerRef}
+      ref={(node) => {
+        headerRef.current = node
+        if (typeof ref === 'function') ref(node)
+        else if (ref) ref.current = node
+      }}
       className="fixed inset-x-0 top-0 z-[60] border-b border-line bg-bg-glass backdrop-blur-[9px]"
     >
       <div className="flex items-center gap-[clamp(10px,1.6vw,20px)] px-[clamp(20px,4vw,56px)] py-[12px]">
@@ -94,7 +115,7 @@ export function Header() {
           ))}
         </nav>
 
-        <MobileNav />
+        <MobileNav overlayBackground={overlayBackground} />
 
         <ThemePicker />
 

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useId, useRef, useState } from 'react'
+import type { RefObject } from 'react'
 import { createPortal } from 'react-dom'
 import { navItems } from '@/data/nav'
 import { cn } from '@/lib/cn'
+import { useOverlay } from '@/lib/useOverlay'
 import { PANEL_QUERY, subscribeToMediaQuery } from '@/lib/useMediaQuery'
 
 /**
@@ -30,28 +32,28 @@ import { PANEL_QUERY, subscribeToMediaQuery } from '@/lib/useMediaQuery'
  * is the real scroll container per `src/styles/layout.css`'s scroll-snap
  * note) so the full-screen list doesn't fight page scroll underneath it.
  *
- * Two things outside the panel itself have to be kept in sync while it's
- * open, both driven from this one effect:
+ * Crossing the 880px `panel:` breakpoint purely by CSS -- `panel:hidden` on
+ * this component's own root -- would hide the fixed full-screen panel (it's
+ * a descendant, so `display:none` cascades to it) while leaving `open`
+ * (and therefore the scroll lock) true, since resizing never touches React
+ * state on its own. Subscribing to the shared panel query
+ * (`subscribeToMediaQuery(PANEL_QUERY, ...)` from `useMediaQuery`, #354 --
+ * the same module `useFitToViewport` and `usePrefersReducedMotion`
+ * consume) closes the menu the moment the viewport crosses into desktop
+ * width so the lock always gets released.
  *
- * 1. Crossing the 880px `panel:` breakpoint purely by CSS -- `panel:hidden`
- *    on this component's own root -- would hide the fixed full-screen panel
- *    (it's a descendant, so `display:none` cascades to it) while leaving
- *    `open` (and therefore the scroll lock) true, since resizing never
- *    touches React state on its own. Subscribing to the shared panel query
- *    (`subscribeToMediaQuery(PANEL_QUERY, ...)` from `useMediaQuery`, #354 --
- *    the same module `useFitToViewport` and `usePrefersReducedMotion`
- *    consume) closes the menu the moment the viewport crosses into desktop
- *    width so the lock always gets released.
- * 2. Not trapping focus (see above) still leaves every *other* focusable
- *    thing on the page -- the trigger button itself, the site mark link,
- *    the theme picker, the clock, the skip link, all of `<main>` -- in
- *    the normal tab sequence, sitting directly behind this panel's opaque
- *    `bg-bg`. Without something marking them non-interactive, Tab/Shift+Tab
- *    from the panel's own controls would silently move focus onto
- *    controls the user cannot see under the overlay. `inert` (not a focus
- *    trap -- Tab still leaves the panel, it just has nothing invisible
- *    left to land on) is applied to everything else in the document while
- *    open and lifted on close.
+ * Scroll lock, background `inert`, and focus restore (#355) are owned by
+ * `useOverlay`/`src/lib/overlay.ts`, not this component. Not trapping focus
+ * (see above) still leaves every *other* focusable thing on the page --
+ * the trigger button itself, the site mark link, the theme picker, the
+ * clock, the skip link, all of `<main>` -- in the normal tab sequence,
+ * sitting directly behind this panel's opaque `bg-bg`. Without something
+ * marking them non-interactive, Tab/Shift+Tab from the panel's own
+ * controls would silently move focus onto controls the user cannot see
+ * under the overlay. `inert` (not a focus trap -- Tab still leaves the
+ * panel, it just has nothing invisible left to land on) is applied to the
+ * `overlayBackground` elements the app shell (`App.tsx`) declares -- this
+ * component never queries the DOM to find them itself.
  *
  * The open panel itself is rendered through a `createPortal` into
  * `document.body` rather than in place. `Header.tsx`'s `<header>` sets
@@ -69,62 +71,35 @@ import { PANEL_QUERY, subscribeToMediaQuery } from '@/lib/useMediaQuery'
  * the four nav links sitting on top of it and nothing else visible
  * through it.
  */
-export function MobileNav() {
+export function MobileNav({ overlayBackground }: { overlayBackground: RefObject<HTMLElement | null>[] }) {
   const [open, setOpen] = useState(false)
-  const wrapperRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
   const firstLinkRef = useRef<HTMLAnchorElement>(null)
   const panelId = useId()
 
+  useOverlay(open, {
+    onDismiss: () => setOpen(false),
+    backgroundRefs: overlayBackground,
+    lockScrollRoot: document.documentElement,
+    initialFocus: firstLinkRef,
+    dismissOnEscape: true,
+    restoreFocusOnEscape: triggerRef,
+  })
+
   useEffect(() => {
     if (!open) return
-
-    firstLinkRef.current?.focus()
-
-    const root = document.documentElement
-    const previousOverflow = root.style.overflow
-    root.style.overflow = 'hidden'
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return
-      setOpen(false)
-      triggerRef.current?.focus()
-    }
-    document.addEventListener('keydown', onKeyDown)
 
     const unsubscribeFromPanelQuery = subscribeToMediaQuery(PANEL_QUERY, (matches) => {
       if (matches) setOpen(false)
     })
 
-    const inertTargets: HTMLElement[] = []
-    const wrapper = wrapperRef.current
-    if (wrapper?.parentElement) {
-      for (const sibling of Array.from(wrapper.parentElement.children)) {
-        if (sibling !== wrapper && sibling instanceof HTMLElement) inertTargets.push(sibling)
-      }
-    }
-    const scrollBar = document.querySelector<HTMLElement>('header > [role="progressbar"]')
-    if (scrollBar) inertTargets.push(scrollBar)
-    const skipLink = document.querySelector<HTMLElement>('a[href="#main-content"]')
-    if (skipLink) inertTargets.push(skipLink)
-    const main = document.getElementById('main-content')
-    if (main) inertTargets.push(main)
-    if (triggerRef.current) inertTargets.push(triggerRef.current)
-
-    for (const el of inertTargets) el.inert = true
-
-    return () => {
-      root.style.overflow = previousOverflow
-      document.removeEventListener('keydown', onKeyDown)
-      unsubscribeFromPanelQuery()
-      for (const el of inertTargets) el.inert = false
-    }
+    return unsubscribeFromPanelQuery
   }, [open])
 
   const close = () => setOpen(false)
 
   return (
-    <div ref={wrapperRef} className="order-last panel:hidden">
+    <div className="order-last panel:hidden">
       <button
         ref={triggerRef}
         type="button"

--- a/src/components/layout/SkipLink.tsx
+++ b/src/components/layout/SkipLink.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from 'react'
+import type { MouseEvent, Ref } from 'react'
 
 /**
  * Skip link (#312). Must be the very first focusable element in DOM order
@@ -12,8 +12,13 @@ import type { MouseEvent } from 'react'
  * activating this link moves focus there explicitly rather than relying on
  * browsers' inconsistent "focus the fragment target" behaviour -- the
  * target carries `tabIndex={-1}` (see `App.tsx`) precisely so this works.
+ *
+ * `ref` (#355): `App.tsx` needs this element itself -- not a selector
+ * matching its `href` -- to declare it as part of `MobileNav`'s overlay
+ * background. React 19 allows `ref` as a plain prop, no `forwardRef`
+ * needed.
  */
-export function SkipLink() {
+export function SkipLink({ ref }: { ref?: Ref<HTMLAnchorElement> }) {
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
     const target = document.getElementById('main-content')
     if (!target) return
@@ -28,6 +33,7 @@ export function SkipLink() {
 
   return (
     <a
+      ref={ref}
       href="#main-content"
       onClick={handleClick}
       className="sr-only focus:not-sr-only focus:fixed focus:top-[var(--space-2xs)] focus:left-[var(--space-2xs)] focus:z-[100] focus:border focus:border-line-2 focus:bg-bg focus:px-[var(--space-sm)] focus:py-[var(--space-2xs)] focus:text-fluid-sm focus:font-mono focus:text-fg"

--- a/src/components/layout/ThemePicker.tsx
+++ b/src/components/layout/ThemePicker.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useId, useRef, useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { cn } from '@/lib/cn'
+import { useOverlay } from '@/lib/useOverlay'
 import { getStoredThemeId, setTheme as persistTheme } from '@/theme/persistence'
 import { DEFAULT_THEME_ID, THEMES } from '@/theme/themes'
 
@@ -13,9 +14,17 @@ import { DEFAULT_THEME_ID, THEMES } from '@/theme/themes'
  * shape exactly (see the literal clamp/px values below, matched against
  * the sample line-by-line) but adds the interaction contract a mockup
  * never had: `aria-expanded`/`aria-haspopup` on the trigger, `Escape` and
- * outside-click/focus-out dismissal that returns focus to the trigger,
- * and `aria-checked` on the selected row instead of relying on colour
- * alone.
+ * outside-click/focus-out dismissal, and `aria-checked` on the selected
+ * row instead of relying on colour alone.
+ *
+ * Dismissal (#355) is `useOverlay`/`src/lib/overlay.ts`'s job, not this
+ * component's own: Escape closes the menu and returns focus to the
+ * trigger; a pointerdown or focus-out landing outside `containerRef`
+ * closes it too, but deliberately does NOT refocus the trigger (the click
+ * or Tab that triggered it already moved focus somewhere real -- pulling
+ * it back would fight that). This picker locks no scroll and inerts no
+ * background; it's a small dropdown, not a full-screen panel like
+ * `MobileNav`'s.
  *
  * Colour data (`THEMES[].swatch`) is the one legitimate place a literal
  * hex value appears in this codebase -- it's runtime data from
@@ -52,40 +61,12 @@ export function ThemePicker() {
 
   const activeTheme = THEMES.find((theme) => theme.id === themeId) ?? THEMES[0]
 
-  useEffect(() => {
-    if (!open) return
-
-    const container = containerRef.current
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') return
-      setOpen(false)
-      triggerRef.current?.focus()
-    }
-
-    const onPointerDown = (event: MouseEvent) => {
-      if (container && !container.contains(event.target as Node)) {
-        setOpen(false)
-      }
-    }
-
-    const onFocusOut = (event: FocusEvent) => {
-      const next = event.relatedTarget as Node | null
-      if (!container || !next || !container.contains(next)) {
-        setOpen(false)
-      }
-    }
-
-    document.addEventListener('keydown', onKeyDown)
-    document.addEventListener('mousedown', onPointerDown)
-    container?.addEventListener('focusout', onFocusOut)
-
-    return () => {
-      document.removeEventListener('keydown', onKeyDown)
-      document.removeEventListener('mousedown', onPointerDown)
-      container?.removeEventListener('focusout', onFocusOut)
-    }
-  }, [open])
+  useOverlay(open, {
+    onDismiss: () => setOpen(false),
+    dismissOnEscape: true,
+    restoreFocusOnEscape: triggerRef,
+    outsideDismissBoundary: containerRef,
+  })
 
   const pick = (id: string) => {
     persistTheme(id)

--- a/src/lib/overlay.test.ts
+++ b/src/lib/overlay.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  activateOverlay,
+  addEscapeListener,
+  addOutsideDismissListener,
+  applyInert,
+  lockScroll,
+} from './overlay'
+
+/**
+ * Minimal fake `EventTarget`: enough of `addEventListener`/
+ * `removeEventListener` to drive the listener helpers without a real DOM.
+ * `dispatch` takes `unknown` (not `Event`) since tests only need to hand
+ * back plain `{ key: ... }`/`{ target: ... }` shapes, not construct real
+ * (unavailable in this Node test environment) `Event` instances.
+ */
+class FakeTarget {
+  private listeners = new Map<string, Set<(event: Event) => void>>()
+
+  addEventListener(type: string, listener: (event: Event) => void) {
+    if (!this.listeners.has(type)) this.listeners.set(type, new Set())
+    this.listeners.get(type)!.add(listener)
+  }
+
+  removeEventListener(type: string, listener: (event: Event) => void) {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  dispatch(type: string, event: unknown) {
+    for (const listener of this.listeners.get(type) ?? []) listener(event as Event)
+  }
+
+  listenerCount(type: string) {
+    return this.listeners.get(type)?.size ?? 0
+  }
+}
+
+class FakeBoundary extends FakeTarget {
+  private containedNodes = new Set<unknown>()
+
+  contains(node: unknown) {
+    return this.containedNodes.has(node)
+  }
+
+  addContained(node: unknown) {
+    this.containedNodes.add(node)
+  }
+}
+
+describe('lockScroll', () => {
+  it('sets overflow to hidden and restores the previous value on release', () => {
+    const root = { style: { overflow: 'visible' } }
+    const release = lockScroll(root)
+    expect(root.style.overflow).toBe('hidden')
+
+    release()
+    expect(root.style.overflow).toBe('visible')
+  })
+
+  it('is reference-counted so two overlays locking the same root cannot clobber each other', () => {
+    const root = { style: { overflow: 'auto' } }
+
+    const releaseFirst = lockScroll(root)
+    const releaseSecond = lockScroll(root)
+    expect(root.style.overflow).toBe('hidden')
+
+    // Releasing the first lock must NOT unlock scroll while the second
+    // overlay is still open -- this is the "cannot clobber" guarantee.
+    releaseFirst()
+    expect(root.style.overflow).toBe('hidden')
+
+    releaseSecond()
+    expect(root.style.overflow).toBe('auto')
+  })
+
+  it('releasing the same lock twice is a no-op', () => {
+    const root = { style: { overflow: 'auto' } }
+    const release = lockScroll(root)
+    release()
+    release()
+    expect(root.style.overflow).toBe('auto')
+  })
+
+  it('unlocks correctly regardless of release order', () => {
+    const root = { style: { overflow: 'scroll' } }
+    const releaseFirst = lockScroll(root)
+    const releaseSecond = lockScroll(root)
+
+    releaseSecond()
+    expect(root.style.overflow).toBe('hidden')
+    releaseFirst()
+    expect(root.style.overflow).toBe('scroll')
+  })
+})
+
+describe('applyInert', () => {
+  it('marks every element inert and restores false on release', () => {
+    const elements = [{ inert: false }, { inert: false }]
+    const release = applyInert(elements)
+    expect(elements.every((el) => el.inert)).toBe(true)
+
+    release()
+    expect(elements.every((el) => el.inert)).toBe(false)
+  })
+
+  it('restores each element to its actual prior value, not a blanket false', () => {
+    const alreadyInert = { inert: true }
+    const notInert = { inert: false }
+    const release = applyInert([alreadyInert, notInert])
+
+    release()
+    expect(alreadyInert.inert).toBe(true)
+    expect(notInert.inert).toBe(false)
+  })
+
+  it('release is idempotent', () => {
+    const el = { inert: false }
+    const release = applyInert([el])
+    release()
+    el.inert = true // simulate something else legitimately re-inerting it
+    release()
+    expect(el.inert).toBe(true)
+  })
+})
+
+describe('addEscapeListener', () => {
+  it('calls onEscape only for the Escape key', () => {
+    const target = new FakeTarget()
+    const onEscape = vi.fn()
+    addEscapeListener(target, onEscape)
+
+    target.dispatch('keydown', { key: 'Enter' })
+    expect(onEscape).not.toHaveBeenCalled()
+
+    target.dispatch('keydown', { key: 'Escape' })
+    expect(onEscape).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops listening after cleanup', () => {
+    const target = new FakeTarget()
+    const onEscape = vi.fn()
+    const cleanup = addEscapeListener(target, onEscape)
+    cleanup()
+
+    target.dispatch('keydown', { key: 'Escape' })
+    expect(onEscape).not.toHaveBeenCalled()
+    expect(target.listenerCount('keydown')).toBe(0)
+  })
+})
+
+describe('addOutsideDismissListener', () => {
+  it('dismisses on a mousedown outside the boundary, not inside it', () => {
+    const doc = new FakeTarget()
+    const boundary = new FakeBoundary()
+    const insideNode = {}
+    boundary.addContained(insideNode)
+    const onDismiss = vi.fn()
+
+    addOutsideDismissListener(doc, boundary, onDismiss)
+
+    doc.dispatch('mousedown', { target: insideNode })
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    doc.dispatch('mousedown', { target: {} })
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses on focus-out only when the next focus target is outside the boundary', () => {
+    const doc = new FakeTarget()
+    const boundary = new FakeBoundary()
+    const insideNode = {}
+    boundary.addContained(insideNode)
+    const onDismiss = vi.fn()
+
+    addOutsideDismissListener(doc, boundary, onDismiss)
+
+    boundary.dispatch('focusout', { relatedTarget: insideNode })
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    boundary.dispatch('focusout', { relatedTarget: null })
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops listening after cleanup', () => {
+    const doc = new FakeTarget()
+    const boundary = new FakeBoundary()
+    const onDismiss = vi.fn()
+    const cleanup = addOutsideDismissListener(doc, boundary, onDismiss)
+    cleanup()
+
+    doc.dispatch('mousedown', { target: {} })
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+})
+
+describe('activateOverlay', () => {
+  function setup() {
+    const doc = new FakeTarget()
+    const root = { style: { overflow: 'visible' } }
+    const background = [{ inert: false }, { inert: false }]
+    const initialFocus = { focus: vi.fn() }
+    const trigger = { focus: vi.fn() }
+    const onDismiss = vi.fn()
+
+    return { doc, root, background, initialFocus, trigger, onDismiss }
+  }
+
+  it('locks scroll, inerts the background, and moves focus in on activation', () => {
+    const { doc, root, background, initialFocus, onDismiss } = setup()
+
+    const deactivate = activateOverlay(
+      { document: doc },
+      { onDismiss, background, lockScrollRoot: root, initialFocus },
+    )
+
+    expect(root.style.overflow).toBe('hidden')
+    expect(background.every((el) => el.inert)).toBe(true)
+    expect(initialFocus.focus).toHaveBeenCalledTimes(1)
+
+    // `lockScroll` is a module-level singleton (that's the whole point --
+    // see the "cannot clobber" test below) so every test that locks must
+    // also release, or it leaks into whichever test runs next.
+    deactivate()
+  })
+
+  it('deactivate undoes the scroll lock and background inert', () => {
+    const { doc, root, background, onDismiss } = setup()
+
+    const deactivate = activateOverlay({ document: doc }, { onDismiss, background, lockScrollRoot: root })
+    deactivate()
+
+    expect(root.style.overflow).toBe('visible')
+    expect(background.every((el) => el.inert)).toBe(false)
+  })
+
+  it('Escape calls onDismiss and restores focus to the configured target', () => {
+    const { doc, onDismiss, trigger } = setup()
+
+    activateOverlay(
+      { document: doc },
+      { onDismiss, dismissOnEscape: true, restoreFocusOnEscape: trigger },
+    )
+
+    doc.dispatch('keydown', { key: 'Escape' })
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    expect(trigger.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('outside dismissal calls onDismiss but never restores focus', () => {
+    const doc = new FakeTarget()
+    const boundary = new FakeBoundary()
+    const onDismiss = vi.fn()
+    const trigger = { focus: vi.fn() }
+
+    activateOverlay(
+      { document: doc },
+      { onDismiss, outsideDismissBoundary: boundary, restoreFocusOnEscape: trigger },
+    )
+
+    doc.dispatch('mousedown', { target: {} })
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+    expect(trigger.focus).not.toHaveBeenCalled()
+  })
+
+  it('deactivate removes all listeners so a later Escape or outside click is a no-op', () => {
+    const { doc, onDismiss, trigger } = setup()
+    const boundary = new FakeBoundary()
+
+    const deactivate = activateOverlay(
+      { document: doc },
+      { onDismiss, dismissOnEscape: true, restoreFocusOnEscape: trigger, outsideDismissBoundary: boundary },
+    )
+    deactivate()
+
+    doc.dispatch('keydown', { key: 'Escape' })
+    doc.dispatch('mousedown', { target: {} })
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it('two overlays locking the same root cannot clobber each other via activateOverlay', () => {
+    const doc = new FakeTarget()
+    const root = { style: { overflow: 'visible' } }
+    const onDismissA = vi.fn()
+    const onDismissB = vi.fn()
+
+    const deactivateA = activateOverlay({ document: doc }, { onDismiss: onDismissA, lockScrollRoot: root })
+    const deactivateB = activateOverlay({ document: doc }, { onDismiss: onDismissB, lockScrollRoot: root })
+
+    deactivateA()
+    expect(root.style.overflow).toBe('hidden')
+
+    deactivateB()
+    expect(root.style.overflow).toBe('visible')
+  })
+})

--- a/src/lib/overlay.ts
+++ b/src/lib/overlay.ts
@@ -1,0 +1,210 @@
+/**
+ * Single owner of overlay behaviour (#355): scroll locking, background
+ * `inert`, and focus restoration, plus the Escape/outside-click/focus-out
+ * dismissal wiring both `MobileNav` and `ThemePicker` used to hand-roll
+ * separately.
+ *
+ * Before this module existed, `MobileNav` located what to mark `inert` by
+ * querying the DOM for markup owned by other components -- the progress
+ * bar by its position inside the header (`header > [role="progressbar"]`),
+ * the skip link by its `href` (`a[href="#main-content"]`), and `<main>` by
+ * its id (`#main-content`). Reordering or renaming any of that broke the
+ * accessibility behaviour silently -- no type error, no test failure, no
+ * runtime warning. `ThemePicker` separately hand-rolled its own Escape /
+ * outside-click / focus-out dismissal with no shared owner of the global
+ * state (`document` listeners, `documentElement.style.overflow`) both
+ * overlays touch.
+ *
+ * Everything here is plain, framework-agnostic functions operating on
+ * whatever minimal element-shaped objects are passed in -- no DOM query, no
+ * selector, no element id. `background` (what counts as "behind" this
+ * overlay) is always a list the *caller* hands in; this module never goes
+ * looking for it. `src/lib/useOverlay.ts` is the thin React-effect wrapper
+ * around `activateOverlay`; this file is what's actually under test (the
+ * test environment is Node, not a browser, so everything below is written
+ * against small structural types rather than real DOM classes).
+ */
+
+/** Anything whose scroll can be locked: just enough of `HTMLElement`. */
+export interface ScrollLockable {
+  style: { overflow: string }
+}
+
+/** Anything that can be marked `inert` while an overlay is open. */
+export interface Inertable {
+  inert: boolean
+}
+
+/** Anything that can receive focus. */
+export interface Focusable {
+  focus(): void
+}
+
+/** Minimal `EventTarget`-shaped surface this module needs for `document`. */
+export interface ListenerTarget {
+  addEventListener(type: string, listener: (event: Event) => void): void
+  removeEventListener(type: string, listener: (event: Event) => void): void
+}
+
+/** The boundary an outside-click/focus-out dismissal is measured against. */
+export interface DismissBoundary extends ListenerTarget {
+  contains(node: unknown): boolean
+}
+
+let scrollLockCount = 0
+let scrollLockRoot: ScrollLockable | null = null
+let scrollLockPreviousOverflow = ''
+
+/**
+ * Locks `root`'s scroll (`style.overflow = 'hidden'`) and returns a release
+ * function. Reference-counted at module scope so two overlays locking the
+ * same root can't clobber each other: the second lock is a no-op beyond
+ * incrementing the count, and `style.overflow` is only restored once every
+ * lock has been released. This is what makes "two overlays cannot clobber
+ * each other's scroll-lock state" true regardless of open/close order.
+ */
+export function lockScroll(root: ScrollLockable): () => void {
+  if (scrollLockCount === 0) {
+    scrollLockRoot = root
+    scrollLockPreviousOverflow = root.style.overflow
+    root.style.overflow = 'hidden'
+  }
+  scrollLockCount += 1
+
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    scrollLockCount -= 1
+    if (scrollLockCount <= 0) {
+      scrollLockCount = 0
+      if (scrollLockRoot) scrollLockRoot.style.overflow = scrollLockPreviousOverflow
+      scrollLockRoot = null
+      scrollLockPreviousOverflow = ''
+    }
+  }
+}
+
+/**
+ * Marks every element in `elements` `inert`, remembering each one's prior
+ * `inert` value so the release function restores it exactly (rather than
+ * assuming `false`) even if something was already inert for an unrelated
+ * reason.
+ */
+export function applyInert(elements: Iterable<Inertable>): () => void {
+  const previous: Array<[Inertable, boolean]> = []
+  for (const element of elements) {
+    previous.push([element, element.inert])
+    element.inert = true
+  }
+
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    for (const [element, wasInert] of previous) element.inert = wasInert
+  }
+}
+
+/** Calls `onEscape` for every `Escape` keydown on `target`; returns cleanup. */
+export function addEscapeListener(target: ListenerTarget, onEscape: () => void): () => void {
+  const onKeyDown = (event: Event) => {
+    if ((event as KeyboardEvent).key === 'Escape') onEscape()
+  }
+  target.addEventListener('keydown', onKeyDown)
+  return () => target.removeEventListener('keydown', onKeyDown)
+}
+
+/**
+ * Calls `onDismiss` when a pointerdown or focus-out lands outside
+ * `boundary`. Mirrors `ThemePicker`'s former hand-rolled outside-click/
+ * focus-out pair exactly (mousedown on `doc`, focusout on `boundary`
+ * itself), just owned in one shared place now.
+ */
+export function addOutsideDismissListener(
+  doc: ListenerTarget,
+  boundary: DismissBoundary,
+  onDismiss: () => void,
+): () => void {
+  const onPointerDown = (event: Event) => {
+    if (!boundary.contains((event as MouseEvent).target)) onDismiss()
+  }
+  const onFocusOut = (event: Event) => {
+    const next = (event as FocusEvent).relatedTarget
+    if (!next || !boundary.contains(next)) onDismiss()
+  }
+
+  doc.addEventListener('mousedown', onPointerDown)
+  boundary.addEventListener('focusout', onFocusOut)
+  return () => {
+    doc.removeEventListener('mousedown', onPointerDown)
+    boundary.removeEventListener('focusout', onFocusOut)
+  }
+}
+
+/** Where `activateOverlay` gets `document` from -- injected, never imported. */
+export interface OverlayEnv {
+  document: ListenerTarget
+}
+
+export interface OverlayConfig {
+  /** Called to close the overlay, from either dismissal path below. */
+  onDismiss: () => void
+  /**
+   * Elements to mark `inert` while the overlay is open -- declared by the
+   * caller (ultimately the app shell), never discovered by query. Omit for
+   * overlays with no full-page background sweep (e.g. a small dropdown).
+   */
+  background?: Iterable<Inertable>
+  /** Locks this root's scroll for as long as the overlay is open. */
+  lockScrollRoot?: ScrollLockable
+  /** Focused once, when the overlay activates. */
+  initialFocus?: Focusable | null
+  /** Closes the overlay on `Escape` when true. */
+  dismissOnEscape?: boolean
+  /**
+   * Focused after an Escape-triggered dismissal (only). Outside-click/
+   * focus-out dismissal never restores focus -- see `outsideDismissBoundary`.
+   */
+  restoreFocusOnEscape?: Focusable | null
+  /**
+   * If set, a pointerdown or focus-out landing outside this boundary
+   * closes the overlay. Deliberately does NOT restore focus (matching the
+   * prior per-component behaviour): the user's click or Tab already moved
+   * focus somewhere else, so pulling it back would fight that.
+   */
+  outsideDismissBoundary?: DismissBoundary | null
+}
+
+/**
+ * Activates one overlay: locks scroll, inerts the background, moves focus
+ * in, and wires whichever dismissal paths are configured. Returns a single
+ * deactivate function that undoes all of it, in reverse order.
+ */
+export function activateOverlay(env: OverlayEnv, config: OverlayConfig): () => void {
+  const cleanups: Array<() => void> = []
+
+  if (config.lockScrollRoot) cleanups.push(lockScroll(config.lockScrollRoot))
+  if (config.background) cleanups.push(applyInert(config.background))
+  config.initialFocus?.focus()
+
+  if (config.dismissOnEscape) {
+    cleanups.push(
+      addEscapeListener(env.document, () => {
+        config.onDismiss()
+        config.restoreFocusOnEscape?.focus()
+      }),
+    )
+  }
+
+  if (config.outsideDismissBoundary) {
+    cleanups.push(addOutsideDismissListener(env.document, config.outsideDismissBoundary, config.onDismiss))
+  }
+
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    for (const cleanup of cleanups.reverse()) cleanup()
+  }
+}

--- a/src/lib/useOverlay.ts
+++ b/src/lib/useOverlay.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
+import { activateOverlay, type Inertable } from './overlay'
+
+/**
+ * React wrapper around `activateOverlay` (#355). This file is deliberately
+ * thin and untested directly -- `overlay.ts` is where the actual scroll
+ * lock/inert/dismissal logic lives and is covered by tests; this hook's
+ * only job is resolving React refs to real elements at effect time (after
+ * commit, so a ref used for `initialFocus` on the same render that mounts
+ * the element it points to is never stale) and injecting the real
+ * `document`.
+ *
+ * `active` is the only reactive dependency: the rest of `config` is read
+ * through a ref updated every render (`configRef`), the same "latest ref"
+ * pattern used to avoid re-running an effect just because an inline object
+ * or closure was recreated. The effect itself only needs to run once per
+ * open/close transition, not on every render while open.
+ */
+export interface UseOverlayConfig {
+  /** Called to close the overlay (typically `() => setOpen(false)`). */
+  onDismiss: () => void
+  /** Elements to mark `inert` while open -- declared by the caller. */
+  background?: Iterable<Inertable>
+  /**
+   * Refs to elements to mark `inert` while open, resolved to their
+   * `.current` value at effect time rather than at render time -- use this
+   * (instead of `background`) when the elements come from refs that may
+   * not be mounted yet on the render that flips `active` to true.
+   */
+  backgroundRefs?: RefObject<HTMLElement | null>[]
+  /** Locks this root's scroll for as long as the overlay is open. */
+  lockScrollRoot?: { style: { overflow: string } }
+  /** Focused once, when the overlay activates. */
+  initialFocus?: RefObject<Pick<HTMLElement, 'focus'> | null>
+  /** Closes the overlay on `Escape` when true. */
+  dismissOnEscape?: boolean
+  /** Focused after an Escape-triggered dismissal (only). */
+  restoreFocusOnEscape?: RefObject<Pick<HTMLElement, 'focus'> | null>
+  /** If set, a pointerdown/focus-out outside this element closes the overlay. */
+  outsideDismissBoundary?: RefObject<(HTMLElement & { contains(node: unknown): boolean }) | null>
+}
+
+/**
+ * Activates the overlay described by `config` for as long as `active` is
+ * true, and deactivates it (releasing the scroll lock, lifting `inert`,
+ * removing listeners) the moment `active` goes false or the component
+ * unmounts.
+ */
+export function useOverlay(active: boolean, config: UseOverlayConfig): void {
+  const configRef = useRef(config)
+
+  // Keeps `configRef` current every render without reading or writing it
+  // during render itself (both are effects, running after commit) -- this
+  // one has no dependency array, so it runs on every commit, and always
+  // before the `[active]` effect below since effects run in declaration
+  // order within a component.
+  useEffect(() => {
+    configRef.current = config
+  })
+
+  useEffect(() => {
+    if (!active) return
+
+    const current = configRef.current
+    const background = current.backgroundRefs
+      ? current.backgroundRefs
+          .map((ref) => ref.current)
+          .filter((element): element is HTMLElement => element !== null)
+      : current.background
+
+    return activateOverlay(
+      { document },
+      {
+        onDismiss: current.onDismiss,
+        background,
+        lockScrollRoot: current.lockScrollRoot,
+        initialFocus: current.initialFocus?.current ?? null,
+        dismissOnEscape: current.dismissOnEscape,
+        restoreFocusOnEscape: current.restoreFocusOnEscape?.current ?? null,
+        outsideDismissBoundary: current.outsideDismissBoundary?.current ?? null,
+      },
+    )
+  }, [active])
+}


### PR DESCRIPTION
## Summary

- MobileNav and ThemePicker each hand-rolled their own scroll lock, background `inert`, and Escape/outside-click/focus-out dismissal, and MobileNav located its `inert` targets by querying the DOM for markup owned by other components (progress bar by position, skip link by `href`, main by id).
- `src/lib/overlay.ts` is now the single owner of that behaviour: a reference-counted scroll lock (so two overlays can't clobber each other's lock state), background `inert` apply/restore, and Escape / outside-click / focus-out dismissal wiring. `src/lib/useOverlay.ts` is the thin React-effect wrapper around it.
- What counts as "background" for the mobile nav's overlay is now declared by the app shell: `App.tsx` holds refs to its own three top-level children (skip link, header, main) and hands them down as a prop, rather than `MobileNav` discovering them by selector or id.
- Both `MobileNav` and `ThemePicker` are adopted onto the shared module; `ThemePicker`'s bespoke dismissal effect is removed entirely.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (adds `src/lib/overlay.test.ts`, covering scroll lock + restore, reference-counted "cannot clobber" behaviour, background inert + restore, Escape dismissal + focus restore, and outside-click/focus-out dismissal without focus restore)
- [ ] Manual browser check at 375px/1440px -- not done by me, see report

Refs #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)