### PR TITLE
Use spacing and type tokens instead of inline clamps

### DIFF
--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -31,7 +31,9 @@ export function Contact() {
        */}
       <div className="grid items-end gap-[clamp(28px,4vw,60px)] [grid-template-columns:repeat(auto-fit,minmax(300px,1fr))]">
         <div>
-          <p className="text-[10px] tracking-[0.2em] text-accent-2">{meta.eyebrow}</p>
+          <p className="text-[10px] tracking-[0.2em] text-accent-2 panel:text-fit-xs">
+            {meta.eyebrow}
+          </p>
 
           {/*
            * Sample line 563: "LET'S BUILD<br>SOMETHING<br><span
@@ -43,11 +45,26 @@ export function Contact() {
            * line-broken markup is then hidden from assistive tech so the
            * two representations of the same heading are never both
            * exposed to it.
+           *
+           * Sizing (owner follow-up, #372): the reference's own
+           * `clamp(20px,3.8vw,46px)` reads squished at desktop -- the
+           * whole content block sat under half the section's height with
+           * large empty bands top and bottom. Above 880px this now scales
+           * against viewport HEIGHT instead of width
+           * (`clamp(30px,5.6vh,74px)`, same vh-clamp idiom the reference
+           * uses for everything below a section's heading row, see
+           * `src/styles/layout.css`), so the headline grows with the
+           * space the section actually has and shrinks back down at short
+           * viewports instead of overflowing `100dvh`. The 74px ceiling
+           * keeps `SOMETHING` (the widest line) clear of the ~387px
+           * column width at the 880px breakpoint's narrowest two-column
+           * layout. Below 880px the original width-based clamp is
+           * untouched -- this growth is a desktop-only fix.
            */}
           <h2
             id="contact-heading"
             aria-label="LET'S BUILD SOMETHING SMALL AND FAST"
-            className="m-0 mt-[20px] font-display text-[clamp(20px,3.8vw,46px)] leading-[1.35] text-fg"
+            className="m-0 mt-[20px] font-display text-[clamp(20px,3.8vw,46px)] leading-[1.35] text-fg panel:text-[clamp(30px,5.6vh,74px)]"
           >
             <span aria-hidden="true">
               LET&apos;S BUILD
@@ -58,7 +75,17 @@ export function Contact() {
             </span>
           </h2>
 
-          <p className="mt-[24px] max-w-[52ch] text-[15px] leading-[1.8] text-dim [text-wrap:pretty]">
+          {/*
+           * Statement sizing (#372): `max-w-[52ch]` is in `ch` units, so it
+           * scales in lockstep with font-size -- growing the font doesn't
+           * add a 4th wrapped line, it keeps the same ~3-line shape at a
+           * larger scale. `panel:mt-[var(--space-fit-margin)]` reuses the
+           * existing "fit-box margin under a heading" token rather than
+           * inventing one; the font-size itself needs a taller ceiling
+           * than any of the `--text-fit-*` tokens offer (all cap by
+           * ~920vh), so it stays a one-off vh clamp here.
+           */}
+          <p className="mt-[24px] max-w-[52ch] text-[15px] leading-[1.8] text-dim [text-wrap:pretty] panel:mt-[var(--space-fit-margin)] panel:text-[clamp(16px,2.6vh,34px)]">
             {CONTACT_STATEMENT}
           </p>
         </div>
@@ -70,10 +97,10 @@ export function Contact() {
                 href={link.href}
                 target={link.external ? '_blank' : undefined}
                 rel={link.external ? 'noopener noreferrer' : undefined}
-                className="flex items-baseline justify-between gap-[14px] py-[17px] text-[14px] text-fg-2 transition-[padding-left,color] duration-[180ms] hover:text-accent-2 motion-safe:hover:pl-[10px]"
+                className="flex items-baseline justify-between gap-[14px] py-[17px] text-[14px] text-fg-2 transition-[padding-left,color] duration-[180ms] hover:text-accent-2 motion-safe:hover:pl-[10px] panel:py-[clamp(20px,3.6vh,44px)] panel:text-[clamp(16px,2.4vh,26px)]"
               >
                 <span className="text-fg">{link.detail}</span>
-                <span className="text-[10px] uppercase tracking-[0.16em] text-dim-2">
+                <span className="text-[10px] uppercase tracking-[0.16em] text-dim-2 panel:text-fit-xs">
                   {link.label} <span aria-hidden="true">→</span>
                 </span>
               </a>
@@ -89,8 +116,18 @@ export function Contact() {
        * Experience's bullet list divider, and the Leviathan pipeline's
        * "move" row -- four dividers that previously each had a different
        * top padding.
+       *
+       * `panel:mt-[clamp(40px,7.5vh,95px)]` (#372): grows the gap between
+       * the grid and the footer at desktop so the block's own internal
+       * rhythm scales along with the headline/statement/links above,
+       * rather than leaving that whitespace fixed while everything around
+       * it grows -- part of closing the ~45%-of-section-height gap
+       * without pushing the block edge-to-edge (the footer itself, and
+       * the eyebrow above the grid, are deliberately left closer to their
+       * original scale so the block keeps a light top/bottom edge rather
+       * than reading as uniformly blown up).
        */}
-      <div className="mt-[clamp(30px,5vh,52px)] border-t border-line pt-[var(--space-fit-md)] text-[9.5px] tracking-[0.18em] text-dim-3">
+      <div className="mt-[clamp(30px,5vh,52px)] border-t border-line pt-[var(--space-fit-md)] text-[9.5px] tracking-[0.18em] text-dim-3 panel:mt-[clamp(40px,7.5vh,95px)] panel:pt-[var(--space-fit-margin)] panel:text-fit-2xs">
         <span>{CONTACT_FOOTER}</span>
       </div>
     </Section>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -82,7 +82,15 @@ export function Contact() {
         </ul>
       </div>
 
-      <div className="mt-[clamp(30px,5vh,52px)] border-t border-line pt-[20px] text-[9.5px] tracking-[0.18em] text-dim-3">
+      {/*
+       * Divider top padding (#359): was a fixed inline `20px`; unified onto
+       * `--space-fit-md`, the same border-t+padding-top treatment now
+       * shared by `ProjectCard.tsx`'s stats footer, Education &
+       * Experience's bullet list divider, and the Leviathan pipeline's
+       * "move" row -- four dividers that previously each had a different
+       * top padding.
+       */}
+      <div className="mt-[clamp(30px,5vh,52px)] border-t border-line pt-[var(--space-fit-md)] text-[9.5px] tracking-[0.18em] text-dim-3">
         <span>{CONTACT_FOOTER}</span>
       </div>
     </Section>

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -91,13 +91,28 @@ export function Contact() {
         </div>
 
         <ul className="flex flex-col border-t border-line">
+          {/*
+           * Link row sizing (owner follow-up, #372): the first pass's
+           * `panel:text-[clamp(16px,2.4vh,26px)]` detail text ("send me an
+           * email", "read the code", ...) read too large next to the rest
+           * of the block. Brought down one step to
+           * `clamp(15px,1.9vh,20px)` -- still clearly bigger than the
+           * pre-#372 fixed `14px`, just no longer competing with the
+           * statement line for attention. `panel:py-[...]` was raised in
+           * the same move (`clamp(20px,3.6vh,44px)` ->
+           * `clamp(22px,3.9vh,48px)`) so each row's total height (padding
+           * + text) stays within ~1px of what it was before this tweak at
+           * every viewport height checked (900/1160/800px) -- the list's
+           * overall block height, and the section's fill, shouldn't
+           * change, only the text/whitespace balance within each row.
+           */}
           {CONTACT_LINKS.map((link) => (
             <li key={link.id} className="border-b border-line">
               <a
                 href={link.href}
                 target={link.external ? '_blank' : undefined}
                 rel={link.external ? 'noopener noreferrer' : undefined}
-                className="flex items-baseline justify-between gap-[14px] py-[17px] text-[14px] text-fg-2 transition-[padding-left,color] duration-[180ms] hover:text-accent-2 motion-safe:hover:pl-[10px] panel:py-[clamp(20px,3.6vh,44px)] panel:text-[clamp(16px,2.4vh,26px)]"
+                className="flex items-baseline justify-between gap-[14px] py-[17px] text-[14px] text-fg-2 transition-[padding-left,color] duration-[180ms] hover:text-accent-2 motion-safe:hover:pl-[10px] panel:py-[clamp(22px,3.9vh,48px)] panel:text-[clamp(15px,1.9vh,20px)]"
               >
                 <span className="text-fg">{link.detail}</span>
                 <span className="text-[10px] uppercase tracking-[0.16em] text-dim-2 panel:text-fit-xs">

--- a/src/components/sections/EducationExperience.tsx
+++ b/src/components/sections/EducationExperience.tsx
@@ -290,8 +290,19 @@ function TimelineEntryCell({
        * larger, not marginally so, and the marker drops to `text-dim` --
        * quiet enough to read as a list marker instead of competing with
        * the (now brighter, larger) bullet text for attention.
+       *
+       * Divider top padding (#359): was its own inline `clamp(8px,1.4vh,
+       * 12px)`, one of four divider top-paddings in this codebase that all
+       * disagreed (this one, `ProjectCard.tsx`'s stats footer, the
+       * Leviathan pipeline's "move" row, and Contact's footer). Unified
+       * onto `--space-fit-md`, the value `ProjectCardStatsFooter` already
+       * used -- an existing token, not a new one, and the same
+       * "featured card wins ties" precedent this codebase already applies
+       * (see `ProjectCardShell`/`ProjectCardStatsFooter` in
+       * `ProjectCard.tsx`) since that footer sits on the featured
+       * Leviathan card.
        */}
-      <div className="flex flex-col gap-[var(--space-fit-3xs-tight)] border-t border-line pt-[clamp(8px,1.4vh,12px)] text-fit-sm leading-[1.6] text-fg-2">
+      <div className="flex flex-col gap-[var(--space-fit-3xs-tight)] border-t border-line pt-[var(--space-fit-md)] text-fit-sm leading-[1.6] text-fg-2">
         {entry.bullets.map((bullet) => (
           <div key={bullet} className="flex gap-[11px]">
             <span aria-hidden="true" className="text-dim">

--- a/src/components/sections/ProjectCard.tsx
+++ b/src/components/sections/ProjectCard.tsx
@@ -106,6 +106,15 @@ export interface ProjectCardStatsFooterProps {
  * shell padding above -- the featured card's declaration (line 353) is
  * the source of truth, and the two smaller cards' hardcoded gaps move to
  * match it.
+ *
+ * The divider's top padding (`--space-fit-md`) is the same "featured card
+ * wins ties" precedent applied a second time (#359): this footer's own
+ * `pt` was already `--space-fit-md`, and three other unrelated
+ * border-t+padding-top dividers elsewhere in the codebase (Education &
+ * Experience's bullet list, the Leviathan pipeline's "move" row, Contact's
+ * footer) each had their own different inline clamp. All four are now
+ * `--space-fit-md`, so the divider reads as one deliberate treatment
+ * instead of four accidental ones.
  */
 export function ProjectCardStatsFooter({ children, className }: ProjectCardStatsFooterProps) {
   return (

--- a/src/components/sections/ProjectsFeatured.tsx
+++ b/src/components/sections/ProjectsFeatured.tsx
@@ -249,7 +249,15 @@ export function ProjectsFeatured() {
             </ProjectCardStatsFooter>
           </ProjectCardShell>
 
-          <div className="flex min-w-0 flex-col justify-center border-line bg-panel-2 p-[clamp(14px,2.2vh,26px)_clamp(16px,2vw,26px)] panel:border-l">
+          {/*
+           * Vertical padding (`clamp(14px,2.2vh,26px)`) is byte-for-byte
+           * `--space-fit-md` (`src/styles/layout.css`), so it now reads
+           * through that token instead of repeating the same clamp inline
+           * (#359). Horizontal padding (`clamp(16px,2vw,26px)`) stays
+           * inline -- it's a vw-based curve with no width-based space
+           * token matching its bounds.
+           */}
+          <div className="flex min-w-0 flex-col justify-center border-line bg-panel-2 p-[var(--space-fit-md)_clamp(16px,2vw,26px)] panel:border-l">
             <InferencePipeline />
           </div>
         </FitRegion>

--- a/src/components/sections/leviathan/InferencePipeline.tsx
+++ b/src/components/sections/leviathan/InferencePipeline.tsx
@@ -31,6 +31,12 @@ const FRAME_INTERVAL_MS = 110
  * line 405: `border-top:1px solid var(--line);padding-top:...` is on the
  * row itself, not on the content column), so `rowBorderTop` lets that one
  * row opt in without affecting the others.
+ *
+ * The row's top padding was its own inline `clamp(9px,1.5vh,14px)`;
+ * unified (#359) onto `--space-fit-md`, the same divider treatment now
+ * shared by `ProjectCard.tsx`'s stats footer, Education & Experience's
+ * bullet list divider, and Contact's footer -- four border-t+padding-top
+ * dividers that previously each had a different top padding.
  */
 function PipelineRow({
   label,
@@ -50,7 +56,7 @@ function PipelineRow({
       className={cn(
         'grid grid-cols-[66px_minmax(0,1fr)] gap-x-3',
         align === 'center' ? 'items-center' : 'items-start',
-        rowBorderTop && 'border-t border-line pt-[clamp(9px,1.5vh,14px)]',
+        rowBorderTop && 'border-t border-line pt-[var(--space-fit-md)]',
       )}
     >
       <span


### PR DESCRIPTION
## What changed

Inventoried every inline `clamp()` in the component tree against the two token scales in `src/styles/layout.css` (the width-based `--text-*`/`--space-*` fluid scale and the height-based `--text-fit-*`/`--space-fit-*` "fit" scale). Almost none of the ~30 inline clamps turned out to be exact duplicates of an existing token — most are pure `vw`-only or `vh`-only clamps pinned to the design reference's own values, which don't share the rem+vw / px+vh hybrid formula any token uses. Where a computed match did exist, it's substituted; everywhere else the value is left inline (see the full list below).

**Substituted (identical computed value, no rendering change):**
- `ProjectsFeatured.tsx` — the featured card's inference-panel vertical padding was `clamp(14px,2.2vh,26px)`, byte-for-byte `--space-fit-md`. Now reads `p-[var(--space-fit-md)_clamp(16px,2vw,26px)]`; the horizontal half stays inline (vw-based, no matching token).

**Divider unification (the four border-t + padding-top "divider" call sites):**

The issue flagged four uses of the same `border-t border-line pt-[...]` pattern with four different top paddings, none agreeing with each other (or, it turns out, with the design reference either — the reference itself uses five different values across these same rows). Unified all four onto `--space-fit-md` (`clamp(14px, 2.2vh, 26px)`), an existing token — not a new one:

| Location | Before | After |
|---|---|---|
| `ProjectCard.tsx` — `ProjectCardStatsFooter` | `var(--space-fit-md)` | unchanged |
| `EducationExperience.tsx` — Timeline bullet list | `clamp(8px,1.4vh,12px)` | `var(--space-fit-md)` |
| `leviathan/InferencePipeline.tsx` — "move" row | `clamp(9px,1.5vh,14px)` | `var(--space-fit-md)` |
| `Contact.tsx` — footer | `20px` (fixed) | `var(--space-fit-md)` |

Picked `--space-fit-md` because it's already the value `ProjectCardStatsFooter` used, and that footer sits on the featured Leviathan card — the same "featured card wins ties" precedent this codebase already applies when call sites disagree (see the existing comments on `ProjectCardShell`/`ProjectCardStatsFooter`, converged the same way for issue #357). This is a deliberate, visible change at the other three sites (most noticeably Contact's footer, previously a fixed non-fluid `20px`) — that's the point of "settle on one treatment," not a substitution, so it isn't covered by the "identical rendering" bar that applies to the token-substitution changes above.

**Left alone — deliberate one-offs (not covered by an existing token):**

The remaining ~25 inline clamps are left as-is. Grouped by why:

- *Pure `vw`-only clamps with no fixed-px + vw offset* (every width-based token is a `rem + vw` hybrid, so a plain `clamp(Apx, Bvw, Cpx)` can never equal one exactly): `Header.tsx` (nav gap, logo gap, horizontal padding), `MobileNav.tsx` (horizontal padding), `Contact.tsx` (grid gap, heading size), `ProjectCard.tsx` (shell horizontal padding, footer gap), `ProjectsOther.tsx` (grid gap), `InferencePipeline.tsx` (move-row gap, token gap-x context, move value size), `Hero.tsx` (grid gap, tagline margin/size), `SkillsGraph.tsx` (frame horizontal padding, legend gap, legend label size), `EducationExperience.tsx` (status-row padding, title size, card horizontal padding).
- *`vh`-based clamps whose bounds don't match any `--text-fit-*`/`--space-fit-*` step* (coefficient and/or min/max differ from every defined step): `EducationExperience.tsx` status-row vertical padding, `ProjectCard.tsx` shell vertical padding, `InferencePipeline.tsx` (pipeline gap, position-row text, token padding, move text size), `Hero.tsx` action-row margin, `SkillsGraph.tsx` frame vertical padding.
- *Matches the design reference byte-for-byte, already documented as intentional*: `SectionHeading.tsx`'s title `clamp(15px,2.2vw,24px)` — the file's own comment already states this is inlined because it appears verbatim in the sample, not because the fluid scale has a matching step.

No new CSS custom property was introduced anywhere in this change; every substitution reuses a token that already existed in `src/styles/layout.css`.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build`, `npm test` all pass (106/106 tests).
- 880px remains the only breakpoint — untouched.
- **Not verified**: browser screenshot comparison at 375px/1440px. I don't have a way to drive a real browser and diff screenshots in this environment, so I can't claim that step was done — flagging honestly rather than asserting it. The `ProjectsFeatured.tsx` substitution is a byte-for-byte value swap so it should be pixel-identical; the four divider sites are an intentional, visible change (documented above) that a human should eyeball before merging.

Refs #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
