### PR TITLE
Keep one authoritative telling per cross-cutting comment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,14 +16,11 @@ import { cn } from '@/lib/cn'
  * skills, education & experience, contact -- each with placeholder content
  * for now.
  *
- * Layout/viewport-fit system: above 880px `.section-shell` (src/styles/
- * layout.css) makes every section exactly one viewport tall, while the
- * scroll-snap itself lives on `:root` (the document is the real scroll
- * container, not `<main>`) so sections snap between whole screens; below
- * 880px both release and sections stack as ordinary flow content.
- * `.snap-shell` on <main> is a marker class only -- it carries no CSS of
- * its own. There is no JavaScript measuring loop -- fit comes entirely
- * from the fluid type scale and CSS documented in that file.
+ * Layout/viewport-fit system: `src/styles/layout.css` (`.section-shell`,
+ * the 880px breakpoint, scroll-snap on `:root`) and `src/lib/
+ * useFitToViewport.ts` (the runtime shrink-to-fit pass) own that mechanism
+ * end to end -- see those files. `.snap-shell` on <main> is a marker class
+ * only -- it carries no CSS of its own.
  *
  * `<SkipLink>` is rendered first, before `<Header>`, so it is the very
  * first focusable element in DOM order -- a keyboard user's first Tab
@@ -37,9 +34,9 @@ import { cn } from '@/lib/cn'
  * fixed header (mochi/style-match audit -- a prior revision added
  * `padding-top: var(--header-h, ...)` here, reasoning the header would
  * otherwise cover the hero on first paint). The sample never does this
- * (`ideas/Portfolio.html` line 264-266: `<section id="top">` is a direct
- * sibling of `<header>`, no offset wrapper) and that padding was actively
- * wrong: every `.section-shell` is already `min-height:100dvh`, so adding
+ * (`ideas/Portfolio.html` line 294: `<section id="top">`, the hero, is a
+ * direct sibling of `<header>`, no offset wrapper) and that padding was
+ * actively wrong: every `.section-shell` is already `min-height:100dvh`, so adding
  * the header's height on top of that made the FIRST section render
  * `header-height` pixels taller than one viewport -- it no longer fit one
  * screen, defeating the whole one-section-one-screen/scroll-snap premise,

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -31,26 +31,18 @@ import { ThemePicker } from './ThemePicker'
  * the trailing group -- theme picker, clock, hamburger, in that DOM/visual
  * order -- is pushed flush right as one unit.
  *
- * Fixed-header / scroll-snap interaction: `scroll-snap-align: start`
- * (`.section-shell`, src/styles/layout.css) aligns each section to the
- * top of the scrollport, and native `#id` anchor jumps land at the exact
- * top of the target element -- both of which a `position: fixed` header
- * would otherwise cover. The sample (`ideas/Portfolio.html`) never
- * compensates for this at the scroll-container level (no
- * `scroll-padding-top`; line 245 sets only `scroll-behavior`/
- * `scroll-snap-type`) -- it relies purely on every section's own top
- * `padding-block` clamp (`.section-shell`) already exceeding the header's
- * rendered height, so the header only ever overlaps padding, never real
- * content. This held at 880px+ (`clamp(4rem,9vh,5.5rem)` there comfortably
- * clears the header) but not below it, where `.section-shell`'s base
- * padding floors at 2.4rem/38.4px against a mobile header nearer 55-60px
- * tall -- the hero eyebrow and every other section's heading row rendered
- * partly behind the header (#314 owner review). `--header-h` is
- * republished here (measured via `ResizeObserver`, not guessed, since the
- * header's rendered height changes with the fluid type scale) so
- * `layout.css`'s base `.section-shell` rule can clear it with
- * `max(var(--space-lg), var(--header-h))`; the 880px+ override still uses
- * its own clamp unconditionally, so desktop is unaffected.
+ * Fixed-header / scroll-snap interaction: a `position: fixed` header would
+ * otherwise cover a section's top when `scroll-snap-align: start`
+ * (`.section-shell`) aligns it to the scrollport, or a native `#id` anchor
+ * jump lands there. `src/styles/layout.css` has the full story of why the
+ * fix is sizing (every section's own top `padding-block` clamp already
+ * exceeds the header's height) rather than a `scroll-padding-top` offset
+ * (tried and removed -- see that file for why).
+ *
+ * `--header-h` is published here via `ResizeObserver` rather than a fixed
+ * guess, since the header's rendered height changes with the fluid type
+ * scale and with viewport width; `layout.css`'s base `.section-shell` rule
+ * consumes it in `max(var(--space-lg), var(--header-h) + var(--space-md))`.
  *
  * `overlayBackground` (#355): forwarded straight through to `MobileNav`,
  * unopened -- `App.tsx` is the one place that declares what counts as

--- a/src/components/layout/Section.tsx
+++ b/src/components/layout/Section.tsx
@@ -19,13 +19,10 @@ interface SectionProps {
 /**
  * Shared shell for the six top-level sections.
  *
- * Fit is achieved purely by CSS (`.section-shell` in `src/styles/
- * layout.css`, driven by the fluid type scale documented there) -- there
- * is no JavaScript measuring or `zoom` fallback. Above 880px each section
- * is exactly one viewport tall and snaps; below 880px the fixed height
- * and snap both release and the section is ordinary flow content. The
- * scroll-snap-type/scroll-behavior that drive snapping live on `:root`
- * (the actual document scroll container), not on this class.
+ * Layout/fit mechanics (`.section-shell`, the 880px breakpoint, scroll-snap
+ * on `:root`, the runtime shrink-to-fit pass) belong to `src/styles/
+ * layout.css` and `src/lib/useFitToViewport.ts` -- see those files for the
+ * full mechanism.
  *
  * `aria-labelledby` (not `aria-label`) sources the landmark's accessible
  * name from the section's own visible heading. Every section renders

--- a/src/components/layout/ThemePicker.tsx
+++ b/src/components/layout/ThemePicker.tsx
@@ -20,11 +20,10 @@ import { DEFAULT_THEME_ID, THEMES } from '@/theme/themes'
  * Dismissal (#355) is `useOverlay`/`src/lib/overlay.ts`'s job, not this
  * component's own: Escape closes the menu and returns focus to the
  * trigger; a pointerdown or focus-out landing outside `containerRef`
- * closes it too, but deliberately does NOT refocus the trigger (the click
- * or Tab that triggered it already moved focus somewhere real -- pulling
- * it back would fight that). This picker locks no scroll and inerts no
- * background; it's a small dropdown, not a full-screen panel like
- * `MobileNav`'s.
+ * closes it too (see `overlay.ts`'s `outsideDismissBoundary` doc for why
+ * that path deliberately doesn't refocus anything). This picker locks no
+ * scroll and inerts no background; it's a small dropdown, not a
+ * full-screen panel like `MobileNav`'s.
  *
  * Colour data (`THEMES[].swatch`) is the one legitimate place a literal
  * hex value appears in this codebase -- it's runtime data from

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -125,12 +125,9 @@ export function Contact() {
       </div>
 
       {/*
-       * Divider top padding (#359): was a fixed inline `20px`; unified onto
-       * `--space-fit-md`, the same border-t+padding-top treatment now
-       * shared by `ProjectCard.tsx`'s stats footer, Education &
-       * Experience's bullet list divider, and the Leviathan pipeline's
-       * "move" row -- four dividers that previously each had a different
-       * top padding.
+       * Divider top padding: unified onto `--space-fit-md` along with three
+       * other dividers across the codebase (#359) -- see
+       * `ProjectCardStatsFooter` in `ProjectCard.tsx` for the full story.
        *
        * `panel:mt-[clamp(40px,7.5vh,95px)]` (#372): grows the gap between
        * the grid and the footer at desktop so the block's own internal

--- a/src/components/sections/EducationExperience.tsx
+++ b/src/components/sections/EducationExperience.tsx
@@ -291,16 +291,9 @@ function TimelineEntryCell({
        * quiet enough to read as a list marker instead of competing with
        * the (now brighter, larger) bullet text for attention.
        *
-       * Divider top padding (#359): was its own inline `clamp(8px,1.4vh,
-       * 12px)`, one of four divider top-paddings in this codebase that all
-       * disagreed (this one, `ProjectCard.tsx`'s stats footer, the
-       * Leviathan pipeline's "move" row, and Contact's footer). Unified
-       * onto `--space-fit-md`, the value `ProjectCardStatsFooter` already
-       * used -- an existing token, not a new one, and the same
-       * "featured card wins ties" precedent this codebase already applies
-       * (see `ProjectCardShell`/`ProjectCardStatsFooter` in
-       * `ProjectCard.tsx`) since that footer sits on the featured
-       * Leviathan card.
+       * Divider top padding: unified onto `--space-fit-md` along with three
+       * other dividers across the codebase (#359) -- see
+       * `ProjectCardStatsFooter` in `ProjectCard.tsx` for the full story.
        */}
       <div className="flex flex-col gap-[var(--space-fit-3xs-tight)] border-t border-line pt-[var(--space-fit-md)] text-fit-sm leading-[1.6] text-fg-2">
         {entry.bullets.map((bullet) => (

--- a/src/components/sections/leviathan/InferencePipeline.tsx
+++ b/src/components/sections/leviathan/InferencePipeline.tsx
@@ -32,11 +32,9 @@ const FRAME_INTERVAL_MS = 110
  * row itself, not on the content column), so `rowBorderTop` lets that one
  * row opt in without affecting the others.
  *
- * The row's top padding was its own inline `clamp(9px,1.5vh,14px)`;
- * unified (#359) onto `--space-fit-md`, the same divider treatment now
- * shared by `ProjectCard.tsx`'s stats footer, Education & Experience's
- * bullet list divider, and Contact's footer -- four border-t+padding-top
- * dividers that previously each had a different top padding.
+ * The row's top padding is unified onto `--space-fit-md` along with three
+ * other dividers across the codebase (#359) -- see `ProjectCardStatsFooter`
+ * in `ProjectCard.tsx` for the full story.
  */
 function PipelineRow({
   label,


### PR DESCRIPTION
## Summary

Comments-only cleanup. Several module header comments retold the same background story (with each copy drifting slightly), and a couple carried claims the code no longer matched after recent refactors. Removed the duplication, corrected the staleness, kept everything that carries non-obvious rationale.

## What was removed and why, fact by fact

**1. "No JavaScript measuring loop" for the viewport-fit system — stale, not just duplicated**
`src/App.tsx` and `src/components/layout/Section.tsx` both stated the section-fit system was "purely CSS" with "no JavaScript measuring or `zoom` fallback." That was true before #356, but #356 added exactly that: `useFitToViewport.ts`, `FitRegion.tsx`, `fitStrategy.ts` — a runtime shrink-to-fit pass driven by CSS `zoom`. `Section.tsx` even contradicted itself in the same file: one paragraph said "no JS fallback," a few lines later it describes providing the `FitClaim` that `FitRegion` uses. Both corrected to point at `src/styles/layout.css` and `src/lib/useFitToViewport.ts` as the two owners of that mechanism.

**2. Wrong line citation in `App.tsx`**
Cited `ideas/Portfolio.html` line 264-266 for `<section id="top">` (the hero). Decoded the reference file and confirmed `<section id="top">` is actually at line 294 — `Hero.tsx` already correctly cites "sample lines 294-328" for the same section. Corrected the App.tsx citation.

**3. `--header-h` / scroll-snap mechanism, retold in two files**
`Header.tsx`'s header comment substantially re-derived the same "why `--header-h` + `max(--space-lg, --header-h)`" story that `src/styles/layout.css` already tells in full next to the CSS rule itself. Trimmed `Header.tsx` to the part that's actually its own territory — why `--header-h` is measured via `ResizeObserver` rather than guessed — with a pointer to `layout.css` for the rest.

**4. Outside-dismiss-doesn't-refocus rationale, retold in `ThemePicker.tsx`**
`src/lib/overlay.ts`'s `outsideDismissBoundary` JSDoc already explains why outside-click/focus-out dismissal deliberately doesn't restore focus. `ThemePicker.tsx` restated the same reasoning for its own dismissal. Reduced to a one-line pointer to `overlay.ts`.

**5. "Four dividers unified onto `--space-fit-md`" (#359), retold in four files**
`Contact.tsx`, `EducationExperience.tsx`, and `InferencePipeline.tsx` each retold the complete story of #359's divider unification (which four dividers, what each one's old value was). `ProjectCard.tsx`'s `ProjectCardStatsFooter` doc is the fullest and most central telling — it's the shared component the other cards consume, and already holds the "featured card wins ties" precedent the other three reference. Kept that one as the owner; reduced the other three to one-line pointers.

## What was deliberately kept

- `src/lib/overlay.ts`'s full history of the old selector-based `inert` discovery (why it was fragile) — the only telling of that history; `App.tsx` already had a proper one-line pointer to it, not a duplicate.
- Every #372 sizing rationale in `Contact.tsx` (why the headline/statement/link-row font sizes changed, with exact measurements) — unique, non-obvious, kept in full.
- Every mochi/style-match audit paragraph with real Chromium-render measurements (`EducationExperience.tsx`'s subgrid/slack story, `ProjectsFeatured.tsx`'s dead-band/`min-h` story, etc.) — these are the only home of that hard-won knowledge.
- `MobileNav.tsx`'s inert rationale (why it needs `inert` instead of a focus trap) — specific to MobileNav's own design, not present elsewhere.
- `src/lib/fitStrategy.ts`'s pointer to `useFitToViewport.ts` for the fit mechanism's full history — already correct, not touched.
- All CSS files under `src/styles/` — read in full; every comment there carries specific rationale (measured contrast ratios, real Chromium-render pixel offsets, why a property was removed) rather than restating something owned elsewhere, so nothing was cut.
- `src/lib/useMediaQuery.ts`'s "Before this module existed..." paragraph describing the pre-#354 `PANEL_QUERY` duplication — verified this is accurate past-tense history, not a present-tense claim, so left as is.

No behavior changes — comments only. Typecheck, lint, build, and all 106 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified layout behavior, including viewport fitting, fixed-header scrolling, and section spacing.
  * Documented theme menu dismissal behavior when clicking outside or moving focus away.
  * Updated spacing documentation to reflect shared responsive spacing across dividers and pipeline rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->