### PR TITLE
Overlay system cleanup: dead config, silent scroll-lock mismatch, ref merge

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
-import { useLayoutEffect, useRef } from 'react'
-import type { Ref, RefObject } from 'react'
+import { useLayoutEffect } from 'react'
+import type { RefObject } from 'react'
 import { navItems } from '@/data/nav'
 import { cn } from '@/lib/cn'
 import { Clock } from './Clock'
@@ -56,23 +56,21 @@ import { ThemePicker } from './ThemePicker'
  * unopened -- `App.tsx` is the one place that declares what counts as
  * "background" for the mobile nav's overlay (see its docstring), and this
  * component is just the layer that composition happens to pass through.
- * `ref` here is a second, independent thing: it's *this* header element's
- * own node being merged into `App.tsx`'s background list (the header, and
- * everything inside it -- nav links, theme picker, clock, progress bar,
- * `MobileNav`'s own trigger -- all become `inert` together when the panel
- * marks it as background), not something `Header` itself reads.
+ * `ref` here is a second, independent thing: `App.tsx` already owns a
+ * `headerRef` for that same background list, so it's the one `ref` this
+ * component needs for its own `--header-h` measurement too -- no separate
+ * internal ref or merge callback required, just one `RefObject` used for
+ * both purposes.
  */
 export function Header({
   ref,
   overlayBackground,
 }: {
-  ref?: Ref<HTMLElement>
+  ref: RefObject<HTMLElement | null>
   overlayBackground: RefObject<HTMLElement | null>[]
 }) {
-  const headerRef = useRef<HTMLElement>(null)
-
   useLayoutEffect(() => {
-    const el = headerRef.current
+    const el = ref.current
     if (!el || typeof ResizeObserver === 'undefined') return
 
     const publish = () => {
@@ -83,15 +81,11 @@ export function Header({
     const observer = new ResizeObserver(publish)
     observer.observe(el)
     return () => observer.disconnect()
-  }, [])
+  }, [ref])
 
   return (
     <header
-      ref={(node) => {
-        headerRef.current = node
-        if (typeof ref === 'function') ref(node)
-        else if (ref) ref.current = node
-      }}
+      ref={ref}
       className="fixed inset-x-0 top-0 z-[60] border-b border-line bg-bg-glass backdrop-blur-[9px]"
     >
       <div className="flex items-center gap-[clamp(10px,1.6vw,20px)] px-[clamp(20px,4vw,56px)] py-[12px]">

--- a/src/lib/overlay.test.ts
+++ b/src/lib/overlay.test.ts
@@ -91,6 +91,29 @@ describe('lockScroll', () => {
     releaseFirst()
     expect(root.style.overflow).toBe('scroll')
   })
+
+  it('refuses to lock a second, different root while the first is still held, and says so loudly', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const rootA = { style: { overflow: 'visible' } }
+    const rootB = { style: { overflow: 'auto' } }
+
+    const releaseA = lockScroll(rootA)
+    expect(rootA.style.overflow).toBe('hidden')
+
+    const releaseB = lockScroll(rootB)
+    // The mismatched root is never touched -- not locked, not restored.
+    expect(rootB.style.overflow).toBe('auto')
+    expect(consoleError).toHaveBeenCalledTimes(1)
+
+    // The no-op release for the refused lock must not disturb rootA's lock.
+    releaseB()
+    expect(rootA.style.overflow).toBe('hidden')
+
+    releaseA()
+    expect(rootA.style.overflow).toBe('visible')
+
+    consoleError.mockRestore()
+  })
 })
 
 describe('applyInert', () => {

--- a/src/lib/overlay.ts
+++ b/src/lib/overlay.ts
@@ -62,8 +62,27 @@ let scrollLockPreviousOverflow = ''
  * incrementing the count, and `style.overflow` is only restored once every
  * lock has been released. This is what makes "two overlays cannot clobber
  * each other's scroll-lock state" true regardless of open/close order.
+ *
+ * The reference count is keyed to a single root at a time (`scrollLockRoot`),
+ * not per-root -- there is currently exactly one scroll-lockable root in
+ * this app (`document.documentElement`), so this has never mattered in
+ * practice. If a second, *different* root is locked while the first is
+ * still held, silently doing nothing to it (while still handing back a
+ * release function that looks like it worked) is exactly the class of
+ * silent failure this module exists to remove, so that case is refused and
+ * surfaced loudly instead of attempted.
  */
 export function lockScroll(root: ScrollLockable): () => void {
+  if (scrollLockCount > 0 && scrollLockRoot !== root) {
+    // Deliberately surfaced: locking a second, different root while one is
+    // already held would otherwise be a silent no-op that hands back a
+    // release function which does nothing visible.
+    console.error(
+      '[lockScroll] A different root is already scroll-locked; locking two different roots at once is not supported. This root will not be locked.',
+    )
+    return () => {}
+  }
+
   if (scrollLockCount === 0) {
     scrollLockRoot = root
     scrollLockPreviousOverflow = root.style.overflow

--- a/src/lib/useOverlay.ts
+++ b/src/lib/useOverlay.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import type { RefObject } from 'react'
-import { activateOverlay, type Inertable } from './overlay'
+import { activateOverlay } from './overlay'
 
 /**
  * React wrapper around `activateOverlay` (#355). This file is deliberately
@@ -20,12 +20,9 @@ import { activateOverlay, type Inertable } from './overlay'
 export interface UseOverlayConfig {
   /** Called to close the overlay (typically `() => setOpen(false)`). */
   onDismiss: () => void
-  /** Elements to mark `inert` while open -- declared by the caller. */
-  background?: Iterable<Inertable>
   /**
    * Refs to elements to mark `inert` while open, resolved to their
-   * `.current` value at effect time rather than at render time -- use this
-   * (instead of `background`) when the elements come from refs that may
+   * `.current` value at effect time rather than at render time -- refs may
    * not be mounted yet on the render that flips `active` to true.
    */
   backgroundRefs?: RefObject<HTMLElement | null>[]
@@ -64,10 +61,8 @@ export function useOverlay(active: boolean, config: UseOverlayConfig): void {
 
     const current = configRef.current
     const background = current.backgroundRefs
-      ? current.backgroundRefs
-          .map((ref) => ref.current)
-          .filter((element): element is HTMLElement => element !== null)
-      : current.background
+      ?.map((ref) => ref.current)
+      .filter((element): element is HTMLElement => element !== null)
 
     return activateOverlay(
       { document },


### PR DESCRIPTION
Follow-up cleanup on the overlay system introduced by #355, from a strict code-quality audit run after that PR merged. Three findings, all behavior-preserving.

## Finding 1 — dead optionality in `useOverlay`'s public contract

`useOverlay`'s config accepted both `background` (an `Iterable<Inertable>` of values) and `backgroundRefs` (an array of React refs). A full-tree grep confirmed no call site (`MobileNav`, `ThemePicker`) ever passed `background` — only `backgroundRefs`. Removed `background` from `UseOverlayConfig` and simplified the effect's resolution from a resolve-or-passthrough ternary down to a single mapping over `backgroundRefs`.

`overlay.ts`'s own lower-level `background` parameter (on `OverlayConfig`/`activateOverlay`) is untouched — that module is deliberately framework-agnostic and takes values directly; this finding was scoped to the React wrapper only.

## Finding 2 — module-global scroll-lock state with a silent invariant

`overlay.ts` holds `scrollLockCount`, `scrollLockRoot`, and `scrollLockPreviousOverflow` at module scope, reference-counted so overlays locking the *same* root can't clobber each other. That guarantee is correct and untouched. The gap: if a second caller locked a *different* root while a lock was already held, that second root was silently never locked — the caller got a release function that looked like it worked but did nothing visible.

Fixed by refusing the mismatched lock outright and surfacing it with `console.error`, in the same idiom `useFitToViewport` already uses for its own refused-claim case (a "deliberately surfaced" comment plus a prefixed, actionable message). Chose the loud-refusal approach over keying state by root because there is currently exactly one scroll-lockable root in this app (`document.documentElement`), so per-root state would add real complexity for a case that has never actually occurred — refusing the mismatch and saying so loudly gets the same "no silent failure" guarantee with a much smaller surface, and mirrors an idiom this codebase already has.

Added a test (`overlay.test.ts`) that locks root A, then attempts to lock a different root B: confirms B is left untouched, `console.error` fires once, and the no-op release for B doesn't disturb A's still-held lock.

## Finding 3 — hand-rolled ref merging in `Header`

`Header.tsx` merged two refs by hand (`node => { headerRef.current = node; if (typeof ref === 'function') ref(node); else if (ref) ref.current = node }`) because it needed its own node for a `ResizeObserver` (the `--header-h` measurement) *and* had to expose that node to `App.tsx` for the overlay background list.

Verified `App.tsx` already owns the `headerRef` it hands down as `ref`, so `Header` now just uses that same `RefObject` directly for its `ResizeObserver` too — the merge callback is gone, `ref` is now a required `RefObject<HTMLElement | null>` instead of an optional generic `Ref`, and the `--header-h` `useLayoutEffect` reads `ref.current` instead of an internal ref (dependency array updated to `[ref]`, which is stable across renders since `App`'s `useRef` never changes identity — same effective behavior as the old `[]`).

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build`, `npm test` all pass.
- Test count: 107 passing (up from 106 — the one Finding 2 test), all pre-existing overlay coverage (scroll lock + restore, refcount non-clobbering, inert + restore including pre-existing inert state, Escape + focus restore, outside-dismiss not restoring focus) intact.
- Not verified in a real browser — only through the test suite and static analysis (typecheck/lint/build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)